### PR TITLE
fix: bound and harden telemetry dashboard categories

### DIFF
--- a/apps/telemetry-worker/src/index.ts
+++ b/apps/telemetry-worker/src/index.ts
@@ -219,6 +219,28 @@ function normalizeSeverity(value: unknown): string {
   return ['warning', 'error', 'critical'].includes(severity) ? severity : 'warning';
 }
 
+function normalizeInferenceHealthStatus(value: unknown): string | null {
+  const status = safeText(value, '', 20).toLowerCase();
+  return ['ok', 'degraded', 'unhealthy'].includes(status) ? status : null;
+}
+
+function normalizeRecoveryStatus(value: unknown): string | null {
+  const status = safeText(value, '', 20).toLowerCase();
+  return ['recovered', 'failed'].includes(status) ? status : null;
+}
+
+function normalizeRecoveryReason(value: unknown): string | null {
+  const reason = String(value ?? '').trim().toLowerCase();
+  return /^[a-z0-9_]{1,64}$/.test(reason) ? reason : null;
+}
+
+function safeRuntimeCount(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const count = Number(value);
+  if (!Number.isFinite(count)) return null;
+  return Math.min(1_000, Math.max(0, Math.floor(count)));
+}
+
 function safeCount(value: unknown): number {
   const count = Number(value ?? 0);
   if (!Number.isFinite(count)) return 0;
@@ -346,6 +368,7 @@ function renderTrendChart({
   rows,
   days,
   valueKey,
+  chartId,
   title,
   ariaLabel,
   caption
@@ -353,6 +376,7 @@ function renderTrendChart({
   rows: any[];
   days: number;
   valueKey: string;
+  chartId: string;
   title: string;
   ariaLabel: string;
   caption: string;
@@ -382,6 +406,9 @@ function renderTrendChart({
   const middle = points[Math.floor((points.length - 1) / 2)];
   const latest = points.at(-1)?.value;
   const latestObserved = observed.at(-1);
+  const accessibleValues = points
+    .map((point) => `${point.day}: ${point.value === null ? 'not available' : fmt(point.value)}`)
+    .join('; ');
 
   return `
     <figure class="panel trend-panel">
@@ -389,7 +416,7 @@ function renderTrendChart({
         <div><span class="eyebrow">Daily rollup</span><h2>${html(title)}</h2></div>
         <div class="chart-latest"><strong>${latest === null || latest === undefined ? '—' : fmt(latest)}</strong><span>latest day</span></div>
       </div>
-      <svg class="trend-chart" viewBox="0 0 ${width} ${height}" role="img" aria-label="${html(ariaLabel)}" preserveAspectRatio="none">
+      <svg class="trend-chart" viewBox="0 0 ${width} ${height}" role="img" aria-label="${html(ariaLabel)}" aria-describedby="${html(chartId)}-data" preserveAspectRatio="none">
         <line class="chart-grid" x1="${left}" y1="${top}" x2="${width - right}" y2="${top}"></line>
         <line class="chart-grid" x1="${left}" y1="${top + plotHeight / 2}" x2="${width - right}" y2="${top + plotHeight / 2}"></line>
         <line class="chart-axis" x1="${left}" y1="${baseline}" x2="${width - right}" y2="${baseline}"></line>
@@ -399,6 +426,7 @@ function renderTrendChart({
       </svg>
       <div class="chart-labels"><span>${shortDate(points[0].day)}</span><span>${shortDate(middle.day)}</span><span>${shortDate(points.at(-1)!.day)}</span></div>
       <figcaption>${html(caption)} · peak ${fmt(actualPeak)}</figcaption>
+      <p class="sr-only" id="${html(chartId)}-data">Daily values for the selected ${days}-day window. ${html(accessibleValues)}. Peak: ${fmt(actualPeak)}.</p>
     </figure>
   `;
 }
@@ -441,8 +469,8 @@ function dashboardShell({
   <title>${html(title)}</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@600;700;800&family=Instrument+Sans:wght@400;500;600;700&display=swap');
-    :root { color-scheme: light dark; --bg:#f8fafc; --panel:#ffffff; --panel-2:#f1f5f9; --text:#334155; --heading:#0f172a; --muted:#64748b; --line:#e2e8f0; --brand:#14b8a6; --brand-strong:#0d9488; --brand-soft:#ccfbf1; --danger:#dc2626; --warn:#d97706; --shadow:0 8px 24px -14px rgba(15,23,42,.22); --font:'Instrument Sans', ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; --font-display:'Bricolage Grotesque', 'Instrument Sans', sans-serif; }
-    body.view-health { --brand:#f97316; --brand-strong:#dc2626; --brand-soft:#ffedd5; }
+    :root { color-scheme: light dark; --bg:#f8fafc; --panel:#ffffff; --panel-2:#f1f5f9; --text:#334155; --heading:#0f172a; --muted:#64748b; --line:#e2e8f0; --brand:#0f766e; --brand-strong:#115e59; --brand-soft:#ccfbf1; --active:#0f766e; --active-strong:#115e59; --danger:#dc2626; --warn:#d97706; --shadow:0 8px 24px -14px rgba(15,23,42,.22); --font:'Instrument Sans', ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; --font-display:'Bricolage Grotesque', 'Instrument Sans', sans-serif; }
+    body.view-health { --brand:#c2410c; --brand-strong:#b91c1c; --brand-soft:#ffedd5; --active:#c2410c; --active-strong:#b91c1c; }
     @media (prefers-color-scheme: dark) { :root { --bg:#030712; --panel:#1e293b; --panel-2:#0f172a; --text:#e2e8f0; --heading:#f1f5f9; --muted:#94a3b8; --line:#334155; --brand:#2dd4bf; --brand-strong:#5eead4; --brand-soft:#134e4a; --danger:#f87171; --warn:#fbbf24; --shadow:0 14px 34px -16px rgba(0,0,0,.7); } body.view-health { --brand:#fb923c; --brand-strong:#f87171; --brand-soft:#7c2d12; } }
     * { box-sizing:border-box; }
     body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font); font-size:14px; line-height:1.5; -webkit-font-smoothing:antialiased; }
@@ -459,7 +487,7 @@ function dashboardShell({
     .tabs, .windows { display:flex; gap:6px; flex-wrap:wrap; }
     .tab, .window-link { color:var(--muted); text-decoration:none; border:1px solid var(--line); border-radius:11px; padding:7px 13px; background:var(--panel); font-weight:600; font-size:13px; transition:border-color .12s, color .12s; }
     .tab:hover, .window-link:hover { border-color:var(--brand); color:var(--brand); }
-    .tab.active, .window-link.active { color:#fff; border-color:transparent; background:linear-gradient(135deg, var(--brand), var(--brand-strong)); box-shadow:var(--shadow); }
+    .tab.active, .window-link.active { color:#fff; border-color:transparent; background:linear-gradient(135deg, var(--active), var(--active-strong)); box-shadow:var(--shadow); }
     .toolbar { display:flex; flex-direction:column; align-items:flex-end; gap:10px; }
     .grid { display:grid; grid-template-columns:repeat(4, minmax(0, 1fr)); gap:14px; margin-bottom:14px; }
     .grid.two { grid-template-columns:repeat(2, minmax(0, 1fr)); }
@@ -507,6 +535,7 @@ function dashboardShell({
     .severity-pill.severity-warning { background:color-mix(in srgb, var(--warn) 16%, transparent); color:var(--warn); }
     .severity-pill.severity-unknown { background:var(--panel-2); color:var(--muted); }
     .table-scroll { overflow-x:auto; margin:0 -4px; padding:0 4px; }
+    .table-scroll:focus-visible { outline:3px solid var(--brand); outline-offset:3px; border-radius:8px; }
     .feature-grid { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); column-gap:20px; }
     .scroll-hint { display:none; color:var(--muted); font-size:10.5px; margin:0 0 8px; }
     .issue-reason { color:var(--heading); font-weight:650; text-transform:capitalize; }
@@ -514,6 +543,7 @@ function dashboardShell({
     .section-intro h2 { font-size:16px; margin:0; }
     .section-intro p { color:var(--muted); font-size:11.5px; margin:0; max-width:58ch; }
     .empty { color:var(--muted); text-align:center; padding:22px; }
+    .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0, 0, 0, 0); white-space:nowrap; border:0; }
     .panel-empty { border:1px dashed var(--line); border-radius:16px; box-shadow:none; }
     code { background:var(--panel-2); border:1px solid var(--line); border-radius:6px; padding:2px 6px; font-size:12px; }
     footer.dash { margin-top:28px; color:var(--muted); font-size:12px; text-align:center; border-top:1px solid var(--line); padding-top:16px; }
@@ -680,9 +710,10 @@ app.get('/dashboard', async (c) => {
       SELECT inference_health_status as status, count(*) as count
       FROM heartbeats
       WHERE last_seen > ${activeThreshold}
-        AND inference_health_status IS NOT NULL
+        AND inference_health_status IN ('ok', 'degraded', 'unhealthy')
       GROUP BY inference_health_status
       ORDER BY count DESC
+      LIMIT 3
     `).all();
 
     const inferenceHealthAggregate = await c.env.DB.prepare(`
@@ -700,7 +731,9 @@ app.get('/dashboard', async (c) => {
       SELECT last_recovery_reason as reason, last_recovery_status as status, count(*) as count
       FROM heartbeats
       WHERE last_seen > ${activeThreshold}
-        AND last_recovery_reason IS NOT NULL
+        AND last_recovery_status IN ('recovered', 'failed')
+        AND length(last_recovery_reason) BETWEEN 1 AND 64
+        AND last_recovery_reason NOT GLOB '*[^a-z0-9_]*'
       GROUP BY last_recovery_reason, last_recovery_status
       ORDER BY count DESC
       LIMIT 10
@@ -735,6 +768,7 @@ app.get('/dashboard', async (c) => {
         rows: dailyReports.results,
         days,
         valueKey: 'reports',
+        chartId: 'health-report-trend',
         title: 'Reports by day',
         ariaLabel: 'Daily health reports trend',
         caption: 'One accepted health snapshot per report ID; repeated deliveries are ignored'
@@ -790,8 +824,8 @@ app.get('/dashboard', async (c) => {
       </section>
       <section class="panel">
         <div class="section-intro" style="margin-top:0"><div><span class="eyebrow">Deduplicated detail</span><h2>Top recurring issues</h2></div><p>Highest-impact issue groups, capped at 12. Full aggregate data remains available from the JSON stats endpoint.</p></div>
-        <p class="scroll-hint">Swipe table for full details →</p>
-        <div class="table-scroll"><table>
+        <p class="scroll-hint">Scroll horizontally for full details →</p>
+        <div class="table-scroll" tabindex="0" role="region" aria-label="Top recurring issues; scroll horizontally for all columns"><table>
           <thead><tr><th>Component</th><th>Reason</th><th>Severity</th><th>Version</th><th>Installs</th><th>Occurrences</th><th>Last seen</th></tr></thead>
           <tbody>${issueRows}</tbody>
         </table></div>
@@ -970,6 +1004,7 @@ app.get('/dashboard', async (c) => {
       rows: dailyInstalls.results,
       days,
       valueKey: 'installs',
+      chartId: 'active-install-trend',
       title: 'Active installs by day',
       ariaLabel: 'Daily active installs trend',
       caption: 'One privacy-preserving daily snapshot per active installation'
@@ -1224,12 +1259,12 @@ app.post('/heartbeat', async (c) => {
       payload.deployment?.image_arch || null,
       payload.deployment?.app_branch || null,
       payload.deployment?.git_hash || null,
-      payload.runtime?.inference_health_status || null,
-      typeof payload.runtime?.inference_health_unhealthy_runtimes === 'number' ? payload.runtime!.inference_health_unhealthy_runtimes : null,
-      typeof payload.runtime?.inference_health_degraded_runtimes === 'number' ? payload.runtime!.inference_health_degraded_runtimes : null,
-      typeof payload.runtime?.inference_health_total_runtimes === 'number' ? payload.runtime!.inference_health_total_runtimes : null,
-      payload.runtime?.last_recovery_reason || null,
-      payload.runtime?.last_recovery_status || null,
+      normalizeInferenceHealthStatus(payload.runtime?.inference_health_status),
+      safeRuntimeCount(payload.runtime?.inference_health_unhealthy_runtimes),
+      safeRuntimeCount(payload.runtime?.inference_health_degraded_runtimes),
+      safeRuntimeCount(payload.runtime?.inference_health_total_runtimes),
+      normalizeRecoveryReason(payload.runtime?.last_recovery_reason),
+      normalizeRecoveryStatus(payload.runtime?.last_recovery_status),
       country
     );
 

--- a/apps/telemetry-worker/test/worker.integration.test.mjs
+++ b/apps/telemetry-worker/test/worker.integration.test.mjs
@@ -66,6 +66,8 @@ test("user metrics dashboard renders a bounded daily trend and distinct mode", a
   assert.match(body, />User Metrics<\/a>/);
   assert.match(body, /Active installs by day/);
   assert.match(body, /aria-label="Daily active installs trend"/);
+  assert.match(body, /aria-describedby="active-install-trend-data"/);
+  assert.match(body, /id="active-install-trend-data">Daily values for the selected 7-day window/);
   assert.match(body, /<svg[^>]+class="trend-chart"/);
   assert.doesNotMatch(body, /Most-Recent Recovery Reasons/);
 });
@@ -108,9 +110,10 @@ test("health data dashboard renders severity-led trends and concise issue detail
   assert.match(body, />Health Data<\/a>/);
   assert.match(body, /Reports by day/);
   assert.match(body, /aria-label="Daily health reports trend"/);
+  assert.match(body, /aria-describedby="health-report-trend-data"/);
   assert.match(body, /severity-pill severity-critical/);
   assert.match(body, /Top recurring issues/);
-  assert.match(body, /class="table-scroll"/);
+  assert.match(body, /class="table-scroll" tabindex="0" role="region" aria-label="Top recurring issues; scroll horizontally for all columns"/);
   assert.doesNotMatch(body, /Usage Geography/);
 });
 
@@ -141,6 +144,100 @@ test("heartbeat writes one bounded daily snapshot per installation", async () =>
   assert.equal(result.version, "2.15.1");
   assert.equal(result.installation_id_hash.length, 64);
   assert.notEqual(result.installation_id_hash, base.installation_id);
+});
+
+test("heartbeat bounds runtime health values and dashboard excludes hostile legacy categories", async (t) => {
+  const testVersion = "runtime-normalization-test";
+  t.after(async () => {
+    await usageDb.prepare("DELETE FROM heartbeats WHERE app_version = ?").bind(testVersion).run();
+    await usageDb.prepare("DELETE FROM heartbeat_daily WHERE version = ?").bind(testVersion).run();
+  });
+
+  const response = await mf.dispatchFetch("http://worker.test/heartbeat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      installation_id: "runtime-normalization-install",
+      timestamp: "2026-07-25T12:00:00Z",
+      version: testVersion,
+      runtime: {
+        inference_health_status: "attacker-controlled-status",
+        inference_health_unhealthy_runtimes: -5,
+        inference_health_degraded_runtimes: 50000,
+        inference_health_total_runtimes: "not-a-number",
+        last_recovery_reason: "<script>alert(1)</script>",
+        last_recovery_status: "attacker-controlled-status",
+      },
+    }),
+  });
+  assert.equal(response.status, 200, await response.text());
+
+  const stored = await usageDb.prepare(`
+    SELECT inference_health_status, inference_health_unhealthy_runtimes,
+           inference_health_degraded_runtimes, inference_health_total_runtimes,
+           last_recovery_reason, last_recovery_status
+    FROM heartbeats WHERE installation_id = 'runtime-normalization-install'
+  `).first();
+  assert.deepEqual(stored, {
+    inference_health_status: null,
+    inference_health_unhealthy_runtimes: 0,
+    inference_health_degraded_runtimes: 1000,
+    inference_health_total_runtimes: null,
+    last_recovery_reason: null,
+    last_recovery_status: null,
+  });
+
+  const validResponse = await mf.dispatchFetch("http://worker.test/heartbeat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      installation_id: "runtime-normalization-valid-install",
+      timestamp: "2026-07-25T12:00:00Z",
+      version: testVersion,
+      runtime: {
+        inference_health_status: "Degraded",
+        inference_health_unhealthy_runtimes: 1,
+        inference_health_degraded_runtimes: 2,
+        inference_health_total_runtimes: 3,
+        last_recovery_reason: "GPU_UNHEALTHY_FALLBACK",
+        last_recovery_status: "Recovered",
+      },
+    }),
+  });
+  assert.equal(validResponse.status, 200, await validResponse.text());
+  const validStored = await usageDb.prepare(`
+    SELECT inference_health_status, inference_health_unhealthy_runtimes,
+           inference_health_degraded_runtimes, inference_health_total_runtimes,
+           last_recovery_reason, last_recovery_status
+    FROM heartbeats WHERE installation_id = 'runtime-normalization-valid-install'
+  `).first();
+  assert.deepEqual(validStored, {
+    inference_health_status: "degraded",
+    inference_health_unhealthy_runtimes: 1,
+    inference_health_degraded_runtimes: 2,
+    inference_health_total_runtimes: 3,
+    last_recovery_reason: "gpu_unhealthy_fallback",
+    last_recovery_status: "recovered",
+  });
+
+  await usageDb.prepare(`
+    WITH RECURSIVE categories(n) AS (
+      SELECT 1 UNION ALL SELECT n + 1 FROM categories WHERE n < 20
+    )
+    INSERT INTO heartbeats (
+      installation_id, app_version, inference_health_status,
+      last_recovery_reason, last_recovery_status, last_seen
+    )
+    SELECT 'legacy-hostile-' || n, ?, 'hostile_status_' || n,
+           '<SCRIPT>' || n, 'recovered', datetime('now')
+    FROM categories
+  `).bind(testVersion).run();
+
+  const dashboard = await mf.dispatchFetch("http://worker.test/dashboard?view=health&days=30");
+  const body = await dashboard.text();
+  assert.equal(dashboard.status, 200);
+  assert.doesNotMatch(body, /hostile_status_|&lt;script&gt;|<script>/i);
+  assert.match(body, /gpu unhealthy fallback/);
 });
 
 test("ingestion rejects oversized bodies before D1 writes", async () => {


### PR DESCRIPTION
## Why
A post-implementation independent review of #107 found one D1/cardinality blocker and accessibility hardening items. #107 was merged externally before that review completed, so this focused follow-up contains only the remediation.

## Changes
- allowlist inference health to `ok`, `degraded`, or `unhealthy` at ingestion and query time
- cap inference status output at three categories
- normalize recovery status/reason and clamp runtime counters at the Worker trust boundary
- exclude unsafe legacy status/reason values from the public dashboard
- use WCAG-AA active-control colors in both modes
- expose every selected chart date/value through a screen-reader description
- make the overflowing recurring-issues region keyboard-focusable and labeled

## Verification
- Worker suite: **12/12 passing**
- Wrangler deployment dry-run: passed
- hostile-cardinality and invalid-value storage regression: passed
- valid producer normalization compatibility test: passed
- `git diff --check`: passed
- populated 390px visual QA for both modes: passed
- contrast endpoints: User Metrics 5.47:1 / 7.58:1; Health Data 5.18:1 / 6.47:1
- local D1 query plans use `idx_inference_health_status` and `idx_last_seen`
