### PR TITLE
Fix monolith native dependency install for v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   sizes and runtime categories are bounded, missing rate-limit bindings fail closed, an atomic
   daily write budget protects both ingestion routes, and 400-day retention cleanup is incremental
   rather than an unbounded maintenance operation.
+- **Monolith UI builds no longer trust a partial optional-dependency install.** The image build uses
+  the committed lockfile, explicitly includes native build dependencies, verifies Lightning CSS
+  before compiling the UI, and retries the clean install once if npm silently skips its platform
+  binary.
 
 ## [2.15.0] - 2026-07-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,12 @@ ENV APP_VERSION_BASE=${APP_VERSION_BASE}
 ENV APP_BRANCH=${APP_BRANCH}
 
 COPY apps/ui/package.json apps/ui/package-lock.json ./
-RUN npm install --legacy-peer-deps
+RUN set -eux; \
+    npm ci --include=dev --include=optional --legacy-peer-deps; \
+    if ! node -e "require('lightningcss')"; then \
+        npm ci --include=dev --include=optional --legacy-peer-deps; \
+    fi; \
+    node -e "require('lightningcss')"
 
 COPY apps/ui/ .
 RUN npm run build


### PR DESCRIPTION
## Summary
- install the UI dependency tree from the committed lockfile in monolith builds
- explicitly include native optional build dependencies
- verify Lightning CSS and retry one clean install if npm silently skips its platform binary
- record the reliability fix in the v2.16.0 changelog

## Validation
- `npm ci --include=dev --include=optional --legacy-peer-deps`
- native `lightningcss` load
- frontend: 122 files / 605 tests
- `svelte-check`: 0 errors, 0 warnings
- production Vite build

The exact Linux monolith and image-flavour matrix is delegated to CI before merge.