### PR TITLE
chore: codify pull request and roadmap delivery

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Outcome
+
+What useful user, operator, or contributor outcome now works?
+
+## Scope
+
+- **Included:**
+- **Explicitly excluded:**
+- **Issue or roadmap outcome:**
+
+## Verification
+
+Focused and full commands with real results:
+
+```text
+
+```
+
+## Data integrity and risk
+
+- Detection-history or configuration risk:
+- Migration/recovery path, if data changes:
+- Security or secret-handling risk:
+- Deployment verification, if deployed:
+
+## Checklist
+
+- [ ] The change is one reviewable behaviour or maintenance slice.
+- [ ] Focused tests and the repository Definition of Done pass.
+- [ ] `CHANGELOG.md` and maintained documentation are current where needed.
+- [ ] Schema changes include a reversible migration and retain one Alembic head.
+- [ ] No secret, private runtime data, unrelated work, or generated user media is included.
+- [ ] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,38 @@
+name: Secret scan
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Check out full history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Scan repository for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ assessment of the project against the standards, and the path to close remaining
 gaps, is in
 [`docs/reviews/2026-07-07-project-quality-and-gold-standard-review.md`](docs/reviews/2026-07-07-project-quality-and-gold-standard-review.md).
 
-Everyday work happens on `dev`. Follow the commit rules in `CLAUDE.md` §10.
+Everyday work starts from current `dev` on a short-lived branch and reaches
+`dev` through a pull request. Release pull requests alone target `main`. Follow
+the commit rules in `CLAUDE.md` §10.
 
 Release notes follow the human-first standard in
 [`docs/development/releasing.md`](docs/development/releasing.md) and use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- **Pull requests and roadmap work now have an explicit delivery contract.**
+  Everyday changes use short-lived branches and reviewed pull requests into
+  `dev`, while release pull requests alone target `main`. The roadmap records
+  prioritised outcomes and evidence gates; issues retain actionable discussion,
+  and pull requests retain the verified delivery slice.
+- **CI now scans the repository's full history for committed secrets.** Gitleaks
+  runs on pull requests, pushes to `dev` and `main`, a weekly schedule, and
+  manual dispatch with read-only repository permissions.
 - **Provider support now has a global candidate contract and an installation proof.** Registry and
   release-sidecar generator metadata distinguish providers that are safe everywhere from reviewed
   candidates that are worth probing. Compatibility evidence schema 4 binds each passing provider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,11 @@ looser.
   [`backend/scripts/docs_consistency_check.py`](backend/scripts/docs_consistency_check.py):
   local doc links resolve, documented endpoints in `docs/api.md` map to real routes,
   and stale compose/nav terms are rejected.
+- [`.github/workflows/security.yml`](.github/workflows/security.yml) — scans the
+  complete Git history with Gitleaks on pull requests, protected-branch pushes,
+  a weekly schedule, and manual dispatch. It has read-only repository
+  permissions and may not expose repository or deployment secrets to
+  pull-request code.
 - [`.github/dependabot.yml`](.github/dependabot.yml) — dependency updates for pip,
   npm, Docker, and Actions.
 
@@ -273,7 +278,15 @@ gate as permission to skip the local Definition of Done command.
 
 ## 10. Workflow & commit rules
 
