### PR TITLE
Assert species-search results by species, not payload size

### DIFF
--- a/backend/tests/test_species_search_api.py
+++ b/backend/tests/test_species_search_api.py
@@ -182,12 +182,15 @@ async def test_species_search_deduplicates_classifier_alias_labels_to_one_canoni
 
         assert response.status_code == 200, response.text
         payload = response.json()
-        assert len(payload) == 1
-        assert payload[0]["id"] == "Parus major"
-        assert payload[0]["scientific_name"] == "Parus major"
-        assert payload[0]["common_name"] == "Great Tit"
-        assert payload[0]["display_name"] == "Parus major"
-        assert payload[0]["taxa_id"] == taxa_id
+        # Assert about the species under test rather than the size of the whole
+        # payload: taxonomy cached by earlier tests can also match this query.
+        matches = [item for item in payload if item["scientific_name"] == "Parus major"]
+        assert len(matches) == 1, f"aliases did not collapse to one species: {payload}"
+        assert matches[0]["id"] == "Parus major"
+        assert matches[0]["common_name"] == "Great Tit"
+        assert matches[0]["display_name"] == "Parus major"
+        assert matches[0]["taxa_id"] == taxa_id
+        assert not [item for item in payload if item["id"] in set(labels)]
     finally:
         async with get_db() as db:
             await db.execute("DELETE FROM taxonomy_cache WHERE taxa_id = ?", (taxa_id,))
@@ -210,9 +213,12 @@ async def test_species_search_hides_noncanonical_model_labels(client: httpx.Asyn
 
     assert response.status_code == 200, response.text
     payload = response.json()
-    assert len(payload) == 1
-    assert payload[0]["id"] == "Great Tit"
-    assert payload[0]["display_name"] == "Great Tit"
+    # Assert about these labels rather than the size of the whole payload:
+    # taxonomy cached by earlier tests can also match this query.
+    ids = [item["id"] for item in payload]
+    assert "Great Tit" in ids
+    assert "Great tit and allies" not in ids
+    assert "Life (life)" not in ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Outcome

`test_species_search_deduplicates_classifier_alias_labels_to_one_canonical_species` and `test_species_search_hides_noncanonical_model_labels` no longer depend on test ordering.

## Scope

- **Included:** both tests assert about the species and labels they are about, instead of the size of the entire search payload.
- **Explicitly excluded:** production code, and the wider question of which test seeds the extra taxonomy row.
- **Issue or roadmap outcome:** none; test-quality follow-up to #139.

## Verification

Both tests query `/api/species/search?q=great` and asserted `len(payload) == 1`, which silently assumes nothing else in the database matches "great". A `taxonomy_cache` row for the genus `Parus`, common name **"Great** Tits and Allies", is present by the time they run under some selections, so the payload legitimately holds two entries:

```text
assert 2 == 1
 +  where 2 = len([{'id': 'Parus major', 'scientific_name': 'Parus major', ...},
                   {'id': 'Parus', 'common_name': 'Great Tits and Allies', ...}])
```

```text
backend $ .venv/bin/python -m pytest tests/ -q -k "species or blocked"
-> before: 2 failed, 94 passed
-> after:  96 passed

backend $ .venv/bin/python -m pytest tests/test_species_search_api.py -q
-> 8 passed

backend $ .venv/bin/python -m pytest -q
-> 1820 passed, 44 skipped in 58.69s

repo root $ ruff check .           -> All checks passed!
repo root $ ruff format --check .  -> 395 files already formatted
```

The assertions still catch what they were written for. Aliases that failed to collapse would appear under their raw label ids, which is now asserted against explicitly, and noncanonical labels that stopped being hidden would appear in the id list.

**Correction to #139.** That PR's description said these tests read `backend/data/speciesid.db`, a developer database. That was wrong. The row is created inside the per-run temporary database that `conftest.py` provisions — confirmed by querying the temp database directly after a failing run. `conftest.py` sets `DB_PATH` before collection and the isolation works; the fault was the assertions, not the database wiring.

The remaining open question is which test seeds that genus row. It does not appear when any single candidate file runs alone, nor when either half of the selection runs, so it needs the full set. Worth pinning down separately, since a test that leaves taxonomy rows behind conflicts with CLAUDE.md §2 ("Tests own their fixtures ... and clean up"). These two tests are no longer sensitive to it either way.

No `CHANGELOG.md` entry: test-only, with no user-visible behaviour change.

## Data integrity and risk

- Detection-history or configuration risk: none; test-only change.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: not applicable.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.