### PR TITLE
Refresh sidebar navigation and system status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+- **The desktop sidebar now matches the rest of the application more closely.** The large centred
+  bird mark remains, while navigation is grouped into observation and management areas, the active
+  route has a clearer Blue Tit treatment, live system state is shown as compact honest rows, and
+  authenticated or public access is presented in a quieter account card.
+
 ## [2.15.0] - 2026-07-23
 
 ### Added

--- a/apps/ui/src/App.svelte
+++ b/apps/ui/src/App.svelte
@@ -681,13 +681,13 @@
 
       <Sidebar {currentRoute} onNavigate={navigate} {mobileSidebarOpen} onMobileClose={() => mobileSidebarOpen = false}>
           {#snippet status()}
-              <div class="flex items-center gap-3 px-2">
-                  <ConnectionStatus
-                      birdnetEnabled={Boolean(settingsStore.birdnetEnabled)}
-                      {notificationsActive}
-                      connected={detectionsStore.connected}
-                      className="gap-3"
-                  />
+              <ConnectionStatus
+                  birdnetEnabled={Boolean(settingsStore.birdnetEnabled)}
+                  {notificationsActive}
+                  connected={detectionsStore.connected}
+                  variant="sidebar"
+              />
+              <div class="mt-1 flex justify-end">
                   <UpdateIndicator />
               </div>
           {/snippet}

--- a/apps/ui/src/app.css
+++ b/apps/ui/src/app.css
@@ -215,6 +215,23 @@ html[data-theme='dark'] {
     @apply text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-white;
   }
 
+  /* Sidebar navigation — denser monitor-style hierarchy with a clear selected route. */
+  .sidebar-nav {
+    @apply flex min-h-11 w-full items-center gap-3 rounded-xl px-3 text-left text-sm font-semibold transition-all duration-200 focus-ring;
+  }
+
+  .sidebar-nav-active {
+    @apply bg-brand-100/90 text-slate-900 shadow-sm ring-1 ring-brand-200/70 ring-inset dark:bg-brand-900/40 dark:text-slate-100 dark:ring-brand-700/40;
+  }
+
+  .sidebar-nav-active svg {
+    @apply text-brand-600 dark:text-brand-400;
+  }
+
+  .sidebar-nav-inactive {
+    @apply text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white;
+  }
+
   /* Badges */
   .badge {
     @apply inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold border;

--- a/apps/ui/src/lib/components/ConnectionStatus.svelte
+++ b/apps/ui/src/lib/components/ConnectionStatus.svelte
@@ -5,39 +5,74 @@
         birdnetEnabled = false,
         notificationsActive = false,
         connected = false,
-        className = 'gap-4'
+        className = 'gap-4',
+        variant = 'compact'
     }: {
         birdnetEnabled?: boolean;
         notificationsActive?: boolean;
         connected?: boolean;
         className?: string;
+        variant?: 'compact' | 'sidebar';
     } = $props();
 </script>
 
-<div class={`flex items-center ${className}`}>
-    {#if birdnetEnabled}
-        <div class="relative flex items-center justify-center group cursor-help text-brand-500 dark:text-brand-400" title={$_('status.audio_active')}>
-            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-brand-400 opacity-20"></span>
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" /></svg>
+{#if variant === 'sidebar'}
+    <div class="space-y-1" role="status" aria-live="polite">
+        <div class="flex min-h-7 items-center gap-2 rounded-lg px-2 text-xs text-slate-600 dark:text-slate-300">
+            <span class="relative flex h-2 w-2 flex-shrink-0">
+                {#if connected}
+                    <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-20"></span>
+                {/if}
+                <span class="relative inline-flex h-2 w-2 rounded-full {connected ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-red-500'}"></span>
+            </span>
+            <span class="min-w-0 flex-1 truncate">{$_('status.live_updates')}</span>
+            <span class="flex-shrink-0 text-[0.625rem] font-semibold {connected ? 'text-emerald-700 dark:text-emerald-300' : 'text-red-600 dark:text-red-400'}">
+                {connected ? $_('status.online') : $_('status.offline')}
+            </span>
         </div>
-    {/if}
 
-    {#if notificationsActive}
-        <div class="relative flex items-center justify-center text-indigo-500 dark:text-indigo-400 cursor-help" title={$_('status.notifications_enabled')}>
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h6m-6 8 4-4h6a4 4 0 0 0 4-4V7a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v9a4 4 0 0 0 4 4z" /></svg>
+        <div class="flex min-h-7 items-center gap-2 rounded-lg px-2 text-xs text-slate-600 dark:text-slate-300">
+            <span class="inline-flex h-2 w-2 flex-shrink-0 rounded-full {birdnetEnabled ? 'bg-brand-500 dark:bg-brand-400' : 'bg-slate-300 dark:bg-slate-600'}"></span>
+            <span class="min-w-0 flex-1 truncate">{$_('status.audio_analysis')}</span>
+            <span class="flex-shrink-0 text-[0.625rem] font-semibold {birdnetEnabled ? 'text-brand-700 dark:text-brand-300' : 'text-slate-400 dark:text-slate-500'}">
+                {birdnetEnabled ? $_('common.enabled') : $_('common.disabled')}
+            </span>
         </div>
-    {/if}
 
-    <div class="flex items-center gap-2 cursor-help" title={connected ? $_('status.system_online') : $_('status.system_offline')}>
-        {#if connected}
-            <div class="relative flex items-center justify-center text-accent-500 dark:text-accent-400">
-                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-400 opacity-20"></span>
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" /></svg>
-            </div>
-        {:else}
-            <div class="relative flex items-center justify-center text-red-500">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <div class="flex min-h-7 items-center gap-2 rounded-lg px-2 text-xs text-slate-600 dark:text-slate-300">
+            <span class="inline-flex h-2 w-2 flex-shrink-0 rounded-full {notificationsActive ? 'bg-indigo-500 dark:bg-indigo-400' : 'bg-slate-300 dark:bg-slate-600'}"></span>
+            <span class="min-w-0 flex-1 truncate">{$_('status.notifications')}</span>
+            <span class="flex-shrink-0 text-[0.625rem] font-semibold {notificationsActive ? 'text-indigo-700 dark:text-indigo-300' : 'text-slate-400 dark:text-slate-500'}">
+                {notificationsActive ? $_('common.enabled') : $_('common.disabled')}
+            </span>
+        </div>
+    </div>
+{:else}
+    <div class={`flex items-center ${className}`}>
+        {#if birdnetEnabled}
+            <div class="group relative flex cursor-help items-center justify-center text-brand-500 dark:text-brand-400" title={$_('status.audio_active')}>
+                <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand-400 opacity-20"></span>
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" /></svg>
             </div>
         {/if}
+
+        {#if notificationsActive}
+            <div class="relative flex cursor-help items-center justify-center text-indigo-500 dark:text-indigo-400" title={$_('status.notifications_enabled')}>
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h6m-6 8 4-4h6a4 4 0 0 0 4-4V7a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v9a4 4 0 0 0 4 4z" /></svg>
+            </div>
+        {/if}
+
+        <div class="flex cursor-help items-center gap-2" title={connected ? $_('status.system_online') : $_('status.system_offline')}>
+            {#if connected}
+                <div class="relative flex items-center justify-center text-accent-500 dark:text-accent-400">
+                    <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent-400 opacity-20"></span>
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" /></svg>
+                </div>
+            {:else}
+                <div class="relative flex items-center justify-center text-red-500">
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                </div>
+            {/if}
+        </div>
     </div>
-</div>
+{/if}

--- a/apps/ui/src/lib/components/Sidebar.layout.test.ts
+++ b/apps/ui/src/lib/components/Sidebar.layout.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import appSource from '../../App.svelte?raw';
+import connectionStatusSource from './ConnectionStatus.svelte?raw';
+import sidebarSource from './Sidebar.svelte?raw';
+
+describe('Sidebar hybrid refresh', () => {
+    it('keeps the large brand mark centred above the navigation', () => {
+        expect(sidebarSource).toContain('data-sidebar-brand');
+        expect(sidebarSource).toContain("sizes={collapsed ? '40px' : '64px'}");
+        expect(sidebarSource).toContain("collapsed ? 'h-10 w-10' : 'h-16 w-16'");
+        expect(sidebarSource).toContain('items-center text-center');
+    });
+
+    it('groups observation and management routes with a stronger active state', () => {
+        expect(sidebarSource).toContain("section: 'observe'");
+        expect(sidebarSource).toContain("section: 'manage'");
+        expect(sidebarSource).toContain("$_('nav.observe')");
+        expect(sidebarSource).toContain("$_('nav.manage')");
+        expect(sidebarSource).toContain('data-sidebar-section');
+        expect(sidebarSource).toContain('sidebar-nav-active');
+    });
+
+    it('shows truthful operational status rows in the expanded sidebar', () => {
+        expect(appSource).toContain('variant="sidebar"');
+        expect(sidebarSource).toContain('data-sidebar-status');
+        expect(connectionStatusSource).toContain("variant?: 'compact' | 'sidebar'");
+        expect(connectionStatusSource).toContain("$_('status.live_updates')");
+        expect(connectionStatusSource).toContain("$_('status.audio_analysis')");
+        expect(connectionStatusSource).toContain("$_('status.notifications')");
+        expect(connectionStatusSource).toContain("$_('status.online')");
+        expect(connectionStatusSource).toContain("$_('status.offline')");
+    });
+
+    it('uses an account card when expanded while preserving compact auth actions', () => {
+        expect(sidebarSource).toContain('data-sidebar-account');
+        expect(sidebarSource).toContain('authStore.username');
+        expect(sidebarSource).toContain('accountInitial');
+        expect(sidebarSource).toContain("$_('auth.public_view')");
+        expect(sidebarSource).toContain("$_('auth.logout')");
+        expect(sidebarSource).toContain("$_('auth.login')");
+    });
+});

--- a/apps/ui/src/lib/components/Sidebar.svelte
+++ b/apps/ui/src/lib/components/Sidebar.svelte
@@ -20,26 +20,40 @@
         status?: import('svelte').Snippet;
     }>();
 
-    // Direct reactive access to stores
     let collapsed = $derived(layoutStore.sidebarCollapsed);
+    let accountInitial = $derived((authStore.username?.trim().slice(0, 1) || 'Y').toUpperCase());
+
+    type NavSection = 'observe' | 'manage';
 
     type NavItem = {
         path: string;
         label: string;
         icon: string;
+        section: NavSection;
         requiresAuth?: boolean;
     };
 
+    type NavGroup = {
+        id: NavSection;
+        label: string;
+        items: NavItem[];
+    };
+
     const allNavItems = $derived.by((): NavItem[] => ([
-        { path: '/', label: $_('nav.dashboard'), icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6' },
-        { path: '/events', label: $_('nav.explorer'), icon: 'M4 6h16M4 10h16M4 14h16M4 18h16' },
-        { path: '/species', label: $_('nav.leaderboard'), icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z' },
-        { path: '/settings', label: $_('nav.settings'), icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z', requiresAuth: true },
-        { path: '/about', label: $_('nav.about'), icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' },
+        { path: '/', label: $_('nav.dashboard'), icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6', section: 'observe' },
+        { path: '/events', label: $_('nav.explorer'), icon: 'M4 6h16M4 10h16M4 14h16M4 18h16', section: 'observe' },
+        { path: '/species', label: $_('nav.leaderboard'), icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z', section: 'observe' },
+        { path: '/settings', label: $_('nav.settings'), icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z', section: 'manage', requiresAuth: true },
+        { path: '/about', label: $_('nav.about'), icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z', section: 'manage' },
     ]));
 
-    // Filter nav items based on auth status
-    const navItems = $derived(allNavItems.filter(item => !item.requiresAuth || authStore.showSettings));
+    const navSections = $derived.by((): NavGroup[] => {
+        const visibleItems = allNavItems.filter(item => !item.requiresAuth || authStore.showSettings);
+        return [
+            { id: 'observe', label: $_('nav.observe'), items: visibleItems.filter(item => item.section === 'observe') },
+            { id: 'manage', label: $_('nav.manage'), items: visibleItems.filter(item => item.section === 'manage') },
+        ];
+    });
 
     function navigateAndClose(path: string): void {
         onNavigate(path);
@@ -58,24 +72,26 @@
     }
 </script>
 
-<!-- Mobile backdrop overlay -->
 {#if mobileSidebarOpen}
     <div
         role="button"
         tabindex="0"
-        class="fixed inset-0 bg-black/50 z-40 md:hidden transition-opacity duration-300"
+        class="fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 md:hidden"
         onclick={onMobileClose}
-        onkeydown={(e) => e.key === 'Enter' || e.key === 'Escape' ? onMobileClose?.() : null}
+        onkeydown={(event) => event.key === 'Enter' || event.key === 'Escape' ? onMobileClose?.() : null}
         aria-label={$_('nav.close_menu', { default: 'Close menu' })}
     ></div>
 {/if}
 
-<aside class="fixed left-0 top-0 h-full bg-white/90 dark:bg-slate-900/90 shadow-lg border-r border-slate-200/80 dark:border-slate-700/50 backdrop-blur-xl transition-all duration-300 flex flex-col {collapsed ? 'w-20' : 'w-64'}
-    {mobileSidebarOpen ? 'translate-x-0 z-50' : '-translate-x-full md:translate-x-0 z-50'}">
-    <!-- Logo and Collapse Button -->
-    <div class="relative flex flex-col items-center w-full p-4 border-b border-slate-200/80 dark:border-slate-700/50 text-center gap-3">
+<aside
+    class="fixed left-0 top-0 z-50 flex h-full flex-col border-r border-slate-200/80 bg-white/95 shadow-xl backdrop-blur-xl transition-all duration-300 dark:border-slate-700/60 dark:bg-slate-900/95 {collapsed ? 'w-20' : 'w-64'} {mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}"
+>
+    <div
+        data-sidebar-brand
+        class="relative flex w-full flex-col items-center text-center gap-3 border-b border-slate-200/80 px-4 py-5 dark:border-slate-700/60"
+    >
         <button
-            class="flex flex-col items-center gap-3 focus-ring rounded-lg p-1 -m-1"
+            class="focus-ring -m-1 flex flex-col items-center gap-3 rounded-xl p-1"
             onclick={() => navigateAndClose('/')}
         >
             <BrandMark
@@ -84,11 +100,11 @@
                 class="flex-shrink-0 transition-all duration-300 {collapsed ? 'h-10 w-10' : 'h-16 w-16'}"
             />
             {#if !collapsed}
-                <div class="flex flex-col overflow-hidden items-center">
-                    <h1 class="text-sm font-bold text-gradient leading-tight truncate">
+                <div class="flex flex-col items-center overflow-hidden">
+                    <h1 class="text-gradient truncate text-sm font-bold leading-tight">
                         {$_('app.logo_title')}
                     </h1>
-                    <span class="text-xs font-semibold text-slate-600 dark:text-slate-300 truncate">
+                    <span class="truncate text-xs font-semibold text-slate-600 dark:text-slate-300">
                         {$_('app.logo_subtitle')}
                     </span>
                 </div>
@@ -96,95 +112,149 @@
         </button>
     </div>
 
-    <!-- Navigation -->
-    <nav class="flex-1 overflow-y-auto p-3 space-y-1">
-        {#each navItems as item}
-            <button
-                class="nav-button w-full flex items-center gap-3 text-left"
-                class:nav-button-active={isRouteActive(item)}
-                class:nav-button-inactive={!isRouteActive(item)}
-                onclick={() => handleNavClick(item)}
-                title={collapsed ? item.label : ''}
-                aria-label={item.label}
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d={item.icon} />
-                </svg>
+    <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-4" aria-label={$_('nav.navigation', { default: 'Primary navigation' })}>
+        {#each navSections as section, sectionIndex}
+            <div data-sidebar-section={section.id} class={sectionIndex === 0 ? '' : 'mt-5'}>
                 {#if !collapsed}
-                    <span class="text-sm">{item.label}</span>
+                    <div class="px-3 pb-2 text-[0.625rem] font-bold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500">
+                        {section.label}
+                    </div>
                 {/if}
-            </button>
+                <div class="space-y-1">
+                    {#each section.items as item}
+                        <button
+                            class="sidebar-nav {collapsed ? 'justify-center px-0' : ''}"
+                            class:sidebar-nav-active={isRouteActive(item)}
+                            class:sidebar-nav-inactive={!isRouteActive(item)}
+                            onclick={() => handleNavClick(item)}
+                            title={collapsed ? item.label : ''}
+                            aria-label={item.label}
+                            aria-current={isRouteActive(item) ? 'page' : undefined}
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d={item.icon} />
+                            </svg>
+                            {#if !collapsed}
+                                <span class="truncate text-sm">{item.label}</span>
+                            {/if}
+                        </button>
+                    {/each}
+                </div>
+            </div>
         {/each}
     </nav>
 
-
-    <!-- Status Section -->
     {#if !collapsed}
-        <div class="p-3 border-t border-slate-200/80 dark:border-slate-700/50">
-            <div class="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-3 space-y-2">
+        <div data-sidebar-status class="shrink-0 border-t border-slate-200/80 p-3 dark:border-slate-700/60">
+            <div class="rounded-xl border border-slate-200/80 bg-slate-50/90 p-3 shadow-sm dark:border-slate-700/70 dark:bg-slate-800/55">
+                <div class="mb-2 flex items-center justify-between gap-2">
+                    <span class="text-[0.625rem] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                        {$_('status.title')}
+                    </span>
+                </div>
                 {@render status?.()}
             </div>
         </div>
     {/if}
 
-    <!-- Auth Actions (Login/Logout) -->
-    <div class="p-3 border-t border-slate-200/80 dark:border-slate-700/50 space-y-2">
-        {#if authStore.isAuthenticated}
-            <button
-                class="nav-button w-full flex items-center gap-3 text-left nav-button-inactive hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50/80 dark:hover:bg-red-900/30 group"
-                onclick={() => authStore.logout()}
-                title={collapsed ? $_('auth.logout') : ''}
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 flex-shrink-0 group-hover:scale-110 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-                </svg>
-                {#if !collapsed}
-                    <span class="text-sm font-medium">{$_('auth.logout')}</span>
-                {/if}
-            </button>
-        {:else if authStore.isGuest}
-            <button
-                class="nav-button w-full flex items-center gap-3 text-left nav-button-inactive hover:text-accent-600 dark:hover:text-accent-400 hover:bg-accent-50/80 dark:hover:bg-accent-900/30 group"
-                onclick={() => authStore.requestLogin()} 
-                title={collapsed ? $_('auth.login') : ''}
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 flex-shrink-0 group-hover:scale-110 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
-                </svg>
-                {#if !collapsed}
-                    <span class="text-sm font-medium">{$_('auth.login')}</span>
-                {/if}
-            </button>
+    <div class="shrink-0 border-t border-slate-200/80 p-3 dark:border-slate-700/60">
+        {#if !collapsed}
+            {#if authStore.isAuthenticated}
+                <div data-sidebar-account class="flex min-w-0 items-center gap-2 rounded-xl border border-slate-200/80 bg-slate-50/90 p-2 dark:border-slate-700/70 dark:bg-slate-800/55">
+                    <div class="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg bg-brand-100 text-xs font-bold text-brand-700 dark:bg-brand-900/50 dark:text-brand-300">
+                        {accountInitial}
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <div class="truncate text-xs font-semibold text-slate-800 dark:text-slate-100">{authStore.username}</div>
+                        <div class="truncate text-[0.625rem] text-slate-500 dark:text-slate-400">{$_('app.title')}</div>
+                    </div>
+                    <button
+                        class="focus-ring rounded-lg p-2 text-slate-400 transition hover:bg-red-50 hover:text-red-600 dark:text-slate-500 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+                        onclick={() => authStore.logout()}
+                        title={$_('auth.logout')}
+                        aria-label={$_('auth.logout')}
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                        </svg>
+                    </button>
+                </div>
+            {:else if authStore.isGuest}
+                <div data-sidebar-account class="flex min-w-0 items-center gap-2 rounded-xl border border-slate-200/80 bg-slate-50/90 p-2 dark:border-slate-700/70 dark:bg-slate-800/55">
+                    <div class="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                        </svg>
+                    </div>
+                    <div class="min-w-0 flex-1 truncate text-xs font-semibold text-slate-700 dark:text-slate-200">
+                        {$_('auth.public_view')}
+                    </div>
+                    <button
+                        class="focus-ring rounded-lg p-2 text-slate-400 transition hover:bg-accent-50 hover:text-accent-700 dark:text-slate-500 dark:hover:bg-accent-900/30 dark:hover:text-accent-300"
+                        onclick={() => authStore.requestLogin()}
+                        title={$_('auth.login')}
+                        aria-label={$_('auth.login')}
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
+                        </svg>
+                    </button>
+                </div>
+            {/if}
+        {:else}
+            {#if authStore.isAuthenticated}
+                <button
+                    class="sidebar-nav sidebar-nav-inactive justify-center px-0 hover:text-red-600 dark:hover:text-red-400"
+                    onclick={() => authStore.logout()}
+                    title={$_('auth.logout')}
+                    aria-label={$_('auth.logout')}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                    </svg>
+                </button>
+            {:else if authStore.isGuest}
+                <button
+                    class="sidebar-nav sidebar-nav-inactive justify-center px-0"
+                    onclick={() => authStore.requestLogin()}
+                    title={$_('auth.login')}
+                    aria-label={$_('auth.login')}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
+                    </svg>
+                </button>
+            {/if}
         {/if}
     </div>
 
-    <!-- Language, Theme, Collapse — inline utility row -->
-    <div class="p-3 border-t border-slate-200/80 dark:border-slate-700/50">
+    <div class="shrink-0 border-t border-slate-200/80 p-3 dark:border-slate-700/60">
         <div class="flex items-center {collapsed ? 'flex-col gap-1' : 'justify-around gap-1'}">
             <LanguageSelector dropUp compact />
             <button
-                class="p-2.5 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400 transition-all duration-200 focus-ring"
+                class="focus-ring rounded-xl p-2.5 text-slate-500 transition-all duration-200 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
                 onclick={() => themeStore.toggle()}
                 title={themeStore.isDark ? $_('theme.switch_light') : $_('theme.switch_dark')}
                 aria-label={themeStore.isDark ? $_('theme.switch_light') : $_('theme.switch_dark')}
             >
                 {#if themeStore.isDark}
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
                     </svg>
                 {:else}
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
                     </svg>
                 {/if}
             </button>
             <button
-                class="p-2.5 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400 transition-all duration-200 focus-ring"
+                class="focus-ring rounded-xl p-2.5 text-slate-500 transition-all duration-200 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
                 onclick={() => layoutStore.toggleSidebar()}
                 title={collapsed ? $_('nav.expand_sidebar') : $_('nav.collapse_sidebar')}
                 aria-label={collapsed ? $_('nav.expand_sidebar') : $_('nav.collapse_sidebar')}
             >
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                     {#if collapsed}
                         <path stroke-linecap="round" stroke-linejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
                     {:else}
@@ -194,5 +264,4 @@
             </button>
         </div>
     </div>
-
 </aside>

--- a/apps/ui/src/lib/i18n/locales.identical-baseline.json
+++ b/apps/ui/src/lib/i18n/locales.identical-baseline.json
@@ -219,6 +219,7 @@
     "settings.telegram.bot_token_placeholder",
     "shortcuts.actions",
     "shortcuts.navigation",
+    "status.notifications",
     "theme.font_compact",
     "theme.font_studio",
     "theme.horizontal",

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -9,6 +9,8 @@
     "dashboard": "Dashboard",
     "explorer": "Explorer",
     "leaderboard": "Bestenliste",
+    "observe": "Beobachten",
+    "manage": "Verwalten",
     "audio_history": "Audioverlauf",
     "settings": "Einstellungen",
     "setup_wizard": "Einrichtungsassistent",
@@ -1255,6 +1257,12 @@
     "status_check_again": "Erneut prüfen"
   },
   "status": {
+    "title": "Systemstatus",
+    "live_updates": "Live-Aktualisierungen",
+    "online": "Verbunden",
+    "offline": "Getrennt",
+    "audio_analysis": "Audioanalyse",
+    "notifications": "Benachrichtigungen",
     "audio_active": "Audio-Analyse aktiv",
     "notifications_enabled": "Benachrichtigungen aktiviert",
     "system_online": "System online",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -9,6 +9,8 @@
     "dashboard": "Dashboard",
     "explorer": "Explorer",
     "leaderboard": "Leaderboard",
+    "observe": "Observe",
+    "manage": "Manage",
     "audio_history": "Audio History",
     "jobs": "Jobs",
     "settings": "Settings",
@@ -1301,6 +1303,12 @@
     "status_check_again": "Check again"
   },
   "status": {
+    "title": "System status",
+    "live_updates": "Live updates",
+    "online": "Online",
+    "offline": "Offline",
+    "audio_analysis": "Audio analysis",
+    "notifications": "Notifications",
     "audio_active": "Audio Analysis Active",
     "notifications_enabled": "Notifications Enabled",
     "system_online": "System Online",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -9,6 +9,8 @@
     "dashboard": "Tablero",
     "explorer": "Explorador",
     "leaderboard": "Clasificación",
+    "observe": "Observar",
+    "manage": "Gestionar",
     "audio_history": "Historial de audio",
     "settings": "Ajustes",
     "setup_wizard": "Asistente de configuración",
@@ -1255,6 +1257,12 @@
     "status_check_again": "Comprobar de nuevo"
   },
   "status": {
+    "title": "Estado del sistema",
+    "live_updates": "Actualizaciones en directo",
+    "online": "En línea",
+    "offline": "Desconectado",
+    "audio_analysis": "Análisis de audio",
+    "notifications": "Notificaciones",
     "audio_active": "Análisis de audio activo",
     "notifications_enabled": "Notificaciones habilitadas",
     "system_online": "Sistema en línea",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -9,6 +9,8 @@
     "dashboard": "Tableau de bord",
     "explorer": "Explorateur",
     "leaderboard": "Classement",
+    "observe": "Observer",
+    "manage": "Gérer",
     "audio_history": "Historique audio",
     "settings": "Paramètres",
     "setup_wizard": "Assistant de configuration",
@@ -1255,6 +1257,12 @@
     "status_check_again": "Vérifier à nouveau"
   },
   "status": {
+    "title": "État du système",
+    "live_updates": "Mises à jour en direct",
+    "online": "En ligne",
+    "offline": "Hors ligne",
+    "audio_analysis": "Analyse audio",
+    "notifications": "Notifications",
     "audio_active": "Analyse audio active",
     "notifications_enabled": "Notifications activées",
     "system_online": "Système en ligne",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -9,6 +9,8 @@
     "dashboard": "Dashboard",
     "explorer": "Esplora",
     "leaderboard": "Classifica",
+    "observe": "Osserva",
+    "manage": "Gestisci",
     "audio_history": "Cronologia audio",
     "settings": "Impostazioni",
     "setup_wizard": "Configurazione guidata",
@@ -1264,6 +1266,12 @@
     "status_check_again": "Controlla di nuovo"
   },
   "status": {
+    "title": "Stato del sistema",
+    "live_updates": "Aggiornamenti in tempo reale",
+    "online": "Connesso",
+    "offline": "Disconnesso",
+    "audio_analysis": "Analisi audio",
+    "notifications": "Notifiche",
     "audio_active": "Analisi Audio Attiva",
     "notifications_enabled": "Notifiche Abilitate",
     "system_online": "Sistema Online",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -9,6 +9,8 @@
     "dashboard": "ダッシュボード",
     "explorer": "エクスプローラー",
     "leaderboard": "リーダーボード",
+    "observe": "観察",
+    "manage": "管理",
     "audio_history": "音声履歴",
     "settings": "設定",
     "setup_wizard": "セットアップウィザード",
@@ -1255,6 +1257,12 @@
     "status_check_again": "再確認"
   },
   "status": {
+    "title": "システム状態",
+    "live_updates": "ライブ更新",
+    "online": "オンライン",
+    "offline": "オフライン",
+    "audio_analysis": "音声分析",
+    "notifications": "通知",
     "audio_active": "音声分析中",
     "notifications_enabled": "通知有効",
     "system_online": "システムオンライン",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -9,6 +9,8 @@
     "dashboard": "Painel",
     "explorer": "Explorar",
     "leaderboard": "Ranking",
+    "observe": "Observar",
+    "manage": "Gerir",
     "audio_history": "Histórico de áudio",
     "settings": "Configurações",
     "setup_wizard": "Assistente de configuração",
@@ -1264,6 +1266,12 @@
     "status_check_again": "Verificar novamente"
   },
   "status": {
+    "title": "Estado do sistema",
+    "live_updates": "Atualizações em direto",
+    "online": "Conectado",
+    "offline": "Desconectado",
+    "audio_analysis": "Análise de áudio",
+    "notifications": "Notificações",
     "audio_active": "Análise de Áudio Ativa",
     "notifications_enabled": "Notificações Ativadas",
     "system_online": "Sistema Online",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -9,6 +9,8 @@
     "dashboard": "Дашборд",
     "explorer": "Просмотр",
     "leaderboard": "Рейтинг",
+    "observe": "Наблюдение",
+    "manage": "Управление",
     "audio_history": "История аудио",
     "settings": "Настройки",
     "setup_wizard": "Мастер настройки",
@@ -1264,6 +1266,12 @@
     "status_check_again": "Проверить снова"
   },
   "status": {
+    "title": "Состояние системы",
+    "live_updates": "Обновления в реальном времени",
+    "online": "Онлайн",
+    "offline": "Офлайн",
+    "audio_analysis": "Аудиоанализ",
+    "notifications": "Уведомления",
     "audio_active": "Аудиоанализ активен",
     "notifications_enabled": "Уведомления включены",
     "system_online": "Система онлайн",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -9,6 +9,8 @@
     "dashboard": "仪表盘",
     "explorer": "探索",
     "leaderboard": "排行榜",
+    "observe": "观察",
+    "manage": "管理",
     "audio_history": "音频历史",
     "settings": "设置",
     "setup_wizard": "设置向导",
@@ -1255,6 +1257,12 @@
     "status_check_again": "重新检查"
   },
   "status": {
+    "title": "系统状态",
+    "live_updates": "实时更新",
+    "online": "在线",
+    "offline": "离线",
+    "audio_analysis": "音频分析",
+    "notifications": "通知",
     "audio_active": "音频分析活跃",
     "notifications_enabled": "通知已启用",
     "system_online": "系统在线",


### PR DESCRIPTION
## Summary
- retain the large centred YA-WAMF bird mark
- group navigation into Observe and Manage sections with a clearer active route
- add truthful live-update, audio-analysis, and notification status rows
- present authenticated and public access as compact account cards
- preserve collapsed and mobile sidebar behavior
- add localized labels and layout regression coverage

## Verification
- `npm test` — 599 tests passed
- `npm run check` — 0 errors and 0 warnings
- `npm run build` — production build passed
- visual QA at 1440x1000, 1280x720, and collapsed rail
- `git diff --check`