### PR TITLE
Add the 2.17.0 release notes

### DIFF
--- a/docs/releases/v2.17.0.md
+++ b/docs/releases/v2.17.0.md
@@ -1,0 +1,59 @@
+# YA-WAMF 2.17.0
+
+YA-WAMF 2.17.0 gives you a complete way to add sightings from your own photos or videos and makes
+reclassification much safer for brief, distant, or partially tracked birds. It also keeps model and
+accelerator choices honest for the exact image and hardware running your feeder.
+
+## What's new
+
+- **Add an observation from a photo or video.** The new **Observe → Add observation** page retains
+  the original media locally, classifies it through the normal full-frame, crop, or video path, and
+  lets you confirm the species before it appears in history. Upload progress survives a browser
+  reload, duplicate media is rejected, and failures can retry without another upload.
+- **Place uploaded sightings on the map.** YA-WAMF reads valid EXIF GPS coordinates when available.
+  If a photo has no location, you can place a pin, enter coordinates, leave the location empty, or
+  clear it before saving.
+- **Use acceleration only after it is proved on this installation.** The setup wizard, Settings,
+  Model Manager, and automatic provider selection now share the same image-aware hardware evidence.
+  Providers appear in measured preference order and are offered only when the current model, image,
+  runtime, and visible hardware support them.
+
+## Smoother everyday use
+
+- **Reclassification handles fleeting birds more fairly.** Video analysis looks for recurring,
+  time-separated evidence instead of requiring a bird to fill most of a long visit. Nearby frames
+  cannot manufacture extra votes, conflicting full-frame and crop results still abstain, and weak
+  evidence cannot replace an existing identification.
+- **Cached media remains useful after Frigate retention expires.** Reclassification prefers a
+  playable retained recording or event clip. If video cannot produce a safe result, the same job
+  visibly tries the best retained snapshot and explains when the identification stays unchanged.
+- **Model choices are simpler and safer.** Four redundant comparison models no longer appear in
+  current setup or Model Manager flows. If one was previously active, YA-WAMF moves to an installed
+  ConvNeXt Large model when available or the bundled fallback, while leaving the old files in place
+  for rollback.
+
+## Before you update
+
+- **Back up `/config` and `/data`, then update normally.** This release adds idempotent database
+  migrations for manual-observation drafts, optional observation coordinates, and retained video
+  evidence diagnostics. YA-WAMF applies them automatically during startup; keep the container
+  running until the startup progress view reports that the backend is ready.
+- **Keep the unsuffixed tag unless you intentionally use a smaller runtime image.** `latest` and
+  `v2.17.0` remain the full compatibility build. Read the
+  [hardware-acceleration guide](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/blob/v2.17.0/docs/setup/hardware-acceleration.md)
+  before switching to `v2.17.0-cpu`, `v2.17.0-intel`, or `v2.17.0-cuda`; change only the image tag
+  so the existing `/config`, `/data`, models, and provider preference remain intact.
+
+## Good to know
+
+- **Uploaded media stays on your YA-WAMF storage.** It is not dependent on Frigate retention.
+  Location is optional, and coordinates are saved only when you confirm an EXIF value or map pin.
+- **Hardware validation is deliberately installation-specific.** A GPU or NPU that is visible but
+  has not passed the current model and runtime checks remains unavailable until validation succeeds.
+  This avoids treating an older result from another image, artifact, or runtime as proof.
+- **The new video rule remains conservative.** A source still needs three independent evaluated
+  moments, at least two confident votes, and 60% agreement among confident votes. When trustworthy
+  image representations disagree, YA-WAMF keeps the existing identification.
+
+See the [full changelog](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/blob/v2.17.0/CHANGELOG.md)
+for the complete technical record.


### PR DESCRIPTION
## Outcome

`docs/releases/v2.17.0.md` now exists alongside the 2.13.0–2.16.0 notes. It was written but never committed, so it existed only as an untracked local file.

## Scope

- **Included:** the 2.17.0 release notes, unmodified apart from the filename.
- **Explicitly excluded:** any edit to the content, the `CHANGELOG.md` version headings, and tagging or publishing the release.
- **Issue or roadmap outcome:** none.

## Verification

Found while clearing filename-collision copies from the working tree (`… 2.md`, `… 3.md` duplicates created by folder sync). Every other such file was either byte-identical to its original or a stale older copy, but this one had **no original**: `v2.17.0.md` did not exist, so the duplicate was the only copy of the notes. Content is unchanged; only the filename was corrected.

The notes match the Unreleased section of `CHANGELOG.md` (manual observations, EXIF/map placement, installation-specific accelerator validation, the conservative video-consensus rule, and the retired comparison models), and follow the human-first standard in `docs/development/releasing.md`.

```text
backend $ .venv/bin/python scripts/docs_consistency_check.py
-> Documentation consistency check passed. Validated routes: 168
```

The `v2.17.0` GitHub links inside the notes point at a tag that does not exist yet. That matches how the earlier release notes are written — the links resolve once the tag is created — and the docs gate checks local links, which pass.

## Data integrity and risk

- Detection-history or configuration risk: none; documentation only.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none. The notes contain no host names, tokens, or runtime data.
- Deployment verification, if deployed: not applicable.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.