### PR TITLE
Harden telemetry idempotency, rollups, and free-tier controls

### DIFF
--- a/.github/workflows/deploy-telemetry-worker.yml
+++ b/.github/workflows/deploy-telemetry-worker.yml
@@ -1,0 +1,58 @@
+name: Deploy telemetry worker
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "apps/telemetry-worker/**"
+      - ".github/workflows/deploy-telemetry-worker.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: telemetry-worker-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Test, migrate, and deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    defaults:
+      run:
+        working-directory: apps/telemetry-worker
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: apps/telemetry-worker/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Run Worker and D1 integration tests
+        run: npm test
+
+      - name: Apply usage rollup migrations
+        run: >-
+          npx wrangler d1 execute yawamf-telemetry
+          --remote --yes
+          --file=./migrations/telemetry/0001_daily_heartbeats.sql
+
+      - name: Apply health idempotency migrations
+        run: >-
+          npx wrangler d1 execute yawamf-health-issues
+          --remote --yes
+          --file=./migrations/health/0001_report_batches.sql
+
+      - name: Deploy telemetry Worker
+        run: npx wrangler deploy

--- a/apps/telemetry-worker/README.md
+++ b/apps/telemetry-worker/README.md
@@ -64,10 +64,14 @@ database_id = "PASTE_YOUR_HEALTH_ID_HERE"
 Create the tables in your remote database:
 
 ```bash
-npm install
+npm ci
 npx wrangler d1 execute yawamf-telemetry --file=./schema.sql --remote
+npx wrangler d1 execute yawamf-telemetry --file=./migrations/telemetry/0001_daily_heartbeats.sql --remote
 npx wrangler d1 execute yawamf-health-issues --file=./health_schema.sql --remote
+npx wrangler d1 execute yawamf-health-issues --file=./migrations/health/0001_report_batches.sql --remote
 ```
+
+The rollup migrations are idempotent. They add one usage snapshot per installation/day (keyed by an opaque installation hash), one compact health batch marker per unique report, and a shared daily write-budget row. Rollups, detailed health aggregates, and batch markers retain 400 days; normal ingestion removes expired rows in bounded chunks. Health ingestion uses at most 30 D1 statements per request, below Cloudflare Free's 50-query invocation limit.
 
 ### 6. Deploy the Worker
 Publish the code to the edge:
@@ -80,18 +84,22 @@ You will get a URL like `https://yawamf-telemetry.<your-subdomain>.workers.dev`.
 
 ## Deploying Updates
 
-When you make changes to the worker code (e.g., updating `src/index.ts`), you can push the new version using the same non-interactive method:
+Pushes to `dev` that touch `apps/telemetry-worker/**` run `.github/workflows/deploy-telemetry-worker.yml`. The workflow installs locked dependencies, runs the Worker+D1 integration suite, applies both idempotent migrations, and deploys only after all prior steps pass.
 
-1. **Set the API Token**:
+For an authorised manual deployment:
+
+1. **Set the Cloudflare API token**:
    ```bash
    export CLOUDFLARE_API_TOKEN=your_token_here
    ```
 
-2. **Deploy**:
+2. **Apply migrations, then deploy**:
    ```bash
+   npm run db:migrate:telemetry
+   npm run db:migrate:health
    npm run deploy
    ```
-   *Note: This command is non-interactive and does not require a browser login when the API token is set.*
+   Migrations are idempotent and must succeed before publishing the Worker. These commands are non-interactive when the API token is set.
 
 ## Dashboard
 
