### PR TITLE
Pin that a blocked species cannot become Unknown Bird

### DIFF
--- a/backend/tests/test_detection_service_filter.py
+++ b/backend/tests/test_detection_service_filter.py
@@ -80,3 +80,39 @@ def test_filter_and_label_rejects_structured_blocked_species_by_common_name():
         assert reason == "blocked_label"
     finally:
         _restore_classification_settings(saved)
+
+
+def test_filter_and_label_blocks_species_scoring_inside_the_unknown_catchall_band():
+    """A blocked species must not be saved, including under the Unknown Bird catch-all.
+
+    Scores between min_confidence and threshold are saved as an Unknown Bird
+    catch-all rather than dropped. The blocked-species check therefore has to run
+    before that gate, otherwise a blocked species re-enters history under a
+    different name.
+    """
+    service = DetectionService(MagicMock())
+    saved = _with_classification_settings(
+        blocked_labels=["Grey Squirrel"],
+        blocked_species=[],
+        min_confidence=0.5,
+        threshold=0.7,
+    )
+    try:
+        # Control: an unblocked label in the same band is saved as Unknown Bird,
+        # so the catch-all really is reachable at this score.
+        allowed, allowed_reason = service.filter_and_label(
+            classification={"label": "Some Bird", "score": 0.6, "index": 1},
+            frigate_event="evt-catchall-allowed",
+        )
+        assert allowed is not None
+        assert allowed["label"] == "Unknown Bird"
+        assert allowed_reason == "unknown_catchall"
+
+        blocked, blocked_reason = service.filter_and_label(
+            classification={"label": "Grey Squirrel", "score": 0.6, "index": 1},
+            frigate_event="evt-catchall-blocked",
+        )
+        assert blocked is None
+        assert blocked_reason == "blocked_label"
+    finally:
+        _restore_classification_settings(saved)


### PR DESCRIPTION
## Outcome

The ordering that stops a blocked species re-entering history as "Unknown Bird" is now covered by a test. No behaviour changes.

## Scope

- **Included:** one regression test in `backend/tests/test_detection_service_filter.py`.
- **Explicitly excluded:** all production code. See the investigation note below for why nothing was changed.
- **Issue or roadmap outcome:** none.

## Verification

This started as an investigation into blocked labels being counted ahead of the confidence gate. A user's diagnostics bundle showed `filter_blocked_label: 3106` against `filter_low_confidence: 361`, with the most recent blocked drop being `Perisoreus canadensis` at score `0.137` — far below that install's `0.5` floor. The initial reading was that low-confidence noise is being attributed to the blocklist, and that the confidence gate should run first.

**That change would be a data-integrity regression.** `filter_and_label` saves scores between `min_confidence` and `threshold` as an Unknown Bird catch-all rather than dropping them:

```text
blocked label   @ 0.60 -> dropped               (reason blocked_label)
unblocked label @ 0.60 -> SAVED as Unknown Bird (reason unknown_catchall)
```

So if the blocked check moved after the confidence gate, a blocked species scoring inside that band would be written to history under a different name. The current ordering is correct and load-bearing, and the counter behaviour is a consequence of it rather than a defect. The per-drop detail is not lost either — `last_drop` already records the label and score, which is how the 0.137 value above was read.

Nothing covered this. The existing `test_filter_and_label_rejects_structured_blocked_species_by_common_name` scores `0.92`, above the threshold, so it passes with or without correct ordering.

The new test asserts the control case (an unblocked label in the same band *is* saved as Unknown Bird, proving the band is reachable) and then that a blocked label at the same score is still dropped. Temporarily removing the early block check makes it fail exactly as intended:

```text
E  AssertionError: assert {'label': 'Unknown Bird', 'score': 0.6, 'index': 1,
                           'source': 'low_confidence_catchall'} is None
```

```text
backend $ .venv/bin/python -m pytest tests/test_detection_service_filter.py -q
-> 4 passed

backend $ .venv/bin/python -m pytest -q
-> 1820 passed, 44 skipped in 59.82s

repo root $ ruff check .           -> All checks passed!
repo root $ ruff format --check .  -> 395 files already formatted
```

No `CHANGELOG.md` entry: test-only, with no user-visible behaviour change.

## Data integrity and risk

- Detection-history or configuration risk: none; the change is a test. It strengthens the §1 guarantee that a blocked species never reaches detection history.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: not applicable.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.