### PR TITLE
Offer only species filters the events query can match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Species in the Events filter no longer show "No events yet".** When a detection stored a
+  scientific name but no taxonomy id, the filter list resolved an id live and offered it as the
+  filter value. No stored row carried that id, so selecting the species matched nothing and the
+  page reported zero events for a species that plainly had some. The filter now offers a value the
+  events query can actually match.
+
 - **Manual reclassification no longer rejects good fleeting sightings or applies unsafe weak
   replacements.** Retained recordings use Frigate boxes only at timestamps backed by `path_data`,
   so one stale box cannot repeatedly classify background after the bird has moved. A video

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -442,7 +442,11 @@ async def get_event_filters(
                         canonical = await taxonomy_service.get_canonical_english_name(t_id, db=db)
                         if canonical:
                             com_name = canonical
-                value = f"taxa:{t_id}" if t_id else display_name
+                # The filter value has to be something the events query can match. A
+                # taxa id resolved live from taxonomy is fine for naming and
+                # localisation, but only the stored id is guaranteed to exist on a
+                # row, so an unstored id would offer a species that returns nothing.
+                value = f"taxa:{taxa_id}" if taxa_id else display_name
                 return EventFilterSpecies(
                     value=value,
                     display_name=sci_name or display_name,

--- a/backend/tests/test_events_unknown_filter_api.py
+++ b/backend/tests/test_events_unknown_filter_api.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -393,3 +394,42 @@ def test_detection_updated_payload_masks_hidden_noncanonical_labels():
     assert payload["scientific_name"] is None
     assert payload["common_name"] is None
     assert payload["taxa_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_events_filters_only_offer_species_that_match_events(client: httpx.AsyncClient):
+    """A species offered as a filter option must return its own events.
+
+    Rows can store a scientific name without a taxa id. Taxonomy resolved live
+    while building the options may supply an id that no row carries, and the
+    events query cannot match it, so the option would return nothing.
+    """
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+
+    event_id = f"evt-{uuid.uuid4().hex[:8]}"
+    display_name = f"Old World Rats (Rattus rattus {uuid.uuid4().hex[:4]})"
+    await _insert_detection(event_id, display_name, "cam1", scientific_name="Rattus rattus", taxa_id=None)
+
+    resolved = {"scientific_name": "Rattus rattus", "common_name": "Old World Rats", "taxa_id": 4816}
+
+    try:
+        with (
+            patch("app.routers.events.taxonomy_service.get_names", AsyncMock(return_value=resolved)),
+            patch(
+                "app.routers.events.taxonomy_service.get_canonical_english_name",
+                AsyncMock(return_value="Old World Rats"),
+            ),
+        ):
+            filters_resp = await client.get("/api/events/filters", params={"force_refresh": "true"})
+
+        assert filters_resp.status_code == 200
+        offered = [item for item in filters_resp.json()["species"] if item["value"] == display_name]
+        assert offered, "species with no stored taxa id was not offered by its matchable display name"
+
+        events_resp = await client.get("/api/events", params={"species": offered[0]["value"], "limit": 20})
+        assert events_resp.status_code == 200
+        assert len(events_resp.json()) == 1
+    finally:
+        await _delete_detection(event_id)
+        _event_filters_cache.clear()


### PR DESCRIPTION
## Outcome

Selecting a species in the Events filter now returns that species' events. Previously a species could be listed in the dropdown and then report `0 total` / "No events yet", which is what #131 reported.

## Scope

- **Included:** `/api/events/filters` uses the **stored** taxa id for a species option's `value`, falling back to the display name when no row carries one. Live taxonomy resolution still supplies scientific/common names and localisation. One regression test asserting an offered filter option returns its own events.
- **Explicitly excluded:** blocklist matching (verified correct — see below), the empty-state copy, and species search/browse.
- **Issue or roadmap outcome:** fixes the reproducible half of #131.

## Verification

Reproduced from the reporter's screenshots, which show the Events species dropdown listing `Old World Rats (Rattus rattus)` while the page reads `0 total`.

Root cause: `get_unique_species_with_taxonomy()` builds the option list from stored detections, then each option is enriched with `t_id = taxa_id or taxonomy.get("taxa_id")` and emitted as `value = f"taxa:{t_id}"`. When a row stores a scientific name but no taxa id, the live lookup supplies an id that exists nowhere in the data. The events query matches `COALESCE(d.taxa_id, tc_filter.taxa_id) = ?`, and with no stored id and no `taxonomy_cache` row to bridge it, nothing matches.

Failing reproduction before the fix:

```text
OFFERED value='taxa:4816' display='Rattus rattus'
EVENTS for that value: 0
AssertionError: filter value 'taxa:4816' was offered but returns no events
```

After:

```text
OFFERED value='Old World Rats (Rattus rattus)' display='Rattus rattus'
EVENTS for that value: 1
```

The new test was confirmed to fail on `dev` and pass with the change.

```text
backend $ .venv/bin/python -m pytest tests/test_events_unknown_filter_api.py -q
-> 10 passed

backend $ .venv/bin/python -m pytest -q
-> 1825 passed, 44 skipped in 54.15s

repo root $ ruff check .
-> All checks passed!

repo root $ ruff format --check .
-> 395 files already formatted
```

Separately verified while diagnosing #131, and **not** changed here: the blocklist is matching correctly. A structured entry of common name `Old World Rats` / scientific name `Rattus` does match a detection of `Rattus rattus`, because both sides reduce to `old world rats`. The reporter's suspicion of a genus-vs-species naming mismatch was not the cause.

## Data integrity and risk

- Detection-history or configuration risk: none. Read path only; no schema, ingest, or classification change. The option list itself is unchanged — only the `value` used to filter by it.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: pick a species in the Events filter that previously showed "No events yet" and confirm its events now load. Options for species that already store a taxa id keep their existing `taxa:` values.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.