### PR TITLE
fix: terminal recovery retries snapshot classification when snapshot materializes late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   usable video, the same job visibly downgrades to the best available snapshot instead of failing
   without attempting the remaining evidence.
 
+### Fixed
+
+- **Short bird detections are no longer silently dropped when the snapshot appears late.**
+  When a `new` event could not be classified and the matching `end` event finds no persisted
+  detection, the terminal recovery now re-runs the full snapshot/recording-frame retrieval chain
+  for its own bounded, freshness-free horizon (default 8 attempts, 2 s apart), so a snapshot or
+  recording segment that Frigate materializes just after `end` still gets classified
+  (`EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET`, `EVENT_SNAPSHOT_TERMINAL_RETRY_DELAY_SECONDS`).
+
 ## [2.16.0] - 2026-07-25
 
 ### Added

--- a/backend/app/services/event_processor.py
+++ b/backend/app/services/event_processor.py
@@ -583,7 +583,7 @@ class EventProcessor:
                 event_id=event.frigate_event,
                 stage="classify_snapshot",
                 timeout_seconds=EVENT_STAGE_TIMEOUT_CLASSIFY_SECONDS,
-                coro=self._classify_snapshot(event),
+                coro=self._classify_snapshot(event, terminal_recovery=recovering_terminal_event),
                 fallback=None,
             )
         finally:

--- a/backend/app/services/event_processor.py
+++ b/backend/app/services/event_processor.py
@@ -995,6 +995,35 @@ class EventProcessor:
             lang="en",
         )
 
+    async def _try_obtain_snapshot_input(self, event: EventData) -> tuple[Optional[bytes], str]:
+        """One bounded attempt at obtaining a classification image for an event.
+
+        Prefers the crop-aware Frigate snapshot and otherwise runs the full
+        fallback chain (uncropped snapshot, thumbnail, media cache, recording
+        frame). Returns (image_bytes, source) or (None, "unavailable").
+        """
+        event_snapshot_state = {
+            "end_time": (
+                getattr(event, "end_time_ts", None) if bool(getattr(event, "end_time_known", False)) else None
+            ),
+            "data": getattr(event, "data", {}),
+        }
+        snapshot_provenance = frigate_snapshot_input_provenance(event_snapshot_state)
+        snapshot_data, _ = await frigate_client.get_snapshot_with_error(
+            event.frigate_event,
+            crop=snapshot_provenance.is_cropped,
+            quality=95,
+        )
+        if snapshot_data:
+            return snapshot_data, snapshot_provenance.input_source
+
+        snapshot_data, snapshot_source = await self._load_snapshot_classification_fallback(
+            event.frigate_event,
+            camera=getattr(event, "camera", None),
+            start_time_ts=getattr(event, "start_time_ts", None),
+        )
+        return snapshot_data, snapshot_source
+
     async def _classify_snapshot(self, event: EventData) -> Optional[Tuple[list, Optional[bytes], str]]:
         """Classify snapshot or use Frigate sublabel if trusted.
 

--- a/backend/app/services/event_processor.py
+++ b/backend/app/services/event_processor.py
@@ -90,6 +90,17 @@ EVENT_SNAPSHOT_RECOVERY_EXTRA_RETRIES = max(
     0,
     int(os.getenv("EVENT_SNAPSHOT_RECOVERY_EXTRA_RETRIES", "5")),
 )
+# Terminal MQTT recovery re-runs the classification-input chain for a bounded
+# horizon once the detection has ended, so Frigate can materialize the event
+# snapshot or flush the recording segment used by the frame fallback.
+EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET = max(
+    1,
+    int(os.getenv("EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET", "8")),
+)
+EVENT_SNAPSHOT_TERMINAL_RETRY_DELAY_SECONDS = max(
+    0.5,
+    float(os.getenv("EVENT_SNAPSHOT_TERMINAL_RETRY_DELAY_SECONDS", "2.0")),
+)
 # Short window around the detection start used to pull a classification frame from
 # Frigate's continuous recording when no snapshot/thumbnail is available.
 RECORDING_FRAME_FALLBACK_BEFORE_SECONDS = max(0, int(os.getenv("RECORDING_FRAME_FALLBACK_BEFORE_SECONDS", "2")))
@@ -942,7 +953,10 @@ class EventProcessor:
         except (TypeError, ValueError):
             return False
 
-    def _snapshot_unavailable_retry_budget(self, event: EventData) -> int:
+    def _snapshot_unavailable_retry_budget(self, event: EventData, *, terminal: bool = False) -> int:
+        if terminal:
+            return EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET
+
         retries = 1
         if self._mqtt_snapshot_recovery_active():
             retries += EVENT_SNAPSHOT_RECOVERY_EXTRA_RETRIES

--- a/backend/app/services/event_processor.py
+++ b/backend/app/services/event_processor.py
@@ -1024,16 +1024,27 @@ class EventProcessor:
         )
         return snapshot_data, snapshot_source
 
-    async def _classify_snapshot(self, event: EventData) -> Optional[Tuple[list, Optional[bytes], str]]:
+    async def _classify_snapshot(
+        self,
+        event: EventData,
+        *,
+        terminal_recovery: bool = False,
+    ) -> Optional[Tuple[list, Optional[bytes], str]]:
         """Classify snapshot or use Frigate sublabel if trusted.
