### PR TITLE
Add live CPU and accelerator status graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Unreleased]
 
 ### Changed
+- **System status now carries a subtle live host-activity trace.** A lightweight one-minute SVG
+  history shows real CPU load and, when the host exposes a supported counter, active accelerator
+  utilization. Unsupported or unavailable accelerator data is omitted rather than estimated.
 - **The desktop sidebar now matches the rest of the application more closely.** The large centred
   bird mark remains, while navigation is grouped into observation and management areas, the active
   route has a clearer Blue Tit treatment, live system state is shown as compact honest rows, and

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -1608,10 +1608,20 @@ export interface components {
     StartRunResponse: {
     run_id: string;
 };
+    SystemAcceleratorTelemetry: {
+    kind: "npu" | "gpu";
+    label: string;
+    utilization_percent?: number | null;
+};
     SystemDebugResponse: {
     disk_usage: Array<unknown>;
     platform: string;
     python: string;
+};
+    SystemTelemetryResponse: {
+    accelerator?: components['schemas']['SystemAcceleratorTelemetry'] | null;
+    cpu_percent?: number | null;
+    sampled_at: string;
 };
     TaxonomySyncStartResponse: {
     status: string;
@@ -3343,6 +3353,15 @@ export interface paths {
 };
       requestBody: unknown;
       response: components['schemas']['DetectionsTimelineSpanResponse'];
+    };
+  };
+  "/api/system-telemetry": {
+    get: {
+      operationId: "get_system_telemetry_api_system_telemetry_get";
+      path: never;
+      query: never;
+      requestBody: unknown;
+      response: components['schemas']['SystemTelemetryResponse'];
     };
   };
   "/api/update-status": {

--- a/apps/ui/src/lib/api/system.telemetry.test.ts
+++ b/apps/ui/src/lib/api/system.telemetry.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { apiFetchMock, handleResponseMock } = vi.hoisted(() => ({
+    apiFetchMock: vi.fn(),
+    handleResponseMock: vi.fn()
+}));
+
+vi.mock('./core', () => ({
+    API_BASE: '/api',
+    apiFetch: apiFetchMock,
+    handleResponse: handleResponseMock
+}));
+
+import { fetchSystemTelemetry } from './system';
+
+describe('system telemetry', () => {
+    beforeEach(() => {
+        apiFetchMock.mockReset();
+        handleResponseMock.mockReset();
+    });
+
+    it('fetches one uncached bounded telemetry sample', async () => {
+        const response = new Response('{}');
+        const sample = {
+            sampled_at: '2026-07-25T12:00:00Z',
+            cpu_percent: 37.5,
+            accelerator: { kind: 'npu', label: 'NPU', utilization_percent: 18.2 }
+        };
+        apiFetchMock.mockResolvedValue(response);
+        handleResponseMock.mockResolvedValue(sample);
+
+        await expect(fetchSystemTelemetry()).resolves.toEqual(sample);
+        expect(apiFetchMock).toHaveBeenCalledWith('/api/system-telemetry', {
+            cache: 'no-store',
+            timeoutMs: 2_500
+        });
+        expect(handleResponseMock).toHaveBeenCalledWith(response);
+    });
+});

--- a/apps/ui/src/lib/api/system.ts
+++ b/apps/ui/src/lib/api/system.ts
@@ -122,6 +122,17 @@ export async function checkHealth(): Promise<HealthStatus> {
     return handleResponse<HealthStatus>(response);
 }
 
+export type SystemTelemetry = paths['/api/system-telemetry']['get']['response'];
+export type SystemAcceleratorTelemetry = NonNullable<SystemTelemetry['accelerator']>;
+
+export async function fetchSystemTelemetry(): Promise<SystemTelemetry> {
+    const response = await apiFetch(`${API_BASE}/system-telemetry`, {
+        cache: 'no-store',
+        timeoutMs: 2_500
+    });
+    return handleResponse<SystemTelemetry>(response);
+}
+
 export interface UpdateStatus {
     current_version: string;
     channel: 'dev' | 'stable' | 'main' | string;

--- a/apps/ui/src/lib/components/Sidebar.layout.test.ts
+++ b/apps/ui/src/lib/components/Sidebar.layout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import appSource from '../../App.svelte?raw';
 import connectionStatusSource from './ConnectionStatus.svelte?raw';
 import sidebarSource from './Sidebar.svelte?raw';
+import telemetryGraphSource from './SystemTelemetryGraph.svelte?raw';
 
 describe('Sidebar hybrid refresh', () => {
     it('keeps the large brand mark centred above the navigation', () => {
@@ -43,5 +44,19 @@ describe('Sidebar hybrid refresh', () => {
     it('keeps navigation and bottom controls reachable on short viewports', () => {
         expect(sidebarSource).toContain('[@media(max-height:42rem)]:hidden');
         expect(sidebarSource).toContain('[@media(max-height:42rem)]:py-3');
+    });
+
+    it('layers a lightweight live telemetry graph behind the status content', () => {
+        expect(sidebarSource).toContain("import SystemTelemetryGraph from './SystemTelemetryGraph.svelte'");
+        expect(sidebarSource).toContain('<SystemTelemetryGraph />');
+        expect(sidebarSource).toContain('relative overflow-hidden');
+        expect(sidebarSource).toContain('relative z-10');
+    });
+
+    it('samples telemetry only while the status card is actually visible', () => {
+        expect(telemetryGraphSource).toContain('IntersectionObserver');
+        expect(telemetryGraphSource).toContain('!inViewport');
+        expect(telemetryGraphSource).toContain('document.hidden');
+        expect(telemetryGraphSource).toContain('history = []');
     });
 });

--- a/apps/ui/src/lib/components/Sidebar.svelte
+++ b/apps/ui/src/lib/components/Sidebar.svelte
@@ -7,6 +7,7 @@
     import { _ } from 'svelte-i18n';
     import BrandMark from './BrandMark.svelte';
     import LanguageSelector from './LanguageSelector.svelte';
+    import SystemTelemetryGraph from './SystemTelemetryGraph.svelte';
 
     onMount(() => {
         updateStatusStore.load();
@@ -146,13 +147,16 @@
 
     {#if !collapsed}
         <div data-sidebar-status class="shrink-0 border-t border-slate-200/80 p-3 dark:border-slate-700/60 [@media(max-height:42rem)]:hidden">
-            <div class="rounded-xl border border-slate-200/80 bg-slate-50/90 p-3 shadow-sm dark:border-slate-700/70 dark:bg-slate-800/55">
-                <div class="mb-2 flex items-center justify-between gap-2">
-                    <span class="text-[0.625rem] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
-                        {$_('status.title')}
-                    </span>
+            <div class="relative overflow-hidden rounded-xl border border-slate-200/80 bg-slate-50/90 p-3 shadow-sm dark:border-slate-700/70 dark:bg-slate-800/55">
+                <SystemTelemetryGraph />
+                <div class="relative z-10">
+                    <div class="mb-2 flex items-center justify-between gap-2">
+                        <span class="text-[0.625rem] font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                            {$_('status.title')}
+                        </span>
+                    </div>
+                    {@render status?.()}
                 </div>
-                {@render status?.()}
             </div>
         </div>
     {/if}

--- a/apps/ui/src/lib/components/SystemTelemetryGraph.svelte
+++ b/apps/ui/src/lib/components/SystemTelemetryGraph.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { fetchSystemTelemetry } from '../api/system';
+    import {
+        appendTelemetrySample,
+        telemetryPolyline,
+        type TelemetryPoint
+    } from './systemTelemetryGraph';
+
+    const SAMPLE_INTERVAL_MS = 2_500;
+
+    let history = $state<TelemetryPoint[]>([]);
+    let sampling = false;
+    let inViewport = false;
+    let container: HTMLDivElement;
+
+    let current = $derived(history.at(-1));
+    let cpuPoints = $derived(telemetryPolyline(history, 'cpu'));
+    let acceleratorPoints = $derived(telemetryPolyline(history, 'accelerator'));
+    let cpuArea = $derived(cpuPoints ? `0,100 ${cpuPoints} 100,100` : '');
+
+    function displayPercent(value: number | null | undefined): string | null {
+        return typeof value === 'number' ? `${Math.round(value)}%` : null;
+    }
+
+    let currentCpuPercent = $derived(displayPercent(current?.cpu));
+    let currentAcceleratorPercent = $derived(displayPercent(current?.accelerator));
+
+    async function takeSample(): Promise<void> {
+        if (sampling || document.hidden || !inViewport) return;
+        sampling = true;
+        try {
+            const sample = await fetchSystemTelemetry();
+            if (!inViewport || document.hidden) return;
+            history = appendTelemetrySample(history, sample);
+        } catch {
+            // Telemetry is decorative; never leave stale values looking live.
+            history = [];
+        } finally {
+            sampling = false;
+        }
+    }
+
+    onMount(() => {
+        const observer = new IntersectionObserver(([entry]) => {
+            const isVisible = entry?.isIntersecting ?? false;
+            if (isVisible === inViewport) return;
+            inViewport = isVisible;
+            if (inViewport && !document.hidden) {
+                void takeSample();
+            } else {
+                history = [];
+            }
+        });
+        observer.observe(container);
+
+        const interval = window.setInterval(() => void takeSample(), SAMPLE_INTERVAL_MS);
+        const handleVisibility = () => {
+            if (document.hidden) {
+                history = [];
+            } else if (inViewport) {
+                void takeSample();
+            }
+        };
+        document.addEventListener('visibilitychange', handleVisibility);
+        return () => {
+            observer.disconnect();
+            window.clearInterval(interval);
+            document.removeEventListener('visibilitychange', handleVisibility);
+        };
+    });
+</script>
+
+<div
+    bind:this={container}
+    data-system-telemetry
+    class="pointer-events-none absolute inset-0 overflow-hidden rounded-xl"
+    aria-hidden="true"
+>
+    {#if cpuPoints}
+        <svg
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            class="absolute inset-x-0 bottom-0 h-full w-full"
+        >
+            <polygon
+                points={cpuArea}
+                fill="currentColor"
+                class="text-brand-500 opacity-[0.07] dark:text-brand-400 dark:opacity-[0.09]"
+            />
+            <polyline
+                points={cpuPoints}
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.25"
+                vector-effect="non-scaling-stroke"
+                class="text-brand-500 opacity-20 dark:text-brand-400 dark:opacity-25"
+            />
+            {#if acceleratorPoints}
+                <polyline
+                    points={acceleratorPoints}
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.1"
+                    vector-effect="non-scaling-stroke"
+                    class="text-indigo-500 opacity-20 dark:text-indigo-400 dark:opacity-25"
+                />
+            {/if}
+        </svg>
+    {/if}
+
+    {#if current}
+        <div class="absolute right-3 top-2 flex items-center gap-2 text-[0.5625rem] font-semibold tabular-nums">
+            {#if currentCpuPercent}
+                <span class="text-brand-700/70 dark:text-brand-300/70">CPU {currentCpuPercent}</span>
+            {/if}
+            {#if currentAcceleratorPercent}
+                <span class="text-indigo-700/70 dark:text-indigo-300/70">
+                    {current.acceleratorLabel ?? ''} {currentAcceleratorPercent}
+                </span>
+            {/if}
+        </div>
+    {/if}
+</div>

--- a/apps/ui/src/lib/components/systemTelemetryGraph.test.ts
+++ b/apps/ui/src/lib/components/systemTelemetryGraph.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendTelemetrySample, telemetryPolyline, type TelemetryPoint } from './systemTelemetryGraph';
+
+describe('system telemetry graph helpers', () => {
+    it('keeps a bounded rolling history and ignores empty baseline samples', () => {
+        const existing: TelemetryPoint[] = Array.from({ length: 25 }, (_, index) => ({
+            cpu: index,
+            accelerator: index / 2,
+            acceleratorLabel: 'NPU'
+        }));
+
+        const unchanged = appendTelemetrySample(existing, {
+            sampled_at: '2026-07-25T12:00:00Z',
+            cpu_percent: null,
+            accelerator: { kind: 'npu', label: 'NPU', utilization_percent: null }
+        });
+        expect(unchanged).toBe(existing);
+
+        const updated = appendTelemetrySample(existing, {
+            sampled_at: '2026-07-25T12:00:02Z',
+            cpu_percent: 48.2,
+            accelerator: { kind: 'npu', label: 'NPU', utilization_percent: 17.1 }
+        });
+        expect(updated).toHaveLength(25);
+        expect(updated[0]?.cpu).toBe(1);
+        expect(updated.at(-1)).toEqual({ cpu: 48.2, accelerator: 17.1, acceleratorLabel: 'NPU' });
+    });
+
+    it('maps bounded utilization values into SVG coordinates without inventing zeroes', () => {
+        const points: TelemetryPoint[] = [
+            { cpu: 0, accelerator: null, acceleratorLabel: 'NPU' },
+            { cpu: 50, accelerator: 25, acceleratorLabel: 'NPU' },
+            { cpu: 100, accelerator: 75, acceleratorLabel: 'NPU' }
+        ];
+
+        expect(telemetryPolyline(points, 'cpu')).toBe('0,100 50,50 100,0');
+        expect(telemetryPolyline(points, 'accelerator')).toBe('50,75 100,25');
+    });
+});

--- a/apps/ui/src/lib/components/systemTelemetryGraph.ts
+++ b/apps/ui/src/lib/components/systemTelemetryGraph.ts
@@ -1,0 +1,55 @@
+import type { SystemTelemetry } from '../api/system';
+
+export interface TelemetryPoint {
+    cpu: number | null;
+    accelerator: number | null;
+    acceleratorLabel: string | null;
+}
+
+const HISTORY_LIMIT = 25;
+
+function finitePercent(value: number | null | undefined): number | null {
+    return typeof value === 'number' && Number.isFinite(value)
+        ? Math.max(0, Math.min(100, value))
+        : null;
+}
+
+export function appendTelemetrySample(
+    history: TelemetryPoint[],
+    sample: SystemTelemetry,
+    limit = HISTORY_LIMIT
+): TelemetryPoint[] {
+    const cpu = finitePercent(sample.cpu_percent);
+    const accelerator = finitePercent(sample.accelerator?.utilization_percent);
+    if (cpu === null && accelerator === null) return history;
+
+    return [
+        ...history,
+        {
+            cpu,
+            accelerator,
+            acceleratorLabel: sample.accelerator?.label ?? null
+        }
+    ].slice(-Math.max(1, limit));
+}
+
+function coordinate(value: number): string {
+    return Number(value.toFixed(2)).toString();
+}
+
+export function telemetryPolyline(
+    history: TelemetryPoint[],
+    series: 'cpu' | 'accelerator'
+): string {
+    const denominator = Math.max(1, history.length - 1);
+    return history
+        .map((point, index) => {
+            const value = point[series];
+            if (value === null) return null;
+            const x = index / denominator * 100;
+            const y = 100 - finitePercent(value)!;
+            return `${coordinate(x)},${coordinate(y)}`;
+        })
+        .filter((point): point is string => point !== null)
+        .join(' ');
+}

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request, Depends, Query
+from fastapi import APIRouter, Request, Response, Depends, Query
 import os
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Literal
@@ -7,6 +7,7 @@ from app.database import get_db
 from app.repositories.detection_repository import DetectionRepository
 from app.models import APIModel, DetectionResponse
 from app.config import settings
+from app.services.system_telemetry import system_telemetry_sampler
 from app.services.taxonomy.taxonomy_service import taxonomy_service
 from app.services.weather_service import weather_service
 from app.auth import AuthContext
@@ -19,6 +20,38 @@ from app.utils.api_datetime import utc_naive_now
 from app.utils.timezone import get_user_timezone
 
 router = APIRouter()
+
+
+class SystemAcceleratorTelemetry(APIModel):
+    kind: Literal["npu", "gpu"]
+    label: str
+    utilization_percent: float | None = None
+
+
+class SystemTelemetryResponse(APIModel):
+    sampled_at: str
+    cpu_percent: float | None = None
+    accelerator: SystemAcceleratorTelemetry | None = None
+
+
+@router.get("/system-telemetry", response_model=SystemTelemetryResponse)
+@guest_rate_limit()
+async def get_system_telemetry(request: Request, response: Response) -> SystemTelemetryResponse:
+    """Return one live host-utilization sample for the sidebar's rolling graph."""
+    sample = system_telemetry_sampler.sample()
+    response.headers["Cache-Control"] = "no-store"
+    accelerator = None
+    if sample.accelerator_kind and sample.accelerator_label:
+        accelerator = SystemAcceleratorTelemetry(
+            kind=sample.accelerator_kind,
+            label=sample.accelerator_label,
+            utilization_percent=sample.accelerator_percent,
+        )
+    return SystemTelemetryResponse(
+        sampled_at=datetime.now(timezone.utc).isoformat(),
+        cpu_percent=sample.cpu_percent,
+        accelerator=accelerator,
+    )
 
 
 class UpdateStatusResponse(APIModel):

--- a/backend/app/services/system_telemetry.py
+++ b/backend/app/services/system_telemetry.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+import time
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class SystemTelemetrySample:
+    cpu_percent: float | None
+    accelerator_kind: str | None
+    accelerator_label: str | None
+    accelerator_percent: float | None
+
+
+class SystemTelemetrySampler:
+    """Sample host CPU and supported accelerator counters without external tools."""
+
+    def __init__(
+        self,
+        *,
+        proc_stat_path: Path | str = Path("/proc/stat"),
+        npu_busy_path: Path | str = Path("/sys/class/accel/accel0/device/npu_busy_time_us"),
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._proc_stat_path = Path(proc_stat_path)
+        self._npu_busy_path = Path(npu_busy_path)
+        self._clock = clock
+        self._previous_cpu: tuple[int, int] | None = None
+        self._previous_npu: tuple[int, float] | None = None
+        self._lock = Lock()
+
+    @staticmethod
+    def _percent(value: float) -> float:
+        return round(max(0.0, min(100.0, value)), 1)
+
+    def _read_cpu_counters(self) -> tuple[int, int] | None:
+        try:
+            fields = self._proc_stat_path.read_text(encoding="utf-8").splitlines()[0].split()
+            if not fields or fields[0] != "cpu":
+                return None
+            counters = [int(value) for value in fields[1:]]
+            total = sum(counters)
+            idle = counters[3] + (counters[4] if len(counters) > 4 else 0)
+            return total, idle
+        except (OSError, ValueError, IndexError):
+            return None
+
+    def _sample_cpu(self) -> float | None:
+        current = self._read_cpu_counters()
+        previous = self._previous_cpu
+        self._previous_cpu = current
+        if current is None or previous is None:
+            return None
+        total_delta = current[0] - previous[0]
+        idle_delta = current[1] - previous[1]
+        if total_delta <= 0 or idle_delta < 0:
+            return None
+        return self._percent((total_delta - idle_delta) / total_delta * 100.0)
+
+    def _read_npu_busy_time(self) -> int | None:
+        try:
+            return int(self._npu_busy_path.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            return None
+
+    def _sample_npu(self, now: float) -> float | None:
+        current_busy = self._read_npu_busy_time()
+        previous = self._previous_npu
+        self._previous_npu = (current_busy, now) if current_busy is not None else None
+        if current_busy is None or previous is None:
+            return None
+        busy_delta = current_busy - previous[0]
+        elapsed = now - previous[1]
+        if busy_delta < 0 or elapsed <= 0:
+            return None
+        return self._percent(busy_delta / (elapsed * 1_000_000.0) * 100.0)
+
+    def sample(self) -> SystemTelemetrySample:
+        with self._lock:
+            now = self._clock()
+            cpu_percent = self._sample_cpu()
+            has_npu = self._npu_busy_path.is_file()
+            accelerator_percent = self._sample_npu(now) if has_npu else None
+            return SystemTelemetrySample(
+                cpu_percent=cpu_percent,
+                accelerator_kind="npu" if has_npu else None,
+                accelerator_label="NPU" if has_npu else None,
+                accelerator_percent=accelerator_percent,
+            )
+
+
+system_telemetry_sampler = SystemTelemetrySampler()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -12346,6 +12346,39 @@
         "title": "StartRunResponse",
         "type": "object"
       },
+      "SystemAcceleratorTelemetry": {
+        "properties": {
+          "kind": {
+            "enum": [
+              "npu",
+              "gpu"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "utilization_percent": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Utilization Percent"
+          }
+        },
+        "required": [
+          "kind",
+          "label"
+        ],
+        "title": "SystemAcceleratorTelemetry",
+        "type": "object"
+      },
       "SystemDebugResponse": {
         "properties": {
           "disk_usage": {
@@ -12380,6 +12413,40 @@
           "disk_usage"
         ],
         "title": "SystemDebugResponse",
+        "type": "object"
+      },
+      "SystemTelemetryResponse": {
+        "properties": {
+          "accelerator": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SystemAcceleratorTelemetry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "cpu_percent": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cpu Percent"
+          },
+          "sampled_at": {
+            "title": "Sampled At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sampled_at"
+        ],
+        "title": "SystemTelemetryResponse",
         "type": "object"
       },
       "TaxonomySyncStartResponse": {
@@ -21489,6 +21556,39 @@
           }
         ],
         "summary": "Get Detection Timeline Span",
+        "tags": [
+          "stats"
+        ]
+      }
+    },
+    "/api/system-telemetry": {
+      "get": {
+        "description": "Return one live host-utilization sample for the sidebar's rolling graph.",
+        "operationId": "get_system_telemetry_api_system_telemetry_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemTelemetryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ],
+        "summary": "Get System Telemetry",
         "tags": [
           "stats"
         ]

--- a/backend/tests/test_system_telemetry.py
+++ b/backend/tests/test_system_telemetry.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.main import app
+from app.routers import stats as stats_router
+from app.services.system_telemetry import SystemTelemetrySample, SystemTelemetrySampler
+
+
+def _write_cpu_stat(path: Path, *, user: int, system: int, idle: int) -> None:
+    path.write_text(f"cpu  {user} 0 {system} {idle} 0 0 0 0 0 0\n", encoding="utf-8")
+
+
+def test_sampler_reports_real_cpu_and_npu_utilization_from_counter_deltas(tmp_path: Path) -> None:
+    proc_stat = tmp_path / "stat"
+    npu_busy = tmp_path / "npu_busy_time_us"
+    _write_cpu_stat(proc_stat, user=100, system=100, idle=800)
+    npu_busy.write_text("100000\n", encoding="utf-8")
+    clock_values = iter([10.0, 12.0])
+
+    sampler = SystemTelemetrySampler(
+        proc_stat_path=proc_stat,
+        npu_busy_path=npu_busy,
+        clock=lambda: next(clock_values),
+    )
+
+    first = sampler.sample()
+    assert first.cpu_percent is None
+    assert first.accelerator_kind == "npu"
+    assert first.accelerator_label == "NPU"
+    assert first.accelerator_percent is None
+
+    _write_cpu_stat(proc_stat, user=150, system=150, idle=900)
+    npu_busy.write_text("500000\n", encoding="utf-8")
+
+    second = sampler.sample()
+    assert second.cpu_percent == 50.0
+    assert second.accelerator_kind == "npu"
+    assert second.accelerator_label == "NPU"
+    assert second.accelerator_percent == 20.0
+
+
+@pytest.mark.asyncio
+async def test_system_telemetry_endpoint_returns_live_sample_without_caching(monkeypatch: pytest.MonkeyPatch) -> None:
+    class StubSampler:
+        def sample(self) -> SystemTelemetrySample:
+            return SystemTelemetrySample(
+                cpu_percent=37.5,
+                accelerator_kind="npu",
+                accelerator_label="NPU",
+                accelerator_percent=18.2,
+            )
+
+    monkeypatch.setattr(stats_router, "system_telemetry_sampler", StubSampler(), raising=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/system-telemetry")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json() == {
+        "sampled_at": response.json()["sampled_at"],
+        "cpu_percent": 37.5,
+        "accelerator": {"kind": "npu", "label": "NPU", "utilization_percent": 18.2},
+    }


### PR DESCRIPTION
## Summary
- expose uncached, rate-limited CPU and supported accelerator utilization from real host counters
- render a subtle browser-held one-minute CPU/NPU SVG history behind the sidebar System Status card
- stop polling and clear stale telemetry when the page or status card is not visible
- keep unsupported accelerator data absent rather than inferred

## Validation
- `backend/.venv/bin/python -m pytest -q` — 1764 passed, 65 skipped
- `npm test` — 605 passed
- Ruff lint and format checks — passed
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — passed
- OpenAPI JSON and generated TypeScript freshness — passed
- real-host sampler — CPU 11.2%, Intel NPU 40.7% after baseline
- browser QA — both traces rendered at 1440x1000; card hidden at 1024x600; requests remained 4 -> 4 while hidden
- staged added-line security scan — no secrets, shell injection, eval/exec, unsafe pickle, or SQL interpolation

## Screenshots
- `/home/jellman86/yawamf-sidebar-ideas/14-telemetry-final-desktop.png`
- `/home/jellman86/yawamf-sidebar-ideas/15-telemetry-final-short-height.png`
