### PR TITLE
Merge duplicate species rows in the blocking picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The species picker no longer lists the same species twice.** Blocking a species could show two
+  identical rows, both marked as already added, when a taxonomy id resolved for the classifier
+  label but not the stored detection label. Matching species are now merged on their scientific
+  name, keeping whichever record carries the richer taxonomy.
+
 - **Manual reclassification no longer rejects good fleeting sightings or applies unsafe weak
   replacements.** Retained recordings use Frigate boxes only at timestamps backed by `path_data`,
   so one stale box cannot repeatedly classify background after the bird has moved. A video

--- a/backend/app/routers/species.py
+++ b/backend/app/routers/species.py
@@ -247,12 +247,16 @@ async def _lookup_species_search_taxonomy(
 
 
 def _species_search_result_key(result: dict) -> str:
-    taxa_id = result.get("taxa_id")
-    if taxa_id is not None:
-        return f"taxa:{taxa_id}"
+    # Scientific name is the stable identity across the sources this endpoint
+    # searches. Keying on taxa id first split one species into two rows whenever
+    # the id resolved for the classifier label but not the stored detection label,
+    # or the reverse.
     scientific_name = str(result.get("scientific_name") or "").strip()
     if scientific_name:
         return f"sci:{scientific_name.casefold()}"
+    taxa_id = result.get("taxa_id")
+    if taxa_id is not None:
+        return f"taxa:{taxa_id}"
     common_name = str(result.get("common_name") or "").strip()
     if common_name:
         return f"common:{common_name.casefold()}"

--- a/backend/tests/test_species_search_api.py
+++ b/backend/tests/test_species_search_api.py
@@ -264,3 +264,37 @@ async def test_species_search_includes_cached_non_classifier_taxa_for_blocking(c
             await db.execute("DELETE FROM detections WHERE taxa_id = ?", (taxa_id,))
             await db.execute("DELETE FROM taxonomy_cache WHERE taxa_id = ?", (taxa_id,))
             await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_species_search_merges_same_species_when_only_one_source_has_a_taxa_id(
+    client: httpx.AsyncClient,
+):
+    """One species must not appear twice because a taxa id resolved for only one source.
+
+    Classifier labels and stored detection labels are both searched. When the same
+    taxon resolves with a taxa id from one and without from the other, the picker
+    showed two identical rows, both marked as already blocked.
+    """
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+
+    resolved = {
+        "Rattus": ("Rattus", "Old World Rats", 44436),
+        "Old World Rats (Rattus rattus)": ("Rattus", "Old World Rats", None),
+    }
+
+    async def fake_lookup(_db, *, label: str, lang: str):
+        return resolved[label]
+
+    with (
+        patch("app.routers.species.get_classifier", return_value=_MockClassifier(list(resolved))),
+        patch("app.routers.species._lookup_species_search_taxonomy", AsyncMock(side_effect=fake_lookup)),
+    ):
+        response = await client.get("/api/species/search?q=rat&limit=20")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert len(payload) == 1, f"expected one merged species, got {[p['display_name'] for p in payload]}"
+    assert payload[0]["scientific_name"] == "Rattus"
+    assert payload[0]["taxa_id"] == 44436


### PR DESCRIPTION
## Outcome

Searching for a species to block no longer shows the same species twice. Reported alongside #131, whose screenshot shows `Old World Rats / Rattus` listed twice, both badged **ADDED**.

## Scope

- **Included:** `_species_search_result_key` keys on scientific name before taxa id, so records for one taxon merge. `_pick_preferred_species_search_result` already keeps the richer record, so the surviving row retains its taxa id. One regression test.
- **Explicitly excluded:** blocklist matching semantics, the picker UI, and species search ranking.
- **Issue or roadmap outcome:** fixes the duplicate-entry half of #131.

## Verification

`/api/species/search` searches classifier labels *and* stored detection labels. Both are resolved through `_lookup_species_search_taxonomy`, which can return a taxa id for one and not the other. Because the dedup key checked taxa id first, the two records keyed differently and both survived:

```text
with taxa_id   : taxa:44436
without taxa_id: sci:rattus
same key?       False
```

Failing reproduction before the fix:

```text
AssertionError: expected one merged species, got ['Rattus', 'Rattus']
assert 2 == 1
```

```text
backend $ .venv/bin/python -m pytest tests/test_species_search_api.py -q
-> 8 passed

backend $ .venv/bin/python -m pytest -q
-> 1825 passed, 44 skipped in 54.34s

repo root $ ruff check .
-> All checks passed!

repo root $ ruff format --check .
-> 395 files already formatted
```

Unrelated observation while verifying, **not** introduced here: `pytest tests/ -k "species or blocked"` fails `test_species_search_deduplicates_classifier_alias_labels_to_one_canonical_species` and `test_species_search_hides_noncanonical_model_labels` on clean `dev` as well. Both pass in a full run and when their file runs alone, so it is test-order pollution that predates this branch. Worth its own fix.

## Data integrity and risk

- Detection-history or configuration risk: none. Read path only; no schema, ingest, or stored-blocklist change. Existing blocklist entries are untouched.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: search a blocked species in Settings and confirm one row rather than two.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.