### PR TITLE
Fix date selection using UTC instead of local timezone

### DIFF
--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -110,7 +110,7 @@
 
     let dateRange = $derived.by(() => {
         const today = new Date();
-        const fmt = (d: Date) => d.toISOString().split('T')[0];
+        const fmt = (d: Date) => d.toLocaleDateString('en-CA');
         if (datePreset === 'today') return { start: fmt(today), end: fmt(today) };
         if (datePreset === 'week') { const d = new Date(today); d.setDate(d.getDate() - 7); return { start: fmt(d), end: fmt(today) }; }
         if (datePreset === 'month') { const d = new Date(today); d.setDate(d.getDate() - 30); return { start: fmt(d), end: fmt(today) }; }

--- a/apps/ui/src/lib/stores/detections.svelte.ts
+++ b/apps/ui/src/lib/stores/detections.svelte.ts
@@ -37,16 +37,16 @@ class DetectionsStore {
             // Filter to last 3 days
             const d = new Date();
             d.setDate(d.getDate() - 3);
-            const startDate = d.toISOString().split('T')[0];
+            const startDate = d.toLocaleDateString('en-CA');
 
             const [recent, countResult] = await Promise.all([
                 fetchEvents({ 
                     limit: this.MAX_ITEMS,
                     startDate 
                 }),
-                fetchEventsCount({ 
-                    startDate: new Date().toISOString().split('T')[0],
-                    endDate: new Date().toISOString().split('T')[0]
+                fetchEventsCount({
+                    startDate: new Date().toLocaleDateString('en-CA'),
+                    endDate: new Date().toLocaleDateString('en-CA')
                 })
             ]);
             this.detections = recent;
@@ -91,7 +91,7 @@ class DetectionsStore {
             this.detections = this.detections.filter(d => d.frigate_event !== eventId);
         }
 
-        const today = new Date().toISOString().split('T')[0];
+        const today = new Date().toLocaleDateString('en-CA');
         const isToday =
             detectionDate
                 ? detectionDate.startsWith(today)


### PR DESCRIPTION
toISOString() returns dates in UTC, so in timezones behind UTC the "Today" filter and other date presets would resolve to tomorrow's date after the UTC day boundary. Replace with toLocaleDateString('en-CA') which outputs YYYY-MM-DD using the browser's local timezone.