### PR TITLE
Stop reclassifying events the classification filter already rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Short visits no longer produce a second, futile classification attempt when the event ends.**
+  An event whose classification ran and was deliberately rejected by the confidence or label filter
+  is now remembered as decided, so the terminal `end` recovery no longer mistakes "no detection was
+  saved" for "the initial ingest failed". Previously such events were reclassified against a
+  snapshot Frigate had already discarded, which always failed and logged a misleading
+  "snapshot unavailable after retry" drop. Recovery of genuinely un-ingested events is unchanged.
+
 - **Manual reclassification no longer rejects good fleeting sightings or applies unsafe weak
   replacements.** Retained recordings use Frigate boxes only at timestamps backed by `path_data`,
   so one stale box cannot repeatedly classify background after the bird has moved. A video

--- a/backend/app/services/event_processor.py
+++ b/backend/app/services/event_processor.py
@@ -53,6 +53,10 @@ def decode_image_bytes(contents: bytes) -> Image.Image:
 
 
 FALSE_POSITIVE_TOMBSTONE_TTL_SECONDS = 600.0
+# A classification that reached the filter and was rejected is a decision, not a
+# failed ingest. Remembering that decision keeps the terminal `end` recovery from
+# reclassifying an event whose snapshot Frigate has already discarded.
+CLASSIFICATION_DECIDED_TOMBSTONE_TTL_SECONDS = 600.0
 EVENT_STAGE_TIMEOUT_CLASSIFY_SECONDS = max(1.0, float(os.getenv("EVENT_STAGE_TIMEOUT_CLASSIFY_SECONDS", "60")))
 EVENT_STAGE_TIMEOUT_CONTEXT_SECONDS = max(0.5, float(os.getenv("EVENT_STAGE_TIMEOUT_CONTEXT_SECONDS", "6")))
 EVENT_STAGE_TIMEOUT_AUDIO_CORRELATE_SECONDS = max(
@@ -137,6 +141,7 @@ class EventProcessor:
         self.detection_service = DetectionService(self.classifier)
         self.notification_orchestrator = NotificationOrchestrator()
         self._false_positive_tombstones: dict[str, float] = {}
+        self._classification_decided_tombstones: dict[str, float] = {}
         self._started_events = 0
         self._completed_events = 0
         self._dropped_events = 0
@@ -508,6 +513,16 @@ class EventProcessor:
                     auto_full_visit_enabled=self._auto_full_visit_enabled(),
                 )
                 return
+            if self._is_classification_decided_tombstone_active(event.frigate_event):
+                log.info(
+                    "Skipping terminal recovery - classification already rejected this event",
+                    event_id=event.frigate_event,
+                    camera=event.camera,
+                )
+                duration_ms = (time.monotonic() - started) * 1000.0
+                self._record_completed(event.frigate_event, duration_ms)
+                self._record_recent_outcome(event.frigate_event, "end_event_classification_already_decided")
+                return
             recovering_terminal_event = True
             log.info(
                 "Retrying missing initial detection from final Frigate event state",
@@ -625,6 +640,7 @@ class EventProcessor:
                 label=top_candidate.get("label"),
                 score=top_candidate.get("score"),
             )
