### PR TITLE
Scope the events-filter test taxonomy mock to its own row

### DIFF
--- a/backend/tests/test_events_unknown_filter_api.py
+++ b/backend/tests/test_events_unknown_filter_api.py
@@ -413,9 +413,14 @@ async def test_events_filters_only_offer_species_that_match_events(client: httpx
 
     resolved = {"scientific_name": "Rattus rattus", "common_name": "Old World Rats", "taxa_id": 4816}
 
+    async def fake_get_names(name: str):
+        # Only this row resolves. Resolving every label would give unrelated rows
+        # left by other tests the same taxa id, collapsing them into one option.
+        return dict(resolved) if name == display_name else {}
+
     try:
         with (
-            patch("app.routers.events.taxonomy_service.get_names", AsyncMock(return_value=resolved)),
+            patch("app.routers.events.taxonomy_service.get_names", AsyncMock(side_effect=fake_get_names)),
             patch(
                 "app.routers.events.taxonomy_service.get_canonical_english_name",
                 AsyncMock(return_value="Old World Rats"),


### PR DESCRIPTION
## Outcome

`test_events_filters_only_offer_species_that_match_events` (added in #137) no longer depends on test ordering. It passed in a full run and in its own file, but failed under a partial selection such as `pytest tests/ -k "species or blocked"`.

## Scope

- **Included:** the test's `taxonomy_service.get_names` mock resolves only the row the test inserts, instead of returning the same taxonomy for every label.
- **Explicitly excluded:** production code (unchanged), and the separate test-isolation defect described below.
- **Issue or roadmap outcome:** none; test-quality follow-up to #137.

## Verification

The mock returned one taxonomy for every label, so detections left by other tests in the same run were all assigned `taxa_id 4816`. The options dedup keys on taxa id, so they collapsed into a single option and the row under test was removed from the list:

```text
AssertionError: species with no stored taxa id was not offered by its matchable display name
assert []
```

```text
backend $ .venv/bin/python -m pytest tests/ -q -k "species or blocked"
-> before: 3 failed, 92 passed
-> after:  2 failed, 93 passed   (the 2 remaining are pre-existing, see below)

backend $ .venv/bin/python -m pytest tests/test_events_unknown_filter_api.py -q
-> 10 passed

backend $ .venv/bin/python -m pytest -q
-> 1819 passed, 44 skipped in 53.48s

repo root $ ruff check .           -> All checks passed!
repo root $ ruff format --check .  -> 395 files already formatted
```

No `CHANGELOG.md` entry: this changes a test only, with no user-visible behaviour.

### Pre-existing test-isolation defect, not addressed here

`test_species_search_deduplicates_classifier_alias_labels_to_one_canonical_species` and `test_species_search_hides_noncanonical_model_labels` still fail under the same partial selector on clean `dev`. Both pick up an unexpected genus row:

```text
{'id': 'Parus', 'scientific_name': 'Parus', 'common_name': 'Great Tits and Allies'}
```

That row lives in `backend/data/speciesid.db`, a developer database dated 23 July, not in the temp database `tests/conftest.py` configures via `DB_PATH`. Under some collection orders these tests read the local development database, which conflicts with CLAUDE.md §2 ("never depend on a developer machine"). Worth its own fix, since it makes results depend on whatever is on the machine running them.

## Data integrity and risk

- Detection-history or configuration risk: none; test-only change.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: not applicable.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.