### PR TITLE
Keep sidebar controls reachable on short screens

### DIFF
--- a/apps/ui/src/lib/components/Sidebar.layout.test.ts
+++ b/apps/ui/src/lib/components/Sidebar.layout.test.ts
@@ -39,4 +39,9 @@ describe('Sidebar hybrid refresh', () => {
         expect(sidebarSource).toContain("$_('auth.logout')");
         expect(sidebarSource).toContain("$_('auth.login')");
     });
+
+    it('keeps navigation and bottom controls reachable on short viewports', () => {
+        expect(sidebarSource).toContain('[@media(max-height:42rem)]:hidden');
+        expect(sidebarSource).toContain('[@media(max-height:42rem)]:py-3');
+    });
 });

--- a/apps/ui/src/lib/components/Sidebar.svelte
+++ b/apps/ui/src/lib/components/Sidebar.svelte
@@ -88,7 +88,7 @@
 >
     <div
         data-sidebar-brand
-        class="relative flex w-full flex-col items-center text-center gap-3 border-b border-slate-200/80 px-4 py-5 dark:border-slate-700/60"
+        class="relative flex w-full flex-col items-center text-center gap-3 border-b border-slate-200/80 px-4 py-5 dark:border-slate-700/60 [@media(max-height:42rem)]:py-3"
     >
         <button
             class="focus-ring -m-1 flex flex-col items-center gap-3 rounded-xl p-1"
@@ -145,7 +145,7 @@
     </nav>
 
     {#if !collapsed}
-        <div data-sidebar-status class="shrink-0 border-t border-slate-200/80 p-3 dark:border-slate-700/60">
+        <div data-sidebar-status class="shrink-0 border-t border-slate-200/80 p-3 dark:border-slate-700/60 [@media(max-height:42rem)]:hidden">
             <div class="rounded-xl border border-slate-200/80 bg-slate-50/90 p-3 shadow-sm dark:border-slate-700/70 dark:bg-slate-800/55">
                 <div class="mb-2 flex items-center justify-between gap-2">
                     <span class="text-[0.625rem] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
## Summary
- hide the non-essential status summary below 42rem viewport height
- tighten brand padding at the same breakpoint
- keep navigation scrollable and preserve account/language/theme/collapse controls
- add regression coverage for the short-height behavior

## Verification
- `npm test` — 600 tests passed
- `npm run check` — 0 errors and 0 warnings
- `npm run build` — passed
- visual QA at 1024x600 — status hidden, all controls visible
- `git diff --check`