@@ -101,12 +109,7 @@ The worker includes a small server-rendered dashboard at:
 https://yawamf-telemetry.<your-subdomain>.workers.dev/dashboard
 ```
 
-It is disabled unless both Basic Auth secrets are configured:
-
-```bash
-npx wrangler secret put DASHBOARD_USERNAME
-npx wrangler secret put DASHBOARD_PASSWORD
-```
+The current dashboard is a public, aggregate-only view. It does not expose installation IDs, hostnames, media, raw diagnostic messages, or configuration secrets. Maintainer-only protection for detailed Health Data is implemented separately from the ingestion changes.
 
 The dashboard has two views:
 
@@ -119,6 +122,12 @@ Use `?days=7`, `?days=30`, or `?days=90` to change the reporting window.
 
 - **`POST /heartbeat`**: Receives the telemetry JSON payload.
 - **`POST /health-issues`**: Receives deduped, sanitized anonymous health issue reports.
-- **`GET /dashboard`**: Basic-Auth protected HTML dashboard for usage and health summaries.
+- **`GET /dashboard`**: Returns the current public aggregate HTML dashboard.
 - **`GET /stats/summary`**: Returns a JSON summary of active installs, versions, and model usage.
 - **`GET /stats/health-issues`**: Returns aggregate health issue summaries from the separate health D1 database.
+
+Both POST endpoints reject bodies larger than 128 KiB before JSON parsing. Cloudflare's native rate-limit bindings provide per-location, eventually consistent best-effort limits keyed by source IP and installation (heartbeat: 6/minute; health issues: 1/minute) before D1 writes. They are not global ceilings. An atomic account-wide budget in the usage D1 is the hard write guard and limits estimated indexed writes to 40,000 units/day across both endpoints; exhausted requests receive `503` before telemetry rows are written. The estimate deliberately leaves substantial headroom below Cloudflare Free's 100,000 rows-written/day allowance.
+
+Health schema v3 sends only installation-scoped SHA-256 event identities. Batch-marker SQL compares those opaque identities with prior 400-day markers, so an exact retry or a service restart with overlapping diagnostic history does not increment aggregate counts twice. Existing v1/v2 clients remain accepted with their prior report-level idempotency behavior.
+
+Ingestion is intentionally anonymous and unauthenticated so open-source installations require no shared secret. Rate limits and the global budget bound abuse, but caller-supplied data can still be forged; aggregates are directional product telemetry, not an authoritative audit or billing record.

--- a/apps/telemetry-worker/migrations/health/0001_report_batches.sql
+++ b/apps/telemetry-worker/migrations/health/0001_report_batches.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS health_report_batches (
+    report_id TEXT PRIMARY KEY,
+    installation_id_hash TEXT NOT NULL,
+    report_date TEXT NOT NULL,
+    reported_at TEXT NOT NULL,
+    app_version TEXT,
+    schema_version TEXT,
+    country TEXT,
+    issue_group_count INTEGER NOT NULL DEFAULT 0,
+    event_count INTEGER NOT NULL DEFAULT 0,
+    critical_count INTEGER NOT NULL DEFAULT 0,
+    error_count INTEGER NOT NULL DEFAULT 0,
+    warning_count INTEGER NOT NULL DEFAULT 0,
+    event_groups_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_health_batches_date
+    ON health_report_batches(report_date);
+CREATE INDEX IF NOT EXISTS idx_health_batches_install_date
+    ON health_report_batches(installation_id_hash, report_date);

--- a/apps/telemetry-worker/migrations/telemetry/0001_daily_heartbeats.sql
+++ b/apps/telemetry-worker/migrations/telemetry/0001_daily_heartbeats.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS heartbeat_daily (
+    report_date TEXT NOT NULL,
+    installation_id_hash TEXT NOT NULL,
+    last_reported_at TEXT NOT NULL,
+    version TEXT,
+    channel TEXT,
+    platform TEXT,
+    machine TEXT,
+    inference_provider TEXT,
+    configured_inference_provider TEXT,
+    model TEXT,
+    country TEXT,
+    gpu_model TEXT,
+    deployment_image TEXT,
+    runtime_flavor TEXT,
+    compose_flavor TEXT,
+    environment TEXT,
+    feature_flags TEXT,
+    PRIMARY KEY (report_date, installation_id_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_heartbeat_daily_date
+    ON heartbeat_daily(report_date);
+CREATE INDEX IF NOT EXISTS idx_heartbeat_daily_version_date
+    ON heartbeat_daily(report_date, version);
+
+CREATE TABLE IF NOT EXISTS ingestion_daily_budget (
+    budget_date TEXT PRIMARY KEY,
+    write_units INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL
+);

--- a/apps/telemetry-worker/package-lock.json
+++ b/apps/telemetry-worker/package-lock.json
@@ -8,11 +8,12 @@
       "name": "yawamf-telemetry-worker",
       "version": "1.0.0",
       "dependencies": {
-        "hono": "^4.12.31"
+        "hono": "4.12.31"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^5.20260719.1",
-        "wrangler": "^4.112.0"
+        "@cloudflare/workers-types": "5.20260724.1",
+        "miniflare": "4.20260722.0",
+        "wrangler": "4.114.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -42,9 +43,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260714.1.tgz",
-      "integrity": "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==",
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
+      "integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
       "cpu": [
         "x64"
       ],
@@ -59,9 +60,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260714.1.tgz",
-      "integrity": "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==",
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
+      "integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
       "cpu": [
         "arm64"
       ],
@@ -76,9 +77,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260714.1.tgz",
-      "integrity": "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==",
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
+      "integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +94,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260714.1.tgz",
-      "integrity": "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==",
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
+      "integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
       "cpu": [
         "arm64"
       ],
@@ -110,9 +111,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260714.1.tgz",
-      "integrity": "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==",
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
+      "integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +128,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260719.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260719.1.tgz",
-      "integrity": "sha512-DcGasbfUuczQilc80vhL2MPPdWcaxWkx0hN5IW9UdNDBdrRvWcal3akSJ6Ccm7e8+/OGeR+8tYrqkykA3YGSZw==",
+      "version": "5.20260724.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260724.1.tgz",
+      "integrity": "sha512-gl0brZ60JhkZU3INgr1jsxaFEiWf3AB9RsCjLTMwT5RKspWRUpsFd0wxwbys7gb8Ywkfq9tORhw0y9G+7bDUYw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -147,9 +148,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -610,9 +611,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
       "cpu": [
         "arm64"
       ],
@@ -623,19 +624,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
       "cpu": [
         "x64"
       ],
@@ -646,19 +647,39 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
       "cpu": [
         "arm64"
       ],
@@ -673,9 +694,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
       "cpu": [
         "x64"
       ],
@@ -690,16 +711,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -710,16 +728,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -730,16 +745,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -750,16 +762,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -770,16 +779,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -790,16 +796,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -810,16 +813,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -830,16 +830,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -850,237 +847,230 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
       "cpu": [
         "arm64"
       ],
@@ -1091,16 +1081,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
       "cpu": [
         "ia32"
       ],
@@ -1111,16 +1101,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
       "cpu": [
         "x64"
       ],
@@ -1131,7 +1121,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1332,16 +1322,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260714.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260714.0.tgz",
-      "integrity": "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==",
+      "version": "4.20260722.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
+      "integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "0.34.5",
+        "sharp": "0.35.2",
         "undici": "7.28.0",
-        "workerd": "1.20260714.1",
+        "workerd": "1.20260722.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1380,48 +1370,48 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.4"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
       }
     },
     "node_modules/supports-color": {
@@ -1466,9 +1456,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260714.1.tgz",
-      "integrity": "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==",
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
+      "integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1479,17 +1469,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260714.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
-        "@cloudflare/workerd-linux-64": "1.20260714.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
-        "@cloudflare/workerd-windows-64": "1.20260714.1"
+        "@cloudflare/workerd-darwin-64": "1.20260722.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260722.1",
+        "@cloudflare/workerd-linux-64": "1.20260722.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260722.1",
+        "@cloudflare/workerd-windows-64": "1.20260722.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.112.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.112.0.tgz",
-      "integrity": "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==",
+      "version": "4.114.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
+      "integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1497,10 +1487,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260714.0",
+        "miniflare": "4.20260722.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260714.1"
+        "workerd": "1.20260722.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1514,7 +1504,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260714.1"
+        "@cloudflare/workers-types": "^5.20260722.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/apps/telemetry-worker/package.json
+++ b/apps/telemetry-worker/package.json
@@ -7,14 +7,18 @@
     "check": "wrangler deploy --dry-run --outdir .wrangler/dry-run",
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
+    "test": "npm run check && node --test test/*.test.mjs",
     "db:init": "wrangler d1 execute yawamf-telemetry --file=./schema.sql",
-    "db:health:init": "wrangler d1 execute yawamf-health-issues --file=./health_schema.sql"
+    "db:health:init": "wrangler d1 execute yawamf-health-issues --file=./health_schema.sql",
+    "db:migrate:telemetry": "wrangler d1 execute yawamf-telemetry --remote --yes --file=./migrations/telemetry/0001_daily_heartbeats.sql",
+    "db:migrate:health": "wrangler d1 execute yawamf-health-issues --remote --yes --file=./migrations/health/0001_report_batches.sql"
   },
   "dependencies": {
-    "hono": "^4.12.31"
+    "hono": "4.12.31"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260719.1",
-    "wrangler": "^4.112.0"
+    "@cloudflare/workers-types": "5.20260724.1",
+    "miniflare": "4.20260722.0",
+    "wrangler": "4.114.0"
   }
 }

--- a/apps/telemetry-worker/src/index.ts
+++ b/apps/telemetry-worker/src/index.ts
@@ -4,6 +4,9 @@ import { cors } from 'hono/cors';
 type Bindings = {
   DB: D1Database;
   HEALTH_DB: D1Database;
+  HEARTBEAT_RATE_LIMITER: RateLimit;
+  HEALTH_RATE_LIMITER: RateLimit;
+  ALLOW_UNLIMITED_INGESTION_FOR_TESTS?: string;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();
@@ -95,6 +98,7 @@ interface HealthIssue {
   stage?: string | null;
   severity?: string | null;
   count?: number;
+  event_ids?: string[];
   first_seen_at?: string | null;
   last_seen_at?: string | null;
   sample_context?: Record<string, unknown> | null;
@@ -102,6 +106,7 @@ interface HealthIssue {
 
 interface HealthIssuePayload {
   schema_version?: string;
+  report_id?: string;
   installation_id: string;
   timestamp: string;
   version: string;
@@ -117,7 +122,86 @@ interface HealthIssuePayload {
 }
 
 const MAX_HEALTH_ISSUES_PER_REPORT = 25;
+const MAX_HEALTH_EVENTS_PER_REPORT = 250;
+const MAX_INGESTION_BODY_BYTES = 128 * 1024;
 const MAX_JSON_CHARS = 8192;
+// Conservative D1 rows-written estimates include base rows plus primary/secondary
+// index maintenance. The 40k operational cap leaves 60k rows/day of Free-plan
+// headroom; update these weights whenever an ingestion-table index changes.
+const GLOBAL_D1_DAILY_WRITE_BUDGET = 40_000;
+const HEARTBEAT_BASE_WRITE_UNITS = 16;
+const HEALTH_BASE_WRITE_UNITS = 16;
+const HEALTH_ISSUE_WRITE_UNITS = 8;
+
+type BoundedJsonResult =
+  | { ok: true; value: unknown }
+  | { ok: false; status: 400 | 413; error: string };
+
+async function readBoundedJson(request: Request): Promise<BoundedJsonResult> {
+  const contentLength = Number(request.headers.get('content-length') ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_INGESTION_BODY_BYTES) {
+    return { ok: false, status: 413, error: 'Payload too large' };
+  }
+  if (!request.body) return { ok: false, status: 400, error: 'Missing JSON body' };
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_INGESTION_BODY_BYTES) {
+      await reader.cancel();
+      return { ok: false, status: 413, error: 'Payload too large' };
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return { ok: true, value: JSON.parse(new TextDecoder().decode(body)) };
+  } catch {
+    return { ok: false, status: 400, error: 'Invalid JSON body' };
+  }
+}
+
+async function withinIngestionRateLimit(
+  limiter: RateLimit | undefined,
+  request: Request,
+  installationId: unknown,
+  allowMissingForTests = false,
+): Promise<boolean> {
+  if (!limiter) {
+    if (allowMissingForTests) return true;
+    throw new Error('Required ingestion rate limiter is unavailable');
+  }
+  const ip = request.headers.get('cf-connecting-ip') || 'unknown';
+  const installation = safeText(installationId, 'unknown', 160);
+  for (const key of [`ip:${ip}`, `installation:${installation}`]) {
+    const { success } = await limiter.limit({ key });
+    if (!success) return false;
+  }
+  return true;
+}
+
+async function acquireDailyWriteBudget(db: D1Database, writeUnits: number): Promise<boolean> {
+  const result = await db.prepare(`
+    INSERT INTO ingestion_daily_budget (budget_date, write_units, updated_at)
+    VALUES (date('now'), ?, datetime('now'))
+    ON CONFLICT(budget_date) DO UPDATE SET
+      write_units = ingestion_daily_budget.write_units + excluded.write_units,
+      updated_at = datetime('now')
+    WHERE ingestion_daily_budget.write_units + excluded.write_units <= ?
+    RETURNING write_units
+  `).bind(writeUnits, GLOBAL_D1_DAILY_WRITE_BUDGET).first();
+  return result !== null;
+}
 
 function safeText(value: unknown, fallback = '', limit = 160): string {
   const text = String(value ?? '').trim();
@@ -127,7 +211,7 @@ function safeText(value: unknown, fallback = '', limit = 160): string {
 
 function boundedJson(value: unknown, limit = MAX_JSON_CHARS): string {
   const text = JSON.stringify(value ?? {});
-  return text.length > limit ? text.slice(0, limit - 3) + '...' : text;
+  return text.length > limit ? JSON.stringify({ truncated: true }) : text;
 }
 
 function normalizeSeverity(value: unknown): string {
@@ -138,7 +222,42 @@ function normalizeSeverity(value: unknown): string {
 function safeCount(value: unknown): number {
   const count = Number(value ?? 0);
   if (!Number.isFinite(count)) return 0;
-  return Math.max(0, Math.floor(count));
+  return Math.min(MAX_HEALTH_EVENTS_PER_REPORT, Math.max(0, Math.floor(count)));
+}
+
+const ALLOWED_HEALTH_CONTEXT_KEYS = new Set([
+  'active_provider', 'attempt', 'backend', 'batch_limit', 'cache_enabled',
+  'circuit_failures', 'circuit_open', 'compile_device', 'compile_ok',
+  'configured_provider', 'cuda_available', 'device', 'error_type',
+  'failure_count', 'fallback_active', 'inference_backend', 'intel_gpu_available',
+  'intel_npu_available', 'kind', 'lease_age_seconds', 'max_concurrent',
+  'model_id', 'openvino_available', 'pending', 'pressure_level', 'provider',
+  'queue_depth', 'reason', 'reason_code', 'runtime', 'runtime_backend', 'source',
+  'stage', 'status', 'timeout_seconds', 'worker_pool',
+]);
+
+function sanitizeHealthContext(value: unknown, depth = 0): unknown {
+  if (depth > 2 || value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') return safeText(value, '', 160);
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, 10)
+      .map((item) => sanitizeHealthContext(item, depth + 1))
+      .filter((item) => item !== null);
+  }
+  if (typeof value === 'object') {
+    const sanitized: Record<string, unknown> = {};
+    for (const [rawKey, rawValue] of Object.entries(value as Record<string, unknown>).slice(0, 20)) {
+      const key = safeText(rawKey, '', 80).toLowerCase();
+      if (!ALLOWED_HEALTH_CONTEXT_KEYS.has(key)) continue;
+      const sanitizedValue = sanitizeHealthContext(rawValue, depth + 1);
+      if (sanitizedValue !== null) sanitized[key] = sanitizedValue;
+    }
+    return sanitized;
+  }
+  return safeText(value, '', 160);
 }
 
 async function sha256Hex(value: string): Promise<string> {
@@ -762,12 +881,37 @@ app.get('/dashboard', async (c) => {
 
 app.post('/heartbeat', async (c) => {
   try {
-    const payload = await c.req.json<TelemetryPayload>();
+    const parsed = await readBoundedJson(c.req.raw);
+    if (!parsed.ok) return c.json({ error: parsed.error }, parsed.status);
+    if (!parsed.value || typeof parsed.value !== 'object' || Array.isArray(parsed.value)) {
+      return c.json({ error: 'JSON body must be an object' }, 400);
+    }
+    const payload = parsed.value as TelemetryPayload;
     const country = c.req.raw.cf?.country || 'XX';
 
     if (!payload.installation_id) {
       return c.json({ error: 'Missing installation_id' }, 400);
     }
+    if (!await withinIngestionRateLimit(
+      c.env.HEARTBEAT_RATE_LIMITER,
+      c.req.raw,
+      payload.installation_id,
+      c.env.ALLOW_UNLIMITED_INGESTION_FOR_TESTS === 'true',
+    )) {
+      return c.json({ error: 'Rate limit exceeded' }, 429, { 'Retry-After': '60' });
+    }
+    const expiredDaily = await c.env.DB.prepare(`
+      SELECT COUNT(*) AS count FROM (
+        SELECT 1 FROM heartbeat_daily
+        WHERE report_date < date('now', '-400 days')
+        LIMIT 1
+      )
+    `).first<number>('count') ?? 0;
+    const heartbeatWriteUnits = HEARTBEAT_BASE_WRITE_UNITS + (expiredDaily > 0 ? 4 : 0);
+    if (!await acquireDailyWriteBudget(c.env.DB, heartbeatWriteUnits)) {
+      return c.json({ error: 'Daily ingestion budget exhausted' }, 503, { 'Retry-After': '86400' });
+    }
+    const installationHash = await sha256Hex(payload.installation_id);
 
     const stmt = c.env.DB.prepare(`
       INSERT INTO heartbeats (
@@ -876,7 +1020,7 @@ app.post('/heartbeat', async (c) => {
     const b2i = (val?: boolean) => val ? 1 : 0;
     const b2iNullable = (val?: boolean | null) => typeof val === 'boolean' ? (val ? 1 : 0) : null;
 
-    await stmt.bind(
+    const heartbeatStmt = stmt.bind(
       payload.installation_id,
       payload.version,
       payload.platform?.system || null,
@@ -926,7 +1070,73 @@ app.post('/heartbeat', async (c) => {
       payload.runtime?.last_recovery_reason || null,
       payload.runtime?.last_recovery_status || null,
       country
-    ).run();
+    );
+
+    const dailyStmt = c.env.DB.prepare(`
+      INSERT INTO heartbeat_daily (
+        report_date,
+        installation_id_hash,
+        last_reported_at,
+        version,
+        channel,
+        platform,
+        machine,
+        inference_provider,
+        configured_inference_provider,
+        model,
+        country,
+        deployment_image,
+        runtime_flavor,
+        environment,
+        feature_flags
+      ) VALUES (date('now'), ?, datetime('now'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(report_date, installation_id_hash) DO UPDATE SET
+        last_reported_at = excluded.last_reported_at,
+        version = excluded.version,
+        channel = excluded.channel,
+        platform = excluded.platform,
+        machine = excluded.machine,
+        inference_provider = excluded.inference_provider,
+        configured_inference_provider = excluded.configured_inference_provider,
+        model = excluded.model,
+        country = excluded.country,
+        deployment_image = excluded.deployment_image,
+        runtime_flavor = excluded.runtime_flavor,
+        environment = excluded.environment,
+        feature_flags = excluded.feature_flags
+    `).bind(
+      installationHash,
+      payload.version,
+      payload.deployment?.app_branch || null,
+      payload.platform?.system || null,
+      payload.platform?.machine || null,
+      payload.runtime?.inference_provider_active || null,
+      payload.runtime?.inference_provider_configured || null,
+      payload.configuration?.model_type || null,
+      country,
+      payload.deployment?.image_flavor || null,
+      payload.runtime?.model_runtime || null,
+      payload.deployment?.mode || null,
+      boundedJson({
+        birdnet: payload.integrations?.birdnet_enabled ?? payload.configuration?.birdnet_enabled ?? false,
+        birdweather: payload.integrations?.birdweather_enabled ?? payload.configuration?.birdweather_enabled ?? false,
+        llm: payload.configuration?.llm_enabled ?? false,
+        auto_video: payload.configuration?.auto_video_classification ?? false,
+        ebird: payload.integrations?.ebird_enabled ?? false,
+        inaturalist: payload.integrations?.inaturalist_enabled ?? false,
+      }, 1024),
+    );
+
+    const retentionCleanup = c.env.DB.prepare(`
+      DELETE FROM heartbeat_daily
+      WHERE (report_date, installation_id_hash) IN (
+        SELECT report_date, installation_id_hash FROM heartbeat_daily
+        WHERE report_date < date('now', '-400 days')
+        ORDER BY report_date
+        LIMIT 1
+      )
+    `);
+    await c.env.DB.batch([heartbeatStmt, dailyStmt, retentionCleanup]);
 
     return c.json({ status: 'ok' });
   } catch (e: any) {
@@ -937,7 +1147,12 @@ app.post('/heartbeat', async (c) => {
 
 app.post('/health-issues', async (c) => {
   try {
-    const payload = await c.req.json<HealthIssuePayload>();
+    const parsed = await readBoundedJson(c.req.raw);
+    if (!parsed.ok) return c.json({ error: parsed.error }, parsed.status);
+    if (!parsed.value || typeof parsed.value !== 'object' || Array.isArray(parsed.value)) {
+      return c.json({ error: 'JSON body must be an object' }, 400);
+    }
+    const payload = parsed.value as HealthIssuePayload;
     const country = c.req.raw.cf?.country || 'XX';
 
     if (!payload.installation_id) {
@@ -946,18 +1161,73 @@ app.post('/health-issues', async (c) => {
     if (!Array.isArray(payload.issues)) {
       return c.json({ error: 'Missing issues' }, 400);
     }
+    if (!await withinIngestionRateLimit(
+      c.env.HEALTH_RATE_LIMITER,
+      c.req.raw,
+      payload.installation_id,
+      c.env.ALLOW_UNLIMITED_INGESTION_FOR_TESTS === 'true',
+    )) {
+      return c.json({ error: 'Rate limit exceeded' }, 429, { 'Retry-After': '60' });
+    }
 
     const installationHash = await sha256Hex(payload.installation_id);
     const issues = payload.issues.slice(0, MAX_HEALTH_ISSUES_PER_REPORT);
+    const suppliedReportId = safeText(payload.report_id, '', 64).toLowerCase();
+    const isDeltaReport = /^[a-f0-9]{64}$/.test(suppliedReportId);
+    const legacyIdentity = issues
+      .map((issue) => [
+        safeText(issue.fingerprint, '', 80),
+        safeCount(issue.count),
+        safeText(issue.first_seen_at, '', 80),
+        safeText(issue.last_seen_at, '', 80),
+        normalizeSeverity(issue.severity),
+      ])
+      .sort((a, b) => String(a[0]).localeCompare(String(b[0])));
+    const clientReportId = isDeltaReport
+      ? suppliedReportId
+      : await sha256Hex(JSON.stringify(legacyIdentity));
+    const reportId = await sha256Hex(`${installationHash}:${clientReportId}`);
+    const runtime = payload.runtime ?? {};
+    const integrations = payload.integrations ?? {};
+    const diagnosticsWindow = payload.diagnostics_window ?? {};
+    const windowSeverityCounts = typeof diagnosticsWindow.severity_counts === 'object' && diagnosticsWindow.severity_counts
+      ? diagnosticsWindow.severity_counts as Record<string, unknown>
+      : {};
     const payloadBase = {
       schema_version: safeText(payload.schema_version, 'unknown', 80),
       timestamp: safeText(payload.timestamp, '', 80),
-      runtime: payload.runtime ?? {},
-      integrations: payload.integrations ?? {},
-      diagnostics_window: payload.diagnostics_window ?? {}
+      runtime: {
+        model_type: safeText(runtime.model_type, '', 120) || null,
+        inference_provider: safeText(runtime.inference_provider, '', 80) || null,
+        image_execution_mode: safeText(runtime.image_execution_mode, '', 80) || null,
+        bird_crop_detector_tier: safeText(runtime.bird_crop_detector_tier, '', 80) || null,
+        auto_video_classification: runtime.auto_video_classification === true,
+      },
+      integrations: {
+        birdnet_enabled: integrations.birdnet_enabled === true,
+        birdweather_enabled: integrations.birdweather_enabled === true,
+        ebird_enabled: integrations.ebird_enabled === true,
+        inaturalist_enabled: integrations.inaturalist_enabled === true,
+        llm_enabled: integrations.llm_enabled === true,
+      },
+      diagnostics_window: {
+        captured_at: safeText(diagnosticsWindow.captured_at, '', 80) || null,
+        total_events: safeCount(diagnosticsWindow.total_events),
+        returned_events: safeCount(diagnosticsWindow.returned_events),
+        severity_counts: {
+          critical: safeCount(windowSeverityCounts.critical),
+          error: safeCount(windowSeverityCounts.error),
+          warning: safeCount(windowSeverityCounts.warning),
+        },
+      },
     };
 
-    const stmt = c.env.HEALTH_DB.prepare(`
+    const schemaVersion = safeText(payload.schema_version, 'unknown', 80);
+    const isEventReport = isDeltaReport && schemaVersion === '2026-07-25.health-issues.v3';
+    const occurrenceUpdate = isDeltaReport
+      ? 'health_issue_reports.occurrence_count + excluded.occurrence_count'
+      : 'MAX(health_issue_reports.occurrence_count, excluded.occurrence_count)';
+    const legacyIssueStmt = c.env.HEALTH_DB.prepare(`
       INSERT INTO health_issue_reports (
         report_key,
         installation_id_hash,
@@ -980,7 +1250,71 @@ app.post('/health-issues', async (c) => {
         ip_country,
         created_at,
         updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'), datetime('now'))
+      )
+      SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, datetime('now'), datetime('now')
+      WHERE NOT EXISTS (
+        SELECT 1 FROM health_report_batches WHERE report_id = ?
+      )
+      ON CONFLICT(report_key) DO UPDATE SET
+        app_version = excluded.app_version,
+        platform_system = excluded.platform_system,
+        platform_release = excluded.platform_release,
+        platform_machine = excluded.platform_machine,
+        issue_source = excluded.issue_source,
+        issue_component = excluded.issue_component,
+        issue_reason_code = excluded.issue_reason_code,
+        issue_stage = excluded.issue_stage,
+        severity = excluded.severity,
+        first_seen_at = COALESCE(MIN(health_issue_reports.first_seen_at, excluded.first_seen_at), excluded.first_seen_at, health_issue_reports.first_seen_at),
+        last_seen_at = COALESCE(MAX(health_issue_reports.last_seen_at, excluded.last_seen_at), excluded.last_seen_at, health_issue_reports.last_seen_at),
+        report_count = health_issue_reports.report_count + 1,
+        occurrence_count = ${occurrenceUpdate},
+        sample_context_json = excluded.sample_context_json,
+        last_payload_json = excluded.last_payload_json,
+        ip_country = excluded.ip_country,
+        updated_at = datetime('now')
+    `);
+    const eventIssueStmt = c.env.HEALTH_DB.prepare(`
+      WITH new_events(event_id) AS (
+        SELECT DISTINCT CAST(value AS TEXT) FROM json_each(?)
+        EXCEPT
+        SELECT DISTINCT CAST(seen.value AS TEXT)
+        FROM health_report_batches AS prior,
+             json_each(COALESCE(prior.event_groups_json, '[]')) AS prior_group,
+             json_each(COALESCE(json_extract(prior_group.value, '$.event_ids'), '[]')) AS seen
+        WHERE prior.installation_id_hash = ?
+          AND prior.report_date >= date('now', '-400 days')
+          AND json_extract(prior_group.value, '$.fingerprint') = ?
+      )
+      INSERT INTO health_issue_reports (
+        report_key,
+        installation_id_hash,
+        issue_fingerprint,
+        app_version,
+        platform_system,
+        platform_release,
+        platform_machine,
+        issue_source,
+        issue_component,
+        issue_reason_code,
+        issue_stage,
+        severity,
+        first_seen_at,
+        last_seen_at,
+        report_count,
+        occurrence_count,
+        sample_context_json,
+        last_payload_json,
+        ip_country,
+        created_at,
+        updated_at
+      )
+      SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1,
+             (SELECT COUNT(*) FROM new_events), ?, ?, ?, datetime('now'), datetime('now')
+      WHERE NOT EXISTS (
+        SELECT 1 FROM health_report_batches WHERE report_id = ?
+      )
+        AND EXISTS (SELECT 1 FROM new_events)
       ON CONFLICT(report_key) DO UPDATE SET
         app_version = excluded.app_version,
         platform_system = excluded.platform_system,
@@ -1001,13 +1335,48 @@ app.post('/health-issues', async (c) => {
         updated_at = datetime('now')
     `);
 
+    const statements: D1PreparedStatement[] = [];
+    const eventGroups: Array<{ fingerprint: string; severity: string; event_ids: string[] }> = [];
+    let remainingEventIds = MAX_HEALTH_EVENTS_PER_REPORT;
     let accepted = 0;
+    let eventCount = 0;
+    const severityCounts = { critical: 0, error: 0, warning: 0 };
     for (const issue of issues) {
       const fingerprint = safeText(issue.fingerprint, '', 80);
       if (!fingerprint) continue;
+      const eventIds = isEventReport
+        ? Array.from(new Set(
+            (Array.isArray(issue.event_ids) ? issue.event_ids : [])
+              .map((value) => safeText(value, '', 64).toLowerCase())
+              .filter((value) => /^[a-f0-9]{64}$/.test(value)),
+          )).slice(0, remainingEventIds)
+        : [];
+      if (isEventReport && eventIds.length === 0) continue;
+      remainingEventIds -= eventIds.length;
+
       const reportKey = await sha256Hex(`${installationHash}:${fingerprint}`);
-      const count = safeCount(issue.count);
-      await stmt.bind(
+      const count = isEventReport ? eventIds.length : safeCount(issue.count);
+      const severity = normalizeSeverity(issue.severity) as keyof typeof severityCounts;
+      const source = safeText(issue.source, 'unknown', 80);
+      const component = safeText(issue.component, 'unknown', 80);
+      const reasonCode = safeText(issue.reason_code, 'unknown_reason', 120);
+      const stage = safeText(issue.stage, '', 80) || null;
+      const firstSeenAt = safeText(issue.first_seen_at, '', 80) || null;
+      const lastSeenAt = safeText(issue.last_seen_at, '', 80) || null;
+      const sampleContext = sanitizeHealthContext(issue.sample_context ?? {}) ?? {};
+      const sanitizedIssue = {
+        fingerprint,
+        source,
+        component,
+        reason_code: reasonCode,
+        stage,
+        severity,
+        count,
+        first_seen_at: firstSeenAt,
+        last_seen_at: lastSeenAt,
+        sample_context: sampleContext,
+      };
+      const commonBindings = [
         reportKey,
         installationHash,
         fingerprint,
@@ -1015,22 +1384,187 @@ app.post('/health-issues', async (c) => {
         safeText(payload.platform?.system, '', 80) || null,
         safeText(payload.platform?.release, '', 120) || null,
         safeText(payload.platform?.machine, '', 80) || null,
-        safeText(issue.source, 'unknown', 80),
-        safeText(issue.component, 'unknown', 80),
-        safeText(issue.reason_code, 'unknown_reason', 120),
-        safeText(issue.stage, '', 80) || null,
-        normalizeSeverity(issue.severity),
-        safeText(issue.first_seen_at, '', 80) || null,
-        safeText(issue.last_seen_at, '', 80) || null,
-        count,
-        boundedJson(issue.sample_context ?? {}, 2048),
-        boundedJson({ ...payloadBase, issue }, MAX_JSON_CHARS),
-        country
-      ).run();
+        source,
+        component,
+        reasonCode,
+        stage,
+        severity,
+        firstSeenAt,
+        lastSeenAt,
+      ];
+      const trailingBindings = [
+        boundedJson(sampleContext, 2048),
+        boundedJson({ ...payloadBase, issue: sanitizedIssue }, MAX_JSON_CHARS),
+        country,
+        reportId,
+      ];
+      if (isEventReport) {
+        eventGroups.push({ fingerprint, severity, event_ids: eventIds });
+        statements.push(eventIssueStmt.bind(
+          JSON.stringify(eventIds),
+          installationHash,
+          fingerprint,
+          ...commonBindings,
+          ...trailingBindings,
+        ));
+      } else {
+        statements.push(legacyIssueStmt.bind(
+          ...commonBindings,
+          count,
+          ...trailingBindings,
+        ));
+      }
       accepted++;
+      eventCount += count;
+      severityCounts[severity]++;
     }
 
-    return c.json({ status: 'ok', accepted });
+    if (accepted === 0) {
+      return c.json({ status: 'ok', accepted: 0, duplicate: false });
+    }
+
+    const expiredRows = await c.env.HEALTH_DB.prepare(`
+      SELECT
+        (SELECT COUNT(*) FROM (
+          SELECT report_key FROM health_issue_reports
+          WHERE updated_at < datetime('now', '-400 days')
+          LIMIT 25
+        )) AS issue_count,
+        (SELECT COUNT(*) FROM (
+          SELECT report_id FROM health_report_batches
+          WHERE report_date < date('now', '-400 days')
+          LIMIT 1
+        )) AS batch_count
+    `).first<{ issue_count: number; batch_count: number }>();
+    const expiredIssueCount = Number(expiredRows?.issue_count ?? 0);
+    const expiredBatchCount = Number(expiredRows?.batch_count ?? 0);
+    const healthWriteUnits = HEALTH_BASE_WRITE_UNITS
+      + accepted * HEALTH_ISSUE_WRITE_UNITS
+      + expiredIssueCount * HEALTH_ISSUE_WRITE_UNITS
+      + expiredBatchCount * 4;
+    if (!await acquireDailyWriteBudget(c.env.DB, healthWriteUnits)) {
+      return c.json({ error: 'Daily ingestion budget exhausted' }, 503, { 'Retry-After': '86400' });
+    }
+
+    const eventGroupsJson = JSON.stringify(eventGroups);
+    const legacyBatchMarker = c.env.HEALTH_DB.prepare(`
+      INSERT INTO health_report_batches (
+        report_id,
+        installation_id_hash,
+        report_date,
+        reported_at,
+        app_version,
+        schema_version,
+        country,
+        issue_group_count,
+        event_count,
+        critical_count,
+        error_count,
+        warning_count,
+        event_groups_json
+      ) VALUES (?, ?, date('now'), datetime('now'), ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      ON CONFLICT(report_id) DO NOTHING
+    `).bind(
+      reportId,
+      installationHash,
+      safeText(payload.version, 'unknown', 80),
+      schemaVersion,
+      country,
+      accepted,
+      eventCount,
+      severityCounts.critical,
+      severityCounts.error,
+      severityCounts.warning,
+    );
+    const eventBatchMarker = c.env.HEALTH_DB.prepare(`
+      WITH incoming AS (
+        SELECT DISTINCT
+          CAST(json_extract(issue_group.value, '$.fingerprint') AS TEXT) AS fingerprint,
+          CAST(json_extract(issue_group.value, '$.severity') AS TEXT) AS severity,
+          CAST(event_id.value AS TEXT) AS event_id
+        FROM json_each(?) AS issue_group,
+             json_each(COALESCE(json_extract(issue_group.value, '$.event_ids'), '[]')) AS event_id
+      ),
+      previous AS (
+        SELECT DISTINCT
+          CAST(json_extract(issue_group.value, '$.fingerprint') AS TEXT) AS fingerprint,
+          CAST(event_id.value AS TEXT) AS event_id
+        FROM health_report_batches AS prior,
+             json_each(COALESCE(prior.event_groups_json, '[]')) AS issue_group,
+             json_each(COALESCE(json_extract(issue_group.value, '$.event_ids'), '[]')) AS event_id
+        WHERE prior.installation_id_hash = ?
+          AND prior.report_date >= date('now', '-400 days')
+      ),
+      new_keys AS (
+        SELECT fingerprint, event_id FROM incoming
+        EXCEPT
+        SELECT fingerprint, event_id FROM previous
+      ),
+      new_events AS (
+        SELECT incoming.fingerprint, incoming.severity, incoming.event_id
+        FROM incoming
+        INNER JOIN new_keys USING (fingerprint, event_id)
+      )
+      INSERT INTO health_report_batches (
+        report_id,
+        installation_id_hash,
+        report_date,
+        reported_at,
+        app_version,
+        schema_version,
+        country,
+        issue_group_count,
+        event_count,
+        critical_count,
+        error_count,
+        warning_count,
+        event_groups_json
+      )
+      SELECT ?, ?, date('now'), datetime('now'), ?, ?, ?,
+             COUNT(DISTINCT fingerprint),
+             COUNT(*),
+             COUNT(DISTINCT CASE WHEN severity = 'critical' THEN fingerprint END),
+             COUNT(DISTINCT CASE WHEN severity = 'error' THEN fingerprint END),
+             COUNT(DISTINCT CASE WHEN severity = 'warning' THEN fingerprint END),
+             ?
+      FROM new_events
+      HAVING COUNT(*) > 0
+      ON CONFLICT(report_id) DO NOTHING
+    `).bind(
+      eventGroupsJson,
+      installationHash,
+      reportId,
+      installationHash,
+      safeText(payload.version, 'unknown', 80),
+      schemaVersion,
+      country,
+      eventGroupsJson,
+    );
+    const issueRetentionCleanup = c.env.HEALTH_DB.prepare(`
+      DELETE FROM health_issue_reports
+      WHERE report_key IN (
+        SELECT report_key FROM health_issue_reports
+        WHERE updated_at < datetime('now', '-400 days')
+        ORDER BY updated_at
+        LIMIT 25
+      )
+    `);
+    const batchRetentionCleanup = c.env.HEALTH_DB.prepare(`
+      DELETE FROM health_report_batches
+      WHERE report_id IN (
+        SELECT report_id FROM health_report_batches
+        WHERE report_date < date('now', '-400 days')
+        ORDER BY report_date
+        LIMIT 1
+      )
+    `);
+    statements.unshift(issueRetentionCleanup, batchRetentionCleanup);
+    statements.push(isEventReport ? eventBatchMarker : legacyBatchMarker);
+
+    const results = await c.env.HEALTH_DB.batch(statements);
+    const markerResult = results[results.length - 1];
+    const duplicate = Number(markerResult?.meta?.changes ?? 0) === 0;
+    return c.json({ status: 'ok', accepted: duplicate ? 0 : accepted, duplicate });
   } catch (e: any) {
     console.error('Health issue telemetry error:', e);
     return c.json({ error: e.message }, 500);

--- a/apps/telemetry-worker/test/worker.integration.test.mjs
+++ b/apps/telemetry-worker/test/worker.integration.test.mjs
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { after, before, test } from "node:test";
+import { Miniflare } from "miniflare";
+
+let mf;
+let usageDb;
+let healthDb;
+
+async function applySql(db, path) {
+  const sql = await readFile(new URL(path, import.meta.url), "utf8");
+  const statements = sql
+    .split(";")
+    .map((statement) => statement.trim())
+    .filter(Boolean)
+    .map((statement) => db.prepare(statement));
+  await db.batch(statements);
+}
+
+before(async () => {
+  const script = await readFile(new URL("../.wrangler/dry-run/index.js", import.meta.url), "utf8");
+  mf = new Miniflare({
+    modules: true,
+    script,
+    compatibilityDate: "2024-01-01",
+    bindings: { ALLOWED_ORIGIN: "*", ALLOW_UNLIMITED_INGESTION_FOR_TESTS: "true" },
+    d1Databases: { DB: "test-usage", HEALTH_DB: "test-health" },
+  });
+  usageDb = await mf.getD1Database("DB");
+  healthDb = await mf.getD1Database("HEALTH_DB");
+  await applySql(usageDb, "../schema.sql");
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await applySql(usageDb, "../migrations/telemetry/0001_daily_heartbeats.sql");
+  }
+  await applySql(healthDb, "../health_schema.sql");
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await applySql(healthDb, "../migrations/health/0001_report_batches.sql");
+  }
+});
+
+after(async () => {
+  await mf?.dispose();
+});
+
+test("heartbeat writes one bounded daily snapshot per installation", async () => {
+  await usageDb.prepare(
+    "INSERT INTO heartbeat_daily (report_date, installation_id_hash, last_reported_at) VALUES ('2020-01-01', 'expired', '2020-01-01T00:00:00Z')",
+  ).run();
+  const base = {
+    installation_id: "test-installation",
+    timestamp: "2026-07-25T10:00:00Z",
+    version: "2.15.0",
+    platform: "linux",
+    machine: "x86_64",
+  };
+  for (const payload of [base, { ...base, timestamp: "2026-07-25T12:00:00Z", version: "2.15.1" }]) {
+    const response = await mf.dispatchFetch("http://worker.test/heartbeat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 200, await response.text());
+  }
+
+  const result = await usageDb.prepare(
+    "SELECT COUNT(*) AS rows, MAX(version) AS version, MAX(installation_id_hash) AS installation_id_hash FROM heartbeat_daily",
+  ).first();
+  assert.equal(result.rows, 1);
+  assert.equal(result.version, "2.15.1");
+  assert.equal(result.installation_id_hash.length, 64);
+  assert.notEqual(result.installation_id_hash, base.installation_id);
+});
+
+test("ingestion rejects oversized bodies before D1 writes", async () => {
+  const usageBefore = await usageDb.prepare("SELECT COUNT(*) AS rows FROM heartbeats").first();
+  const healthBefore = await healthDb.prepare("SELECT COUNT(*) AS rows FROM health_report_batches").first();
+  const body = JSON.stringify({
+    installation_id: "oversized-installation",
+    issues: [],
+    padding: "x".repeat(128 * 1024),
+  });
+
+  for (const path of ["heartbeat", "health-issues"]) {
+    const response = await mf.dispatchFetch(`http://worker.test/${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    assert.equal(response.status, 413, await response.text());
+  }
+
+  const usageAfter = await usageDb.prepare("SELECT COUNT(*) AS rows FROM heartbeats").first();
+  const healthAfter = await healthDb.prepare("SELECT COUNT(*) AS rows FROM health_report_batches").first();
+  assert.deepEqual(usageAfter, usageBefore);
+  assert.deepEqual(healthAfter, healthBefore);
+});
+
+test("ingestion fails closed when rate-limit bindings are unavailable", async () => {
+  const script = await readFile(new URL("../.wrangler/dry-run/index.js", import.meta.url), "utf8");
+  const guarded = new Miniflare({
+    modules: true,
+    script,
+    compatibilityDate: "2024-01-01",
+    bindings: { ALLOWED_ORIGIN: "*" },
+    d1Databases: { DB: "guarded-usage", HEALTH_DB: "guarded-health" },
+  });
+  try {
+    const response = await guarded.dispatchFetch("http://worker.test/heartbeat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ installation_id: "guarded-installation" }),
+    });
+    assert.equal(response.status, 500);
+    assert.match(await response.text(), /rate limiter is unavailable/i);
+  } finally {
+    await guarded.dispose();
+  }
+});
+
+test("replayed health report is idempotent and creates one trend batch", async () => {
+  await healthDb.prepare(`
+    INSERT INTO health_report_batches (
+      report_id, installation_id_hash, report_date, reported_at
+    ) VALUES ('expired', 'expired', '2020-01-01', '2020-01-01T00:00:00Z')
+  `).run();
+  const payload = {
+    schema_version: "2026-07-25.health-issues.v2",
+    report_id: "a".repeat(64),
+    installation_id: "test-installation",
+    timestamp: "2026-07-25T12:00:00Z",
+    version: "2.15.1",
+    issues: [{
+      fingerprint: "b".repeat(32),
+      source: "backend",
+      component: "video_classifier",
+      stage: "classify",
+      reason_code: "video_timeout",
+      severity: "error",
+      count: 2,
+      first_seen_at: "2026-07-25T11:00:00Z",
+      last_seen_at: "2026-07-25T11:30:00Z",
+      sample_context: {
+        active_provider: "npu",
+        secret_path: "/config/private/model.bin",
+      },
+      unexpected_secret: "must-not-be-stored",
+    }],
+  };
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await mf.dispatchFetch("http://worker.test/health-issues", {
+      method: "POST",
+      headers: { "content-type": "application/json", "cf-ipcountry": "GB" },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 200, await response.text());
+  }
+
+  const batches = await healthDb.prepare("SELECT COUNT(*) AS rows FROM health_report_batches").first();
+  const issue = await healthDb.prepare(
+    "SELECT occurrence_count, report_count, sample_context_json, last_payload_json FROM health_issue_reports",
+  ).first();
+  assert.deepEqual(batches, { rows: 1 });
+  assert.equal(issue.occurrence_count, 2);
+  assert.equal(issue.report_count, 1);
+  assert.deepEqual(JSON.parse(issue.sample_context_json), { active_provider: "npu" });
+  assert.equal(issue.last_payload_json.includes("private"), false);
+  assert.equal(issue.last_payload_json.includes("must-not-be-stored"), false);
+});
+
+test("v3 event identities remain idempotent across restart-shaped overlapping reports", async () => {
+  const fingerprint = "restart-overlap";
+  const base = {
+    schema_version: "2026-07-25.health-issues.v3",
+    installation_id: "restart-installation",
+    timestamp: "2026-07-25T12:00:00Z",
+    version: "2.15.1",
+    issues: [{
+      fingerprint,
+      source: "backend",
+      component: "video_classifier",
+      reason_code: "video_timeout",
+      severity: "error",
+      count: 2,
+      event_ids: ["1".repeat(64), "2".repeat(64)],
+    }],
+  };
+  const first = { ...base, report_id: "d".repeat(64) };
+  const afterRestart = structuredClone(base);
+  afterRestart.report_id = "e".repeat(64);
+  afterRestart.issues[0].count = 3;
+  afterRestart.issues[0].event_ids.push("3".repeat(64));
+
+  for (const payload of [first, afterRestart, afterRestart]) {
+    const response = await mf.dispatchFetch("http://worker.test/health-issues", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 200, await response.text());
+  }
+
+  const issue = await healthDb.prepare(
+    "SELECT occurrence_count, report_count FROM health_issue_reports WHERE issue_fingerprint = ?",
+  ).bind(fingerprint).first();
+  const batches = await healthDb.prepare(
+    "SELECT event_count FROM health_report_batches WHERE schema_version = ? ORDER BY reported_at, report_id",
+  ).bind("2026-07-25.health-issues.v3").all();
+  assert.deepEqual(issue, { occurrence_count: 3, report_count: 2 });
+  assert.deepEqual(batches.results.map((row) => row.event_count).sort((a, b) => a - b), [1, 2]);
+});
+
+test("oversized allowed context remains bounded valid JSON", async () => {
+  const allowedKeys = [
+    "active_provider", "attempt", "backend", "batch_limit", "cache_enabled",
+    "circuit_failures", "circuit_open", "compile_device", "compile_ok",
+    "configured_provider", "cuda_available", "device", "error_type",
+    "failure_count", "fallback_active", "inference_backend", "intel_gpu_available",
+    "intel_npu_available", "kind", "lease_age_seconds",
+  ];
+  const sampleContext = Object.fromEntries(allowedKeys.map((key) => [key, "x".repeat(500)]));
+  const response = await mf.dispatchFetch("http://worker/health-issues", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      schema_version: "2026-07-25.health-issues.v2",
+      report_id: "c".repeat(64),
+      installation_id: "install-context-limit",
+      timestamp: "2026-07-25T14:00:00Z",
+      version: "2.15.0",
+      issues: [{
+        fingerprint: "fp-context-limit",
+        source: "test",
+        component: "telemetry",
+        reason_code: "context_limit",
+        severity: "warning",
+        count: 999999,
+        sample_context: sampleContext,
+      }],
+    }),
+  });
+  assert.equal(response.status, 200);
+
+  const stored = await healthDb.prepare(
+    "SELECT occurrence_count, sample_context_json, last_payload_json FROM health_issue_reports WHERE issue_fingerprint = ?",
+  ).bind("fp-context-limit").first();
+  assert.equal(stored.occurrence_count, 250);
+  assert.ok(stored.sample_context_json.length <= 2048);
+  assert.ok(stored.last_payload_json.length <= 8192);
+  assert.doesNotThrow(() => JSON.parse(stored.sample_context_json));
+  assert.doesNotThrow(() => JSON.parse(stored.last_payload_json));
+});
+
+test("unchanged legacy snapshots without report IDs are also idempotent", async () => {
+  const payload = {
+    schema_version: "2026-05-03.health-issues.v1",
+    installation_id: "legacy-installation",
+    timestamp: "2026-07-25T12:00:00Z",
+    version: "2.14.0",
+    issues: [{
+      fingerprint: "c".repeat(32),
+      source: "backend",
+      component: "event_processor",
+      reason_code: "legacy_failure",
+      severity: "warning",
+      count: 3,
+      first_seen_at: "2026-07-25T11:00:00Z",
+      last_seen_at: "2026-07-25T11:30:00Z",
+    }],
+  };
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await mf.dispatchFetch("http://worker.test/health-issues", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 200, await response.text());
+  }
+
+  const batches = await healthDb.prepare(
+    "SELECT COUNT(*) AS rows FROM health_report_batches WHERE schema_version = ?",
+  ).bind("2026-05-03.health-issues.v1").first();
+  const issue = await healthDb.prepare(
+    "SELECT occurrence_count, report_count FROM health_issue_reports WHERE issue_fingerprint = ?",
+  ).bind("c".repeat(32)).first();
+  assert.deepEqual(batches, { rows: 1 });
+  assert.deepEqual(issue, { occurrence_count: 3, report_count: 1 });
+
+  const expandedPayload = structuredClone(payload);
+  expandedPayload.timestamp = "2026-07-25T13:00:00Z";
+  expandedPayload.issues[0].count = 4;
+  expandedPayload.issues[0].last_seen_at = "2026-07-25T12:30:00Z";
+  const expandedResponse = await mf.dispatchFetch("http://worker.test/health-issues", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(expandedPayload),
+  });
+  assert.equal(expandedResponse.status, 200, await expandedResponse.text());
+
+  const expandedIssue = await healthDb.prepare(
+    "SELECT occurrence_count, report_count FROM health_issue_reports WHERE issue_fingerprint = ?",
+  ).bind("c".repeat(32)).first();
+  assert.deepEqual(expandedIssue, { occurrence_count: 4, report_count: 2 });
+});
+
+test("health ingestion removes bounded expired detail and marker rows", async () => {
+  await healthDb.prepare(
+    "UPDATE health_issue_reports SET updated_at = '2020-01-01T00:00:00Z' WHERE issue_fingerprint = ?",
+  ).bind("fp-context-limit").run();
+  await healthDb.prepare(`
+    INSERT INTO health_report_batches (
+      report_id, installation_id_hash, report_date, reported_at
+    ) VALUES ('retention-expired', 'expired', '2020-01-01', '2020-01-01T00:00:00Z')
+  `).run();
+
+  const response = await mf.dispatchFetch("http://worker.test/health-issues", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      schema_version: "2026-07-25.health-issues.v2",
+      report_id: "f".repeat(64),
+      installation_id: "retention-trigger",
+      version: "2.15.1",
+      issues: [{ fingerprint: "retention-new", severity: "warning", count: 1 }],
+    }),
+  });
+  assert.equal(response.status, 200, await response.text());
+
+  const expiredIssue = await healthDb.prepare(
+    "SELECT COUNT(*) AS rows FROM health_issue_reports WHERE issue_fingerprint = ?",
+  ).bind("fp-context-limit").first();
+  const expiredMarker = await healthDb.prepare(
+    "SELECT COUNT(*) AS rows FROM health_report_batches WHERE report_id = 'retention-expired'",
+  ).first();
+  assert.deepEqual(expiredIssue, { rows: 0 });
+  assert.deepEqual(expiredMarker, { rows: 0 });
+});
+
+test("shared daily budget rejects ingestion before telemetry rows are written", async () => {
+  await usageDb.prepare(
+    "UPDATE ingestion_daily_budget SET write_units = 39999 WHERE budget_date = date('now')",
+  ).run();
+  const before = await usageDb.prepare("SELECT COUNT(*) AS rows FROM heartbeats").first();
+  try {
+    const response = await mf.dispatchFetch("http://worker.test/heartbeat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ installation_id: "over-budget-installation", version: "2.15.1" }),
+    });
+    assert.equal(response.status, 503, await response.text());
+    assert.equal(response.headers.get("retry-after"), "86400");
+    const after = await usageDb.prepare("SELECT COUNT(*) AS rows FROM heartbeats").first();
+    assert.deepEqual(after, before);
+  } finally {
+    await usageDb.prepare(
+      "UPDATE ingestion_daily_budget SET write_units = 0 WHERE budget_date = date('now')",
+    ).run();
+  }
+});

--- a/apps/telemetry-worker/wrangler.toml
+++ b/apps/telemetry-worker/wrangler.toml
@@ -13,6 +13,20 @@ binding = "HEALTH_DB" # Available in your worker as env.HEALTH_DB
 database_name = "yawamf-health-issues"
 database_id = "07d320ce-39f6-4d5a-bf16-ddf1ad07a1e7"
 
+[[ratelimits]]
+name = "HEARTBEAT_RATE_LIMITER"
+namespace_id = "3103013410305830"
+[ratelimits.simple]
+limit = 6
+period = 60
+
+[[ratelimits]]
+name = "HEALTH_RATE_LIMITER"
+namespace_id = "5020066673955123"
+[ratelimits.simple]
+limit = 1
+period = 60
+
 # CORS headers for the API
 [vars]
 ALLOWED_ORIGIN = "*"

--- a/backend/app/services/telemetry_service.py
+++ b/backend/app/services/telemetry_service.py
@@ -13,7 +13,7 @@ from app.utils.tasks import create_background_task
 
 log = structlog.get_logger()
 
-HEALTH_REPORT_SCHEMA_VERSION = "2026-05-03.health-issues.v1"
+HEALTH_REPORT_SCHEMA_VERSION = "2026-07-25.health-issues.v3"
 HEALTH_REPORT_MAX_ISSUES = 25
 HEALTH_CONTEXT_MAX_KEYS = 20
 HEALTH_CONTEXT_MAX_STRING = 160
@@ -114,6 +114,36 @@ def _fingerprint_issue(event: dict[str, Any]) -> str:
     ]
     raw = "|".join(parts)
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+
+
+def _health_event_identity(event: dict[str, Any]) -> str:
+    event_id = _safe_text(event.get("id"), limit=160)
+    if event_id:
+        return event_id
+    raw = "|".join(
+        [
+            _fingerprint_issue(event),
+            _safe_text(event.get("timestamp"), limit=80),
+            _safe_text(event.get("message"), limit=HEALTH_CONTEXT_MAX_STRING),
+        ]
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _health_event_hash(installation_id: str | None, event: dict[str, Any]) -> str:
+    raw = "|".join(
+        [
+            _safe_text(installation_id, limit=160),
+            _health_event_identity(event),
+        ]
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _health_report_id(installation_id: str | None, events: list[dict[str, Any]]) -> str:
+    event_ids = sorted(_health_event_identity(event) for event in events)
+    raw = "|".join([_safe_text(installation_id, limit=160), *event_ids])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 def build_runtime_telemetry_payload(
@@ -320,12 +350,14 @@ def build_health_issue_report(
                 "stage": _safe_text(raw_event.get("stage"), limit=80) or None,
                 "severity": severity,
                 "count": 0,
+                "event_ids": [],
                 "first_seen_at": timestamp or None,
                 "last_seen_at": timestamp or None,
                 "sample_context": _sanitize_health_context(raw_event.get("context") or {}),
             },
         )
-        issue["count"] += 1
+        issue["event_ids"].append(_health_event_hash(installation_id, raw_event))
+        issue["count"] = len(issue["event_ids"])
         if timestamp:
             first_seen = issue.get("first_seen_at")
             last_seen = issue.get("last_seen_at")
@@ -347,6 +379,10 @@ def build_health_issue_report(
 
     return {
         "schema_version": HEALTH_REPORT_SCHEMA_VERSION,
+        "report_id": _health_report_id(
+            installation_id,
+            [event for event in raw_events if isinstance(event, dict)],
+        ),
         "installation_id": installation_id,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "version": app_version,
@@ -384,6 +420,10 @@ class TelemetryService:
     def __init__(self):
         self._running = False
         self._task = None
+        self._reported_health_event_ids: set[str] = set()
+        self._pending_health_payload: dict[str, Any] | None = None
+        self._pending_health_event_ids: set[str] = set()
+        self._health_report_lock = asyncio.Lock()
         # Note: Do NOT call _ensure_installation_id here - it's async and called in start()
 
     async def _ensure_installation_id(self, max_retries: int = 3) -> bool:
@@ -547,7 +587,12 @@ class TelemetryService:
             log.warning("Failed to send telemetry heartbeat", error=str(e), url=settings.telemetry.url)
 
     async def _send_health_report(self):
-        """Gather sanitized health issue groups and send them to the health endpoint."""
+        """Gather and send at most one copy of each sanitized health issue event."""
+        async with self._health_report_lock:
+            await self._send_health_report_once()
+
+    async def _send_health_report_once(self):
+        """Send one exact in-flight health batch and advance only represented events."""
         try:
             if not settings.telemetry.installation_id:
                 await self._ensure_installation_id()
@@ -555,18 +600,60 @@ class TelemetryService:
             from app.services.error_diagnostics import error_diagnostics_history
 
             diagnostics_snapshot = error_diagnostics_history.snapshot(limit=250)
-            payload = build_health_issue_report(
-                installation_id=settings.telemetry.installation_id,
-                app_version=os.environ.get("APP_VERSION", "unknown"),
-                diagnostics_snapshot=diagnostics_snapshot,
-            )
-            if not payload:
-                log.debug("No health issues to report")
-                return
+            snapshot_events = diagnostics_snapshot.get("events")
+            if not isinstance(snapshot_events, list):
+                snapshot_events = []
+            visible_events = [event for event in snapshot_events if isinstance(event, dict)]
+            visible_event_ids = {_health_event_identity(event) for event in visible_events}
+            self._reported_health_event_ids.intersection_update(visible_event_ids)
 
+            if self._pending_health_payload is None:
+                unsent_events = [
+                    event
+                    for event in visible_events
+                    if _health_event_identity(event) not in self._reported_health_event_ids
+                ]
+                candidate_snapshot = {**diagnostics_snapshot, "events": unsent_events}
+                candidate_payload = build_health_issue_report(
+                    installation_id=settings.telemetry.installation_id,
+                    app_version=os.environ.get("APP_VERSION", "unknown"),
+                    diagnostics_snapshot=candidate_snapshot,
+                )
+                if not candidate_payload:
+                    log.debug("No health issues to report")
+                    return
+
+                selected_fingerprints = {
+                    str(issue.get("fingerprint"))
+                    for issue in candidate_payload.get("issues") or []
+                    if isinstance(issue, dict) and issue.get("fingerprint")
+                }
+                selected_events = [
+                    event for event in unsent_events if _fingerprint_issue(event) in selected_fingerprints
+                ]
+                selected_snapshot = {**diagnostics_snapshot, "events": selected_events}
+                payload = build_health_issue_report(
+                    installation_id=settings.telemetry.installation_id,
+                    app_version=os.environ.get("APP_VERSION", "unknown"),
+                    diagnostics_snapshot=selected_snapshot,
+                )
+                if not payload:
+                    log.debug("No health issues to report")
+                    return
+                self._pending_health_payload = payload
+                self._pending_health_event_ids = {
+                    _health_event_identity(event) for event in selected_events
+                }
+
+            payload = self._pending_health_payload
             async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
                 resp = await client.post(settings.telemetry.health_url, json=payload)
                 if resp.status_code == 200:
+                    self._reported_health_event_ids.update(
+                        self._pending_health_event_ids.intersection(visible_event_ids)
+                    )
+                    self._pending_health_payload = None
+                    self._pending_health_event_ids.clear()
                     log.info(
                         "Health issue telemetry sent successfully",
                         url=settings.telemetry.health_url,

--- a/backend/app/services/telemetry_service.py
+++ b/backend/app/services/telemetry_service.py
@@ -641,9 +641,7 @@ class TelemetryService:
                     log.debug("No health issues to report")
                     return
                 self._pending_health_payload = payload
-                self._pending_health_event_ids = {
-                    _health_event_identity(event) for event in selected_events
-                }
+                self._pending_health_event_ids = {_health_event_identity(event) for event in selected_events}
 
             payload = self._pending_health_payload
             async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -2,4 +2,4 @@
 pytest==9.1.1
 pytest-asyncio==1.4.0
 coverage==7.15.2
-ruff
+ruff==0.15.22

--- a/backend/tests/test_health_issue_telemetry.py
+++ b/backend/tests/test_health_issue_telemetry.py
@@ -132,9 +132,7 @@ async def test_health_report_leaves_truncated_issue_groups_for_next_batch(monkey
     assert len(_RecordingAsyncClient.payloads) == 2
     assert len(_RecordingAsyncClient.payloads[0]["issues"]) == 25
     assert len(_RecordingAsyncClient.payloads[1]["issues"]) == 1
-    fingerprints = {
-        issue["fingerprint"] for payload in _RecordingAsyncClient.payloads for issue in payload["issues"]
-    }
+    fingerprints = {issue["fingerprint"] for payload in _RecordingAsyncClient.payloads for issue in payload["issues"]}
     assert len(fingerprints) == 26
 
 

--- a/backend/tests/test_health_issue_telemetry.py
+++ b/backend/tests/test_health_issue_telemetry.py
@@ -1,4 +1,173 @@
-from app.services.telemetry_service import build_health_issue_report, build_runtime_telemetry_payload
+import asyncio
+
+import pytest
+
+from app.config import settings
+from app.services import telemetry_service as telemetry_module
+from app.services.error_diagnostics import error_diagnostics_history
+from app.services.telemetry_service import TelemetryService, build_health_issue_report, build_runtime_telemetry_payload
+
+
+def _diagnostic_event(
+    event_id: str,
+    *,
+    timestamp: str = "2026-07-25T12:00:00+00:00",
+    reason_code: str = "video_timeout",
+) -> dict:
+    return {
+        "id": event_id,
+        "timestamp": timestamp,
+        "source": "backend",
+        "component": "video_classifier",
+        "stage": "classify",
+        "reason_code": reason_code,
+        "message": "Timed out",
+        "severity": "error",
+        "context": {"timeout_seconds": 180},
+    }
+
+
+def _diagnostic_snapshot(*events: dict) -> dict:
+    return {
+        "captured_at": "2026-07-25T12:05:00+00:00",
+        "total_events": len(events),
+        "returned_events": len(events),
+        "severity_counts": {"error": len(events)},
+        "component_counts": {"video_classifier": len(events)},
+        "events": list(events),
+    }
+
+
+class _RecordingAsyncClient:
+    payloads: list[dict] = []
+    statuses: list[int] = []
+    delay_seconds = 0.0
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def post(self, _url: str, *, json: dict):
+        self.payloads.append(json)
+        await asyncio.sleep(self.delay_seconds)
+        status_code = self.statuses.pop(0) if self.statuses else 200
+        return type("Response", (), {"status_code": status_code})()
+
+
+@pytest.fixture
+def health_sender(monkeypatch):
+    _RecordingAsyncClient.payloads = []
+    _RecordingAsyncClient.statuses = []
+    _RecordingAsyncClient.delay_seconds = 0.0
+    monkeypatch.setattr(telemetry_module.httpx, "AsyncClient", _RecordingAsyncClient)
+    monkeypatch.setattr(settings.telemetry, "installation_id", "00000000-0000-0000-0000-000000000000")
+    monkeypatch.setattr(settings.telemetry, "health_url", "https://telemetry.example/health-issues")
+    return TelemetryService()
+
+
+@pytest.mark.asyncio
+async def test_health_report_does_not_repeat_successfully_sent_event(monkeypatch, health_sender):
+    snapshot = _diagnostic_snapshot(_diagnostic_event("diag:1"))
+    monkeypatch.setattr(error_diagnostics_history, "snapshot", lambda **_kwargs: snapshot)
+
+    await health_sender._send_health_report()
+    await health_sender._send_health_report()
+
+    assert len(_RecordingAsyncClient.payloads) == 1
+
+
+@pytest.mark.asyncio
+async def test_health_report_retry_uses_stable_report_id(monkeypatch, health_sender):
+    snapshot = _diagnostic_snapshot(_diagnostic_event("diag:retry"))
+    monkeypatch.setattr(error_diagnostics_history, "snapshot", lambda **_kwargs: snapshot)
+    _RecordingAsyncClient.statuses = [500, 200]
+
+    await health_sender._send_health_report()
+    await health_sender._send_health_report()
+
+    assert len(_RecordingAsyncClient.payloads) == 2
+    first_id = _RecordingAsyncClient.payloads[0]["report_id"]
+    assert first_id == _RecordingAsyncClient.payloads[1]["report_id"]
+    assert len(first_id) == 64
+    assert _RecordingAsyncClient.payloads[0]["schema_version"] == "2026-07-25.health-issues.v3"
+    assert len(_RecordingAsyncClient.payloads[0]["issues"][0]["event_ids"]) == 1
+    assert len(_RecordingAsyncClient.payloads[0]["issues"][0]["event_ids"][0]) == 64
+
+
+@pytest.mark.asyncio
+async def test_health_report_retries_exact_inflight_batch_before_new_events(monkeypatch, health_sender):
+    current = {"snapshot": _diagnostic_snapshot(_diagnostic_event("diag:inflight"))}
+    monkeypatch.setattr(error_diagnostics_history, "snapshot", lambda **_kwargs: current["snapshot"])
+    _RecordingAsyncClient.statuses = [500, 200, 200]
+
+    await health_sender._send_health_report()
+    current["snapshot"] = _diagnostic_snapshot(
+        _diagnostic_event("diag:inflight"),
+        _diagnostic_event("diag:new", timestamp="2026-07-25T12:10:00+00:00"),
+    )
+    await health_sender._send_health_report()
+    await health_sender._send_health_report()
+
+    assert len(_RecordingAsyncClient.payloads) == 3
+    assert _RecordingAsyncClient.payloads[1] == _RecordingAsyncClient.payloads[0]
+    assert _RecordingAsyncClient.payloads[2]["report_id"] != _RecordingAsyncClient.payloads[0]["report_id"]
+    assert _RecordingAsyncClient.payloads[0]["issues"][0]["count"] == 1
+    assert _RecordingAsyncClient.payloads[2]["issues"][0]["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_health_report_leaves_truncated_issue_groups_for_next_batch(monkeypatch, health_sender):
+    events = [_diagnostic_event(f"diag:{index}", reason_code=f"reason_{index:02d}") for index in range(26)]
+    snapshot = _diagnostic_snapshot(*events)
+    monkeypatch.setattr(error_diagnostics_history, "snapshot", lambda **_kwargs: snapshot)
+
+    await health_sender._send_health_report()
+    await health_sender._send_health_report()
+
+    assert len(_RecordingAsyncClient.payloads) == 2
+    assert len(_RecordingAsyncClient.payloads[0]["issues"]) == 25
+    assert len(_RecordingAsyncClient.payloads[1]["issues"]) == 1
+    fingerprints = {
+        issue["fingerprint"] for payload in _RecordingAsyncClient.payloads for issue in payload["issues"]
+    }
+    assert len(fingerprints) == 26
+
+
+@pytest.mark.asyncio
+async def test_health_report_sends_only_new_events_from_persistent_history(monkeypatch, health_sender):
+    current = {"snapshot": _diagnostic_snapshot(_diagnostic_event("diag:old"))}
+    monkeypatch.setattr(error_diagnostics_history, "snapshot", lambda **_kwargs: current["snapshot"])
+
+    await health_sender._send_health_report()
+    current["snapshot"] = _diagnostic_snapshot(
+        _diagnostic_event("diag:new", timestamp="2026-07-25T12:10:00+00:00"),
+        _diagnostic_event("diag:old"),
+    )
+    await health_sender._send_health_report()
+
+    assert len(_RecordingAsyncClient.payloads) == 2
+    assert _RecordingAsyncClient.payloads[0]["issues"][0]["count"] == 1
+    assert _RecordingAsyncClient.payloads[1]["issues"][0]["count"] == 1
+    assert _RecordingAsyncClient.payloads[0]["report_id"] != _RecordingAsyncClient.payloads[1]["report_id"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_health_reports_do_not_upload_same_event_twice(monkeypatch, health_sender):
+    snapshot = _diagnostic_snapshot(_diagnostic_event("diag:concurrent"))
+    monkeypatch.setattr(error_diagnostics_history, "snapshot", lambda **_kwargs: snapshot)
+    _RecordingAsyncClient.delay_seconds = 0.01
+
+    await asyncio.gather(
+        health_sender._send_health_report(),
+        health_sender._send_health_report(),
+    )
+
+    assert len(_RecordingAsyncClient.payloads) == 1
 
 
 def test_health_issue_report_groups_and_sanitizes_diagnostics():
@@ -62,7 +231,7 @@ def test_health_issue_report_groups_and_sanitizes_diagnostics():
     )
 
     assert report is not None
-    assert report["schema_version"] == "2026-05-03.health-issues.v1"
+    assert report["schema_version"] == "2026-07-25.health-issues.v3"
     assert len(report["issues"]) == 1
 
     issue = report["issues"][0]
@@ -70,6 +239,8 @@ def test_health_issue_report_groups_and_sanitizes_diagnostics():
     assert issue["reason_code"] == "video_timeout"
     assert issue["severity"] == "error"
     assert issue["count"] == 2
+    assert len(issue["event_ids"]) == 2
+    assert all(len(event_id) == 64 for event_id in issue["event_ids"])
     assert issue["fingerprint"]
     assert issue["sample_context"] == {
         "configured_provider": "intel_gpu",


### PR DESCRIPTION
## Summary

- make health telemetry delivery idempotent with stable report IDs, exact in-flight retries, and v3 opaque per-event identities
- advance the local cursor only for issue groups actually emitted in the bounded 25-group payload
- add bounded daily heartbeat rollups and compact health batch markers with 400-day retention
- hash installation IDs in the new daily rollup and sanitize/bound stored health payloads
- reject ingestion bodies above 128 KiB before parsing and enforce native per-IP/per-installation rate limits
- enforce an atomic shared 40,000-unit daily D1 write budget before telemetry writes
- add locked Worker tooling, Miniflare+D1 integration tests, and a migration-first deploy workflow
- upgrade Wrangler/Miniflare/Sharp to patched audited versions

## Correctness

- ambiguous HTTP failures retry the exact same payload/report ID
- events arriving during a retry remain pending for the next batch
- 26+ distinct fingerprints are delivered across bounded batches instead of silently marked sent
- v3 batch SQL counts only event hashes not present in prior 400-day markers, including after service lifecycle resets with overlapping history
- exact v3 retries and overlapping reports are atomic no-ops for already-seen events
- v1/v2 clients retain report-level idempotency behavior

## Security and cost controls

- maximum request body: 128 KiB, enforced while streaming before `JSON.parse`
- heartbeat rate: 6/minute per Cloudflare source IP and installation ID
- health rate: 1/minute per Cloudflare source IP and installation ID
- missing production rate-limit bindings fail closed
- one atomic budget row caps conservative indexed-write estimates at 40,000 units/day across both endpoints; exhausted requests return 503 before telemetry rows are written
- expired heartbeat rollups, detailed health aggregates, and batch markers are deleted in bounded, budgeted chunks
- daily rollups store installation hashes; v3 event IDs are installation-scoped SHA-256 values
- ingestion remains intentionally anonymous; dashboard aggregates are directional product telemetry, not authoritative audit data

## Validation

- `backend/.venv/bin/ruff check backend/app/services/telemetry_service.py backend/tests/test_health_issue_telemetry.py`
- `backend/.venv/bin/pytest -q backend/tests` — 1,769 passed, 65 skipped
- `npm ci`
- `npm test` — Wrangler dry-run + 9 Miniflare/D1 integration tests
- `npm audit --audit-level=high` — 0 vulnerabilities
- `actionlint .github/workflows/deploy-telemetry-worker.yml`
- `git diff --check`
- installed Wrangler 4.114.0 parser probe accepted `d1 execute --remote --yes --file=...` and proceeded to authentication

## Deployment

The GitHub workflow executes the two exact nested SQL migration files before deploying the Worker. Manual scripts use the same files and order. Existing tables and indexes use `IF NOT EXISTS`, and integration tests apply each migration twice.

No remote database mutation or Worker deployment was performed while preparing this PR.