-- **Everyday work happens on `dev`.** Release tags / `main` are handled separately.
+- **Start everyday work from current `dev` on a short-lived branch.** Keep each
+  branch to one reviewable behaviour change or tightly related maintenance slice,
+  then open a pull request into `dev`.
+- Release pull requests alone target `main`; release tags are created from the
+  reviewed release state.
+- Pull requests state the outcome, included and excluded scope, real verification
+  results, and material data, migration, security, or operational risk. Do not
+  merge while a required check is failing or a blocking review conversation is
+  unresolved.
 - **Write GitHub Releases for the person updating their feeder, not for the commit
   history.** Follow [`docs/development/releasing.md`](docs/development/releasing.md)
   and start from [`.github/RELEASE_NOTES_TEMPLATE.md`](.github/RELEASE_NOTES_TEMPLATE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,16 +62,22 @@ migration can upgrade, downgrade, and upgrade again.
 
 ## Branches and Pull Requests
 
-Everyday work targets `dev`. Create feature branches from `dev` unless a
-maintainer asks for a different base.
+Start from current `dev` and create a short-lived branch for one reviewable
+behaviour change or tightly related maintenance slice. Open the pull request
+into `dev`; release pull requests alone target `main`.
 
-Pull requests should:
+Use the repository pull request template to:
 
-- describe the behaviour change and why it is needed,
-- include tests for new or changed behaviour,
-- update `CHANGELOG.md` under `Unreleased`,
-- update docs when settings, APIs, integrations, or user-visible behaviour change,
-- keep CI green.
+- describe the useful outcome and exact included/excluded scope;
+- record focused and full checks with their real results;
+- include tests for new or changed behaviour;
+- update `CHANGELOG.md` under `Unreleased`;
+- update docs when settings, APIs, integrations, or user-visible behaviour change;
+- identify data-integrity, migration, security, or operational risk and recovery;
+- keep required checks green and resolve blocking review conversations.
+
+A pull request is delivery evidence, not a substitute for tests or a place to
+accumulate unrelated roadmap work.
 
 ## UI Notification Rules
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,9 @@
 The single, forward-looking plan for YA-WAMF. This is where **planned** and
 **in-progress** work lives; **completed** work moves to [`CHANGELOG.md`](CHANGELOG.md)
 and is summarised in the [Delivered](#3-delivered) catalogue at the bottom.
+Entries are ordered by product and safety dependency, not promised dates. Each
+entry states an outcome and the evidence needed to call it complete; priority
+and effort are planning aids, not release promises.
 
 > **YA-WAMF is already feature-rich.** This roadmap tracks what's *next*, not what
 > exists — see the [README](README.md) and [Delivered](#3-delivered) for current
@@ -28,6 +31,10 @@ It is anchored by two honest assessments of *where we stand*:
 **Issues first.** Before new feature work, clear anything in `ISSUES.md` and the
 [GitHub issue tracker](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues).
 If a section ever claims "none open", treat it as stale and check both sources.
+Issues retain implementation-ready scope, acceptance criteria, and discussion;
+short-lived pull requests deliver reviewable slices into `dev`. Code and tests
+remain the source of truth, so roadmap work is not shipped until the repository
+proves it.
 
 ---
 

--- a/docs/documentation-standard.md
+++ b/docs/documentation-standard.md
@@ -30,6 +30,25 @@ Ground every claim in the current repository:
 Do not invent capabilities, settings, guarantees, support promises, or future
 dates. Mark unverified assumptions explicitly or remove them.
 
+## Roadmap, changelog, issue, and pull request boundaries
+
+Keep the project records distinct:
+
+- [`../ROADMAP.md`](../ROADMAP.md) contains prioritised future user/operator
+  outcomes, their dependencies, and the evidence needed to consider them
+  complete. It contains no promised dates and never describes planned work as
+  available.
+- [`../CHANGELOG.md`](../CHANGELOG.md) records implemented user- or
+  operator-relevant changes under **Unreleased** until release.
+- GitHub issues hold actionable scope, acceptance criteria, reproduction
+  evidence, and current discussion. Link a roadmap outcome to an issue when it
+  becomes concrete enough to implement.
+- Pull requests deliver one reviewable behaviour change or tightly related
+  maintenance slice into `dev`, with actual verification and material risk
+  recorded. Release pull requests alone promote reviewed `dev` state to `main`.
+- Durable architecture, data-integrity, or security decisions belong in
+  maintained documentation, not only in an issue or pull request conversation.
+
 ## Information architecture
 
 Use the Diátaxis structure. Every user-facing page is exactly one kind:


### PR DESCRIPTION
## Outcome

YA-WAMF now has an explicit delivery contract for short-lived branches, pull requests into `dev`, release PRs into `main`, and evidence-gated roadmap work. CI also scans the complete Git history for committed secrets.

## Scope

- **Included:** contributor/agent workflow guidance, roadmap/changelog/issue/PR boundaries, a YA-WAMF-specific PR template, and a pinned read-only Gitleaks workflow.
- **Explicitly excluded:** branch-protection mutation, product/runtime behaviour, migrations, and AutoFPL-specific research governance.
- **Issue or roadmap outcome:** repository governance hardening requested by the maintainer.

## Verification

```text
python -m ruff check .
passed

python -m ruff format --check .
388 files already formatted

cd backend && python -m pytest tests/ -q
1,769 passed; 65 skipped

python3 backend/scripts/docs_consistency_check.py
passed; 161 routes validated

ruby YAML parse of .github/workflows/security.yml
passed

git diff --check
passed
```

## Data integrity and risk

- Detection-history or configuration risk: none; no runtime ingestion, settings, or deletion path changed.
- Migration/recovery path: no schema or data change.
- Security risk: the new workflow uses read-only repository permissions, full-history checkout without persisted credentials, pinned action SHAs, and no deployment secrets.
- Deployment verification: not applicable; this is repository workflow/documentation only.

## Checklist

- [x] The change is one reviewable maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current.
- [x] No schema change is present.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted-input, secret-redaction, and deletion boundaries are unchanged.