+            self._mark_classification_decided_tombstone(event.frigate_event)
             return
 
         context_ok, context_result = await self._run_stage(
@@ -728,6 +744,27 @@ class EventProcessor:
             return False
         self._prune_false_positive_tombstones()
         expiry = self._false_positive_tombstones.get(event_id)
+        return bool(expiry and expiry > time.monotonic())
+
+    def _prune_classification_decided_tombstones(self) -> None:
+        now = time.monotonic()
+        expired = [event_id for event_id, expiry in self._classification_decided_tombstones.items() if expiry <= now]
+        for event_id in expired:
+            self._classification_decided_tombstones.pop(event_id, None)
+
+    def _mark_classification_decided_tombstone(self, event_id: str) -> None:
+        if not event_id:
+            return
+        self._prune_classification_decided_tombstones()
+        self._classification_decided_tombstones[event_id] = (
+            time.monotonic() + CLASSIFICATION_DECIDED_TOMBSTONE_TTL_SECONDS
+        )
+
+    def _is_classification_decided_tombstone_active(self, event_id: str) -> bool:
+        if not event_id:
+            return False
+        self._prune_classification_decided_tombstones()
+        expiry = self._classification_decided_tombstones.get(event_id)
         return bool(expiry and expiry > time.monotonic())
 
     def _select_usable_classification(

--- a/backend/tests/test_event_processor.py
+++ b/backend/tests/test_event_processor.py
@@ -2,7 +2,7 @@ import pytest
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
-from app.services.event_processor import EventProcessor
+from app.services.event_processor import CLASSIFICATION_DECIDED_TOMBSTONE_TTL_SECONDS, EventProcessor
 from app.services.classification_admission import ClassificationLeaseExpiredError
 from app.services.classifier_service import LiveImageClassificationOverloadedError
 
@@ -363,6 +363,73 @@ async def test_end_event_recovers_detection_when_initial_ingest_created_no_row()
     processor._classify_snapshot.assert_awaited_once()
     processor._handle_detection_save_and_notify.assert_awaited_once()
     processor._handle_terminal_event_enrichment.assert_awaited_once()
+
+
+def _filtered_event_processor() -> EventProcessor:
+    """Processor whose classifier succeeds but whose filter rejects the result."""
+    processor = EventProcessor(MagicMock())
+    processor.detection_service.get_detection_by_frigate_event = AsyncMock(return_value=None)
+    processor._classify_snapshot = AsyncMock(  # type: ignore[method-assign]
+        return_value=(
+            [{"label": "Pontederia crassipes", "score": 0.05, "index": 1}],
+            b"img",
+            "frigate_snapshot_cropped",
+        )
+    )
+    processor._handle_detection_save_and_notify = AsyncMock()  # type: ignore[method-assign]
+    processor._handle_terminal_event_enrichment = AsyncMock()  # type: ignore[method-assign]
+    processor.detection_service.filter_and_label = MagicMock(return_value=(None, "low_confidence"))
+    return processor
+
+
+@pytest.mark.asyncio
+async def test_end_event_skips_terminal_recovery_when_classification_was_already_rejected():
+    processor = _filtered_event_processor()
+
+    new_payload = (
+        b'{"type":"new","after":{"id":"evt-filtered-end","label":"bird","camera":"cam1","start_time":1700000000}}'
+    )
+    await processor.process_mqtt_message(new_payload)
+    assert processor._classify_snapshot.await_count == 1
+
+    end_payload = (
+        b'{"type":"end","after":{"id":"evt-filtered-end","label":"bird","camera":"cam1",'
+        b'"start_time":1700000000,"end_time":1700000004}}'
+    )
+    await processor.process_mqtt_message(end_payload)
+
+    assert processor._classify_snapshot.await_count == 1
+    processor._handle_detection_save_and_notify.assert_not_awaited()
+    processor._handle_terminal_event_enrichment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_event_still_reclassifies_after_classification_filter_rejection():
+    processor = _filtered_event_processor()
+
+    new_payload = (
+        b'{"type":"new","after":{"id":"evt-filtered-update","label":"bird","camera":"cam1","start_time":1700000000}}'
+    )
+    await processor.process_mqtt_message(new_payload)
+
+    update_payload = (
+        b'{"type":"update","after":{"id":"evt-filtered-update","label":"bird","camera":"cam1","start_time":1700000000}}'
+    )
+    await processor.process_mqtt_message(update_payload)
+
+    assert processor._classify_snapshot.await_count == 2
+
+
+def test_classification_decided_tombstone_expires_after_ttl():
+    processor = EventProcessor(MagicMock())
+
+    with patch("app.services.event_processor.time.monotonic", return_value=1000.0):
+        processor._mark_classification_decided_tombstone("evt-ttl")
+        assert processor._is_classification_decided_tombstone_active("evt-ttl") is True
+
+    expired_at = 1000.0 + CLASSIFICATION_DECIDED_TOMBSTONE_TTL_SECONDS + 1.0
+    with patch("app.services.event_processor.time.monotonic", return_value=expired_at):
+        assert processor._is_classification_decided_tombstone_active("evt-ttl") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Outcome

Short visits that Frigate reports as `bird` but the classifier cannot identify are no longer classified twice and no longer produce a misleading `snapshot unavailable after retry` drop. The terminal `end` handler now distinguishes "the initial ingest never produced a classification" from "the initial ingest classified this and the filter rejected it".

## Scope

- **Included:**
  - `CLASSIFICATION_DECIDED_TOMBSTONE_TTL_SECONDS` (600 s) and a `_classification_decided_tombstones` map, mirroring the existing `_false_positive_tombstones` idiom.
  - The tombstone is marked at the `filter_{reason}` drop site, i.e. only where classification succeeded and the filter deliberately rejected the result.
  - The `type=end` branch checks the tombstone before setting `recovering_terminal_event`, records `end_event_classification_already_decided`, and returns.
  - Tests for the skip, for `update` still reclassifying, and for TTL expiry.
- **Explicitly excluded:** the `update` recovery path (a live event can legitimately clear the threshold on a later frame, so it still reclassifies); snapshot retry budgets; any change to the confidence thresholds themselves.
- **Issue or roadmap outcome:** Fixes the real cause behind #133.

## Verification

Diagnosed against 72 h of logs from a live deployment. Of 101 terminal recoveries, 84 succeeded and 17 dropped — and **all 17 drops were preceded by `reason=low_confidence`**, not by a late snapshot:

```text
18:48:14  Processing MQTT event  type=new
18:48:14  Below minimum confidence  min=0.5 score=0.0548   (x5)
18:48:14  Dropping MQTT event after classification filter  reason=low_confidence
18:48:15  Retrying missing initial detection from final Frigate event state
18:48:15  Failed to fetch snapshot  status=404
18:48:17  Failed to fetch snapshot  status=404
18:48:17  Recording-frame fallback: no recording clip  error=clip_not_retained
18:48:17  Skipping MQTT event - snapshot unavailable after retry
```

The snapshot was present at `new` (classification produced five scored candidates) and only 404s afterwards, once the event has ended and Frigate has discarded it. A second event was observed being fully classified twice, returning different junk both times (`Ambystoma gracile` 0.154, then `Pontederia crassipes` 0.078) — a redundant inference this change removes.

```text
backend $ .venv/bin/python -m pytest -q
-> 1827 passed, 44 skipped in 56.84s

repo root $ ruff check .
-> All checks passed!

repo root $ ruff format --check .
-> 395 files already formatted

backend $ .venv/bin/python scripts/docs_consistency_check.py
-> Documentation consistency check passed. Validated routes: 168
```

## Data integrity and risk

- Detection-history or configuration risk: none. No schema or data change, and the gate can only *skip* work that always failed. Recovery for events that genuinely never reached the classifier is untouched and covered by the existing `test_end_event_recovers_detection_when_initial_ingest_created_no_row`.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: the tombstone is in-process and expires after 600 s. A restart between `new` and `end` simply loses it and falls back to today's behaviour, so the failure mode is the current one rather than a worse one.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.