+
+        Args:
+            event: Parsed Frigate MQTT event.
+            terminal_recovery: True when the event is being reclassified from its
+                final ``end`` state because the initial ingest never produced a
+                detection. Uses an extended, freshness-free snapshot retry horizon
+                so Frigate can materialize the snapshot or flush the recording
+                segment used by the frame fallback.
 
         Returns:
             Tuple of (classification_results, snapshot_data, snapshot_source) if successful, None otherwise
         """
         # Normal classification path
         try:
-            retry_budget = self._snapshot_unavailable_retry_budget(event)
-            snapshot_data: bytes | None = None
             # This is the live MQTT path: an absent/unknown end marker is an
             # active event, while a known non-null end marker is completed.
             # Keeping that distinction aligned with the requested Frigate
@@ -1044,43 +1055,63 @@ class EventProcessor:
                 ),
                 "data": getattr(event, "data", {}),
             }
-            snapshot_provenance = frigate_snapshot_input_provenance(event_snapshot_state)
-            snapshot_source = snapshot_provenance.input_source
+            snapshot_data: bytes | None = None
+            snapshot_source = "unavailable"
             last_snapshot_error: str | None = None
-            for retry_index in range(retry_budget + 1):
-                snapshot_data, last_snapshot_error = await frigate_client.get_snapshot_with_error(
-                    event.frigate_event,
-                    crop=snapshot_provenance.is_cropped,
-                    quality=95,
-                )
-                if snapshot_data:
-                    break
 
-                if retry_index >= retry_budget:
-                    break
-
-                if retry_budget > 1:
-                    log.info(
-                        "Snapshot unavailable during Frigate recovery, retrying",
-                        event_id=event.frigate_event,
-                        retry_attempt=retry_index + 1,
-                        retry_budget=retry_budget,
-                        retry_delay_seconds=EVENT_SNAPSHOT_UNAVAILABLE_RETRY_DELAY_SECONDS,
-                    )
-                else:
-                    log.info("Snapshot unavailable, retrying once", event_id=event.frigate_event)
-
-                remaining_freshness = max(0.0, LIVE_EVENT_STALE_SECONDS - self._live_event_age_seconds(event))
-                if remaining_freshness <= 0.0:
-                    break
-                await asyncio.sleep(min(EVENT_SNAPSHOT_UNAVAILABLE_RETRY_DELAY_SECONDS, remaining_freshness))
-            if not snapshot_data:
-                snapshot_data, snapshot_source = await self._load_snapshot_classification_fallback(
-                    event.frigate_event,
-                    camera=getattr(event, "camera", None),
-                    start_time_ts=getattr(event, "start_time_ts", None),
-                )
+            if terminal_recovery:
+                snapshot_data, snapshot_source = await self._try_obtain_snapshot_input(event)
+                if not snapshot_data:
+                    for retry_index in range(self._snapshot_unavailable_retry_budget(event, terminal=True)):
+                        await asyncio.sleep(EVENT_SNAPSHOT_TERMINAL_RETRY_DELAY_SECONDS)
+                        snapshot_data, snapshot_source = await self._try_obtain_snapshot_input(event)
+                        if snapshot_data:
+                            log.info(
+                                "Snapshot materialized during terminal recovery",
+                                event_id=event.frigate_event,
+                                retry_attempt=retry_index + 1,
+                                snapshot_source=snapshot_source,
+                            )
+                            break
                 snapshot_provenance = cached_snapshot_input_provenance({"source": snapshot_source})
+            else:
+                snapshot_provenance = frigate_snapshot_input_provenance(event_snapshot_state)
+                snapshot_source = snapshot_provenance.input_source
+                retry_budget = self._snapshot_unavailable_retry_budget(event)
+                for retry_index in range(retry_budget + 1):
+                    snapshot_data, last_snapshot_error = await frigate_client.get_snapshot_with_error(
+                        event.frigate_event,
+                        crop=snapshot_provenance.is_cropped,
+                        quality=95,
+                    )
+                    if snapshot_data:
+                        break
+
+                    if retry_index >= retry_budget:
+                        break
+
+                    if retry_budget > 1:
+                        log.info(
+                            "Snapshot unavailable during Frigate recovery, retrying",
+                            event_id=event.frigate_event,
+                            retry_attempt=retry_index + 1,
+                            retry_budget=retry_budget,
+                            retry_delay_seconds=EVENT_SNAPSHOT_UNAVAILABLE_RETRY_DELAY_SECONDS,
+                        )
+                    else:
+                        log.info("Snapshot unavailable, retrying once", event_id=event.frigate_event)
+
+                    remaining_freshness = max(0.0, LIVE_EVENT_STALE_SECONDS - self._live_event_age_seconds(event))
+                    if remaining_freshness <= 0.0:
+                        break
+                    await asyncio.sleep(min(EVENT_SNAPSHOT_UNAVAILABLE_RETRY_DELAY_SECONDS, remaining_freshness))
+                if not snapshot_data:
+                    snapshot_data, snapshot_source = await self._load_snapshot_classification_fallback(
+                        event.frigate_event,
+                        camera=getattr(event, "camera", None),
+                        start_time_ts=getattr(event, "start_time_ts", None),
+                    )
+                    snapshot_provenance = cached_snapshot_input_provenance({"source": snapshot_source})
             if not snapshot_data:
                 if settings.classification.trust_frigate_sublabel and event.sub_label:
                     log.info(

--- a/backend/tests/test_event_processor.py
+++ b/backend/tests/test_event_processor.py
@@ -672,7 +672,7 @@ async def test_process_mqtt_message_logs_stage_timeout_for_classification():
     processor = EventProcessor(classifier)
     processor._handle_detection_save_and_notify = AsyncMock()  # type: ignore[method-assign]
 
-    async def _slow_classify(_event):
+    async def _slow_classify(_event, terminal_recovery=False):
         await asyncio.sleep(0.05)
         return ([{"label": "Sparrow", "score": 0.82, "index": 1}], b"img", "frigate_snapshot_cropped")
 
@@ -704,7 +704,7 @@ async def test_process_mqtt_message_records_distinct_overload_drop_reason():
     processor = EventProcessor(classifier)
     processor._handle_detection_save_and_notify = AsyncMock()  # type: ignore[method-assign]
 
-    async def _overloaded_classify(_event):
+    async def _overloaded_classify(_event, terminal_recovery=False):
         raise RuntimeError("classify_snapshot_overloaded")
 
     processor._classify_snapshot = _overloaded_classify  # type: ignore[method-assign]
@@ -1008,7 +1008,7 @@ async def test_process_mqtt_message_coalesces_duplicate_live_event_while_active(
     classify_started = asyncio.Event()
     release_classify = asyncio.Event()
 
-    async def _blocked_classify(_event):
+    async def _blocked_classify(_event, terminal_recovery=False):
         classify_started.set()
         await release_classify.wait()
         return ([{"label": "Sparrow", "score": 0.95, "index": 1}], b"img", "frigate_snapshot_cropped")
@@ -1061,7 +1061,7 @@ async def test_process_mqtt_message_allows_retry_after_classification_when_first
     classify_calls = 0
     save_calls = 0
 
-    async def _classify(_event):
+    async def _classify(_event, terminal_recovery=False):
         nonlocal classify_calls
         classify_calls += 1
         return ([{"label": "Sparrow", "score": 0.95, "index": 1}], b"img", "frigate_snapshot_cropped")
@@ -1847,6 +1847,73 @@ async def test_classify_snapshot_terminal_recovery_ignores_freshness_gating():
     assert snapshot_data == b"old-but-recovered"
     assert mock_frigate.get_snapshot_with_error.await_count == 3
     assert mock_sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_end_event_recovery_calls_classify_with_terminal_recovery_flag():
+    processor = EventProcessor(MagicMock())
+    processor.detection_service.get_detection_by_frigate_event = AsyncMock(return_value=None)
+    processor._classify_snapshot = AsyncMock(  # type: ignore[method-assign]
+        return_value=([{"label": "Cardinal", "score": 0.9, "index": 1}], b"img", "frigate_snapshot")
+    )
+    processor._gather_context_data = AsyncMock(return_value={"audio_match": None, "weather_data": {}})  # type: ignore[method-assign]
+    processor._correlate_audio = AsyncMock(
+        return_value={  # type: ignore[method-assign]
+            "label": "Cardinal",
+            "score": 0.9,
+            "index": 1,
+            "audio_confirmed": False,
+            "audio_species": None,
+            "audio_score": None,
+        }
+    )
+    processor._handle_detection_save_and_notify = AsyncMock()  # type: ignore[method-assign]
+    processor._handle_terminal_event_enrichment = AsyncMock()  # type: ignore[method-assign]
+    processor.detection_service.filter_and_label = MagicMock(  # type: ignore[attr-defined]
+        return_value=({"label": "Cardinal", "score": 0.9, "index": 1}, None)
+    )
+
+    payload = (
+        b'{"type":"end","after":{"id":"evt-end-flag","label":"bird","camera":"cam1",'
+        b'"start_time":1699999000,"end_time":1700000000}}'
+    )
+    await processor.process_mqtt_message(payload)
+
+    assert processor._classify_snapshot.call_count == 1
+    _, kwargs = processor._classify_snapshot.call_args
+    assert kwargs == {"terminal_recovery": True}
+    processor._handle_detection_save_and_notify.assert_awaited_once()
+    processor._handle_terminal_event_enrichment.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_new_event_calls_classify_without_terminal_recovery():
+    processor = EventProcessor(MagicMock())
+    processor._classify_snapshot = AsyncMock(  # type: ignore[method-assign]
+        return_value=([{"label": "Cardinal", "score": 0.9, "index": 1}], b"img", "frigate_snapshot_cropped")
+    )
+    processor._gather_context_data = AsyncMock(return_value={"audio_match": None, "weather_data": {}})  # type: ignore[method-assign]
+    processor._correlate_audio = AsyncMock(
+        return_value={  # type: ignore[method-assign]
+            "label": "Cardinal",
+            "score": 0.9,
+            "index": 1,
+            "audio_confirmed": False,
+            "audio_species": None,
+            "audio_score": None,
+        }
+    )
+    processor._handle_detection_save_and_notify = AsyncMock()  # type: ignore[method-assign]
+    processor.detection_service.filter_and_label = MagicMock(  # type: ignore[attr-defined]
+        return_value=({"label": "Cardinal", "score": 0.9, "index": 1}, None)
+    )
+
+    payload = b'{"type":"new","after":{"id":"evt-new-flag","label":"bird","camera":"cam1","start_time":1700000000}}'
+    await processor.process_mqtt_message(payload)
+
+    assert processor._classify_snapshot.call_count == 1
+    _, kwargs = processor._classify_snapshot.call_args
+    assert kwargs == {"terminal_recovery": False}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_event_processor.py
+++ b/backend/tests/test_event_processor.py
@@ -1675,6 +1675,181 @@ async def test_try_obtain_snapshot_input_returns_unavailable_when_chain_empty():
 
 
 @pytest.mark.asyncio
+async def test_classify_snapshot_terminal_recovery_retries_until_snapshot_materializes():
+    classifier = MagicMock()
+    classifier.classify_async_live = AsyncMock(return_value=[{"label": "Sparrow", "score": 0.95, "index": 1}])
+    processor = EventProcessor(classifier)
+    event = SimpleNamespace(
+        frigate_event="evt-term-snapshot",
+        camera="cam1",
+        start_time_ts=1700000000.0,
+        sub_label=None,
+        sub_label_score=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+        end_time_known=True,
+        end_time_ts=1700000000.5,
+        data={},
+    )
+
+    with (
+        patch("app.services.event_processor.frigate_client") as mock_frigate,
+        patch("app.services.event_processor.Image.open", return_value=MagicMock()),
+        patch("app.services.event_processor.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch.object(
+            EventProcessor,
+            "_load_snapshot_classification_fallback",
+            new=AsyncMock(return_value=(None, "unavailable")),
+        ),
+        patch("app.services.event_processor.EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET", 4),
+    ):
+        mock_frigate.get_snapshot_with_error = AsyncMock(
+            side_effect=[
+                (None, "snapshot_not_found"),
+                (None, "snapshot_not_found"),
+                (b"term-snapshot", None),
+            ]
+        )
+
+        result = await processor._classify_snapshot(event, terminal_recovery=True)
+
+    assert result is not None
+    results, snapshot_data, snapshot_source = result
+    assert results[0]["label"] == "Sparrow"
+    assert snapshot_data == b"term-snapshot"
+    assert snapshot_source == "frigate_snapshot"
+    assert mock_frigate.get_snapshot_with_error.await_count == 3
+    assert mock_sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_classify_snapshot_terminal_recovery_uses_recording_frame_fallback():
+    classifier = MagicMock()
+    classifier.classify_async_live = AsyncMock(return_value=[{"label": "Sparrow", "score": 0.95, "index": 1}])
+    processor = EventProcessor(classifier)
+    event = SimpleNamespace(
+        frigate_event="evt-term-frame",
+        camera="cam1",
+        start_time_ts=1700000000.0,
+        sub_label=None,
+        sub_label_score=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+    )
+
+    with (
+        patch("app.services.event_processor.frigate_client") as mock_frigate,
+        patch("app.services.event_processor.Image.open", return_value=MagicMock()),
+        patch("app.services.event_processor.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch.object(
+            EventProcessor,
+            "_load_snapshot_classification_fallback",
+            new=AsyncMock(
+                side_effect=[
+                    (None, "unavailable"),
+                    (None, "unavailable"),
+                    (b"recording-frame", "frigate_recording_frame"),
+                ]
+            ),
+        ),
+        patch("app.services.event_processor.EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET", 4),
+    ):
+        mock_frigate.get_snapshot_with_error = AsyncMock(return_value=(None, "snapshot_not_found"))
+
+        result = await processor._classify_snapshot(event, terminal_recovery=True)
+
+    assert result is not None
+    _, snapshot_data, snapshot_source = result
+    assert snapshot_data == b"recording-frame"
+    assert snapshot_source == "frigate_recording_frame"
+    assert mock_sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_classify_snapshot_terminal_recovery_returns_none_when_horizon_exhausted():
+    classifier = MagicMock()
+    processor = EventProcessor(classifier)
+    event = SimpleNamespace(
+        frigate_event="evt-term-exhausted",
+        camera="cam1",
+        start_time_ts=1700000000.0,
+        sub_label=None,
+        sub_label_score=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+    )
+
+    with (
+        patch("app.services.event_processor.frigate_client") as mock_frigate,
+        patch("app.services.event_processor.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch.object(
+            EventProcessor,
+            "_load_snapshot_classification_fallback",
+            new=AsyncMock(return_value=(None, "unavailable")),
+        ),
+        patch("app.services.event_processor.EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET", 2),
+    ):
+        mock_frigate.get_snapshot_with_error = AsyncMock(return_value=(None, "snapshot_not_found"))
+
+        result = await processor._classify_snapshot(event, terminal_recovery=True)
+
+    assert result is None
+    assert mock_frigate.get_snapshot_with_error.await_count == 3
+    assert mock_sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_classify_snapshot_terminal_recovery_ignores_freshness_gating():
+    classifier = MagicMock()
+    classifier.classify_async_live = AsyncMock(return_value=[{"label": "Sparrow", "score": 0.95, "index": 1}])
+    processor = EventProcessor(classifier)
+    event = SimpleNamespace(
+        frigate_event="evt-term-freshness",
+        camera="cam1",
+        start_time_ts=1700000000.0,
+        sub_label=None,
+        sub_label_score=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+        end_time_known=True,
+        end_time_ts=1700000000.5,
+        data={},
+    )
+
+    with (
+        patch("app.services.event_processor.frigate_client") as mock_frigate,
+        patch("app.services.event_processor.Image.open", return_value=MagicMock()),
+        patch("app.services.event_processor.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch("app.services.event_processor.time.time", return_value=1700000100.0),
+        patch.object(
+            EventProcessor,
+            "_load_snapshot_classification_fallback",
+            new=AsyncMock(return_value=(None, "unavailable")),
+        ),
+        patch("app.services.event_processor.EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET", 2),
+    ):
+        mock_frigate.get_snapshot_with_error = AsyncMock(
+            side_effect=[
+                (None, "snapshot_not_found"),
+                (None, "snapshot_not_found"),
+                (b"old-but-recovered", None),
+            ]
+        )
+
+        result = await processor._classify_snapshot(event, terminal_recovery=True)
+
+    assert result is not None
+    _, snapshot_data, _ = result
+    assert snapshot_data == b"old-but-recovered"
+    assert mock_frigate.get_snapshot_with_error.await_count == 3
+    assert mock_sleep.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_recording_frame_fallback_extracts_frame_from_recording_window():
     processor = EventProcessor(MagicMock())
     with (

--- a/backend/tests/test_event_processor.py
+++ b/backend/tests/test_event_processor.py
@@ -1591,6 +1591,90 @@ async def test_classify_snapshot_does_not_claim_crop_for_ended_frigate_event():
 
 
 @pytest.mark.asyncio
+async def test_try_obtain_snapshot_input_prefers_crop_aware_snapshot():
+    processor = EventProcessor(MagicMock())
+    event = SimpleNamespace(
+        frigate_event="evt-obtain-snapshot",
+        camera="cam1",
+        start_time_ts=1700000000.0,
+        sub_label=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+        end_time_known=True,
+        end_time_ts=1700000000.5,
+        data={},
+    )
+
+    with patch("app.services.event_processor.frigate_client") as mock_frigate:
+        mock_frigate.get_snapshot_with_error = AsyncMock(return_value=(b"snapshot-bytes", None))
+
+        data, source = await processor._try_obtain_snapshot_input(event)
+
+    assert data == b"snapshot-bytes"
+    assert source == "frigate_snapshot"
+    mock_frigate.get_snapshot_with_error.assert_awaited_once_with("evt-obtain-snapshot", crop=False, quality=95)
+
+
+@pytest.mark.asyncio
+async def test_try_obtain_snapshot_input_runs_full_fallback_chain():
+    processor = EventProcessor(MagicMock())
+    event = SimpleNamespace(
+        frigate_event="evt-obtain-fallback",
+        camera="cam1",
+        start_time_ts=1700000000.0,
+        sub_label=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+    )
+
+    with (
+        patch("app.services.event_processor.frigate_client") as mock_frigate,
+        patch.object(
+            EventProcessor,
+            "_load_snapshot_classification_fallback",
+            new=AsyncMock(return_value=(b"recording-frame", "frigate_recording_frame")),
+        ),
+    ):
+        mock_frigate.get_snapshot_with_error = AsyncMock(return_value=(None, "snapshot_not_found"))
+
+        data, source = await processor._try_obtain_snapshot_input(event)
+
+    assert data == b"recording-frame"
+    assert source == "frigate_recording_frame"
+
+
+@pytest.mark.asyncio
+async def test_try_obtain_snapshot_input_returns_unavailable_when_chain_empty():
+    processor = EventProcessor(MagicMock())
+    event = SimpleNamespace(
+        frigate_event="evt-obtain-none",
+        camera="cam1",
+        start_time_ts=1700000000.0,
+        sub_label=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+    )
+
+    with (
+        patch("app.services.event_processor.frigate_client") as mock_frigate,
+        patch.object(
+            EventProcessor,
+            "_load_snapshot_classification_fallback",
+            new=AsyncMock(return_value=(None, "unavailable")),
+        ),
+    ):
+        mock_frigate.get_snapshot_with_error = AsyncMock(return_value=(None, "snapshot_not_found"))
+
+        data, source = await processor._try_obtain_snapshot_input(event)
+
+    assert data is None
+    assert source == "unavailable"
+
+
+@pytest.mark.asyncio
 async def test_recording_frame_fallback_extracts_frame_from_recording_window():
     processor = EventProcessor(MagicMock())
     with (

--- a/backend/tests/test_event_processor.py
+++ b/backend/tests/test_event_processor.py
@@ -1314,6 +1314,26 @@ def test_snapshot_retry_budget_does_not_stay_elevated_after_frigate_traffic_resu
     assert retry_budget == 1
 
 
+def test_snapshot_unavailable_retry_budget_terminal_ignores_freshness():
+    processor = EventProcessor(MagicMock())
+    event = SimpleNamespace(
+        frigate_event="evt-term-budget",
+        camera="cam1",
+        sub_label=None,
+        frigate_score=None,
+        is_false_positive=False,
+        received_at_ts=1700000001.0,
+    )
+
+    with (
+        patch("app.services.event_processor.time.time", return_value=1700000100.0),
+        patch("app.services.event_processor.EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET", 7),
+    ):
+        budget = processor._snapshot_unavailable_retry_budget(event, terminal=True)
+
+    assert budget == 7
+
+
 @pytest.mark.asyncio
 async def test_classify_snapshot_caps_retry_sleep_to_remaining_freshness():
     classifier = MagicMock()


### PR DESCRIPTION
## Outcome

Short bird detections are no longer silently dropped (`drop_classify_snapshot_unavailable`) when Frigate materializes the event snapshot or flushes the recording segment just after `type=end`. The terminal recovery path now retries the full classification-input chain for its own bounded horizon before giving up.

## Scope

- **Included:**
  - `EVENT_SNAPSHOT_TERMINAL_RETRY_BUDGET` (env, default `8`) and `EVENT_SNAPSHOT_TERMINAL_RETRY_DELAY_SECONDS` (env, default `2.0`) → ~16–20 s terminal retry horizon, freshness-free.
  - `_snapshot_unavailable_retry_budget(event, *, terminal=False)` — terminal branch returns the terminal budget and bypasses `LIVE_EVENT_STALE_SECONDS` freshness gating.
  - New `_try_obtain_snapshot_input(event)` helper — one bounded attempt at the full chain (crop snapshot → uncropped → thumbnail → media cache → recording frame).
  - `_classify_snapshot(event, *, terminal_recovery=False)` — terminal branch loops the full chain (sleep → chain → break on success); non-terminal (`new`/`update`) path unchanged byte-for-byte.
  - Call site passes `terminal_recovery=recovering_terminal_event`.
  - 10 new tests; 4 existing mock functions adapted to the new call signature.
  - `CHANGELOG.md` entry under Unreleased.
- **Explicitly excluded:** pending-snapshot registry, severity change for `classify_snapshot_unavailable`, config flags beyond the two env constants, MQTT/Frigate policy changes.
- **Issue or roadmap outcome:** Closes #133.

## Verification

```text
cd backend
.venv/bin/python -m pytest tests/test_event_processor.py -q
-> 64 passed

.venv/bin/python -m pytest tests/test_event_processor.py tests/test_mqtt_service.py tests/test_classifier_service.py -q
-> 300 passed

.venv/bin/python -m ruff check .
-> All checks passed!

.venv/bin/python -m ruff format --check backend/app/services/event_processor.py backend/tests/test_event_processor.py
-> 2 files already formatted
```

## Data integrity and risk

- Detection-history or configuration risk: none — no schema/data changes; new behavior activates only on the existing terminal-recovery path (an `end` event with no persisted detection).
- Migration/recovery path, if data changes: none.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: behavior is bounded by the 60 s classify stage timeout and 90 s MQTT handler (terminal horizon ~16–20 s fits); two new env knobs default to the tuned values and are optional.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.