### PR TITLE
Report the real reason when no bird crop detector can run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Diagnostics now admit when no bird crop detector is installed.** Choosing the accurate detector
+  tier falls back to the fast detector, but the reported reason was `fallback_fast` even when that
+  fallback was itself missing — so health output and diagnostics bundles described a working
+  fallback while cropping was off entirely and full frames were being classified. The reason now
+  reports `not_installed` or `config_missing` whenever the resolved detector cannot run.
+
 - **Manual reclassification no longer rejects good fleeting sightings or applies unsafe weak
   replacements.** Retained recordings use Frigate boxes only at timestamps backed by `path_data`,
   so one stale box cannot repeatedly classify background after the bird has moved. A video

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,11 +73,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
-- **Diagnostics now admit when no bird crop detector is installed.** Choosing the accurate detector
-  tier falls back to the fast detector, but the reported reason was `fallback_fast` even when that
-  fallback was itself missing — so health output and diagnostics bundles described a working
-  fallback while cropping was off entirely and full frames were being classified. The reason now
-  reports `not_installed` or `config_missing` whenever the resolved detector cannot run.
+- **Diagnostics no longer report a crop-detector fallback that did not happen.** Choosing the
+  accurate detector tier falls back to the fast detector, but the reported reason stayed
+  `fallback_fast` even when that fallback was itself missing, contradicting the `installed`,
+  `healthy`, and `enabled_for_runtime` fields reported beside it. The reason now reports
+  `not_installed` or `config_missing` whenever the resolved detector cannot run. Per-model crop
+  policy is unchanged.
 
 - **Manual reclassification no longer rejects good fleeting sightings or applies unsafe weak
   replacements.** Retained recordings use Frigate boxes only at timestamps backed by `path_data`,

--- a/backend/app/services/model_manager.py
+++ b/backend/app/services/model_manager.py
@@ -890,6 +890,10 @@ class ModelManager:
         config_path = os.path.join(model_dir, "model_config.json")
         installed = os.path.exists(model_path)
         healthy = installed and os.path.exists(config_path)
+        # A tier fallback is only worth reporting when the artifact it fell back to
+        # can actually run. Letting the override win over an unhealthy artifact
+        # reports a working fallback while cropping is in fact off entirely.
+        resolved_reason = "ready" if healthy else ("config_missing" if installed else "not_installed")
         return {
             "model_id": model_id,
             "artifact_kind": str(meta.get("artifact_kind") or "crop_detector"),
@@ -898,7 +902,7 @@ class ModelManager:
             "installed": installed,
             "healthy": healthy,
             "enabled_for_runtime": healthy,
-            "reason": reason_override or ("ready" if healthy else ("config_missing" if installed else "not_installed")),
+            "reason": reason_override if (reason_override and healthy) else resolved_reason,
             "model_path": model_path,
             "labels_path": labels_path,
             "model_config_path": config_path,

--- a/backend/tests/test_model_manager_download.py
+++ b/backend/tests/test_model_manager_download.py
@@ -893,6 +893,37 @@ def test_exact_crop_detector_spec_never_falls_back_to_fast(monkeypatch, tmp_path
     assert exact_spec["reason"] == "not_installed"
 
 
+def test_crop_detector_spec_reports_missing_fallback_rather_than_masking_it(monkeypatch, tmp_path):
+    """A fallback that is itself uninstalled must not be reported as a healthy fallback.
+
+    Selecting the accurate tier falls back to the fast detector. When neither is
+    installed, cropping is off entirely, and the reason has to say so instead of
+    reporting ``fallback_fast`` as though the fallback had succeeded.
+    """
+    monkeypatch.setattr("app.services.model_manager.MODELS_DIR", str(tmp_path))
+
+    spec = ModelManager().get_crop_detector_spec("accurate")
+
+    assert spec["model_id"] == "bird_crop_detector"
+    assert spec["resolved_tier"] == "fast"
+    assert spec["installed"] is False
+    assert spec["enabled_for_runtime"] is False
+    assert spec["reason"] == "not_installed"
+
+
+def test_crop_detector_spec_reports_incomplete_fallback_install(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.services.model_manager.MODELS_DIR", str(tmp_path))
+    fast_dir = tmp_path / "bird_crop_detector"
+    fast_dir.mkdir(parents=True)
+    (fast_dir / "model.onnx").write_bytes(b"fast")
+
+    spec = ModelManager().get_crop_detector_spec("accurate")
+
+    assert spec["installed"] is True
+    assert spec["enabled_for_runtime"] is False
+    assert spec["reason"] == "config_missing"
+
+
 def test_exact_crop_detector_spec_rejects_classifier():
     with pytest.raises(ValueError, match="Unknown crop detector"):
         ModelManager().get_crop_detector_spec_by_model_id("mobilenet_v2_birds")


### PR DESCRIPTION
## Outcome

The crop-detector spec no longer reports a successful tier fallback when the artifact it fell back to cannot run. Health output and diagnostics bundles currently emit self-contradictory state — `installed: false`, `healthy: false`, `enabled_for_runtime: false`, alongside `reason: "fallback_fast"` — which reads as a working fast-tier fallback when no detector is present at all.

## Scope

- **Included:** `_build_crop_detector_spec` applies its `reason_override` only when the resolved artifact is healthy, so a missing or incomplete install reports `not_installed` / `config_missing`. Two tests covering both degraded states.
- **Explicitly excluded:** crop policy, tier fallback order, auto-install, log levels, and the Settings UI.
- **Issue or roadmap outcome:** none closed. This is a diagnostic-accuracy fix only.

## Verification

Observed in a user diagnostics bundle attached to #131:

```text
selected_tier:       "accurate"
resolved_tier:       "fast"
installed:           false
healthy:             false
enabled_for_runtime: false
reason:              "fallback_fast"   <- contradicts the three fields above
load_error:          null
```

Scope note, to avoid overstating this: the per-model crop policy in `docs/plans/2026-07-16-model-crop-policy.md` is deliberate and evidence-based, and that reporter's active model (`convnext_large_inat21`) has a validated crop policy of **Off**. Their absent detector therefore does not affect classification; it affects high-quality thumbnail generation only. This PR does not change any crop behaviour and does not claim a classification impact — it only stops the reason field from contradicting the state fields beside it.

The narrower case still worth surfacing separately: a model whose validated policy is **On** (`mobilenet_v2_birds`, `small_birds`, `medium_birds`, `flexivit_il_all`) running on a host with no detector installed will silently classify uncropped, against its measured policy. That needs its own change and is not attempted here.

```text
backend $ .venv/bin/python -m pytest tests/test_model_manager_download.py tests/test_bird_crop_service.py tests/test_model_validation_probe.py -q
-> 95 passed

backend $ .venv/bin/python -m pytest -q
-> 1826 passed, 44 skipped in 56.81s

repo root $ ruff check .
-> All checks passed!

repo root $ ruff format --check .
-> 395 files already formatted
```

The pre-existing `test_exact_crop_detector_spec_never_falls_back_to_fast`, which asserts `fallback_fast` when the fast detector *is* healthy, still passes — the override is preserved for the case it was written for.

## Data integrity and risk

- Detection-history or configuration risk: none. One diagnostic string changes; no runtime, schema, or classification behaviour is affected. `installed`, `healthy`, and `enabled_for_runtime` already carried the truth and are unchanged.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: `classifier.crop_detector.reason` should read `not_installed` on any instance where the detector is absent.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.