### PR TITLE
Stop caching a failed taxonomy lookup as "no such species"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A species no longer loses its common name because a taxonomy lookup failed once.** A timeout,
+  rate limit, or other failure reaching iNaturalist was recorded as "no such species" and cached,
+  so the species kept showing its scientific name alone. Only an answer from iNaturalist that
+  genuinely holds no match is cached now; a failed request is left for the next attempt.
+
 - **The species picker no longer lists the same species twice.** Blocking a species could show two
   identical rows, both marked as already added, when a taxonomy id resolved for the classifier
   label but not the stored detection label. Matching species are now merged on their scientific

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -25,6 +25,13 @@ def _parenthetical_aliases(value: str) -> tuple[Optional[str], Optional[str]]:
     return left, right
 
 
+class TaxonomyLookupUnavailable(Exception):
+    """The taxonomy provider could not be reached or did not return an answer.
+
+    Distinct from the provider answering that it holds no matching taxon.
+    """
+
+
 class TaxonomyService:
     """Service to handle bidirectional scientific <-> common name lookups using iNaturalist."""
 
@@ -78,16 +85,24 @@ class TaxonomyService:
                 lookup_names.append(right)
 
         result = None
+        lookup_unavailable = False
         for name in lookup_names:
-            result = await self._lookup_inaturalist(name)
+            try:
+                result = await self._lookup_inaturalist(name)
+            except TaxonomyLookupUnavailable:
+                lookup_unavailable = True
+                break
             if result:
                 break
 
         if not result:
-            # 4. Save Failure to Cache (to prevent retrying forever)
-            await self._save_to_cache(
-                {"scientific_name": query_name, "common_name": None, "taxa_id": None, "is_not_found": True}, db=db
-            )
+            # 4. Save Failure to Cache (to prevent retrying forever), but only when
+            # iNaturalist actually answered. Recording a provider outage as
+            # "no such species" would withhold the name until something repairs it.
+            if not lookup_unavailable:
+                await self._save_to_cache(
+                    {"scientific_name": query_name, "common_name": None, "taxa_id": None, "is_not_found": True}, db=db
+                )
             return {"scientific_name": query_name, "common_name": None, "taxa_id": None}
 
         # 3. Enrichment Override (eBird)
@@ -174,7 +189,12 @@ class TaxonomyService:
         )
 
     async def _lookup_inaturalist(self, name: str) -> Optional[Dict]:
-        """Query the iNaturalist API."""
+        """Query the iNaturalist API.
+
+        Returns the taxon, or None when iNaturalist answered and holds no match.
+        Raises :class:`TaxonomyLookupUnavailable` when the request itself failed,
+        because "we could not ask" says nothing about whether the taxon exists.
+        """
         try:
             params = {"q": name, "per_page": 1, "locale": "en"}
 
@@ -182,19 +202,20 @@ class TaxonomyService:
             resp = await client.get(self.API_URL, params=params)
             resp.raise_for_status()
             data = resp.json()
-
-            if data.get("total_results", 0) > 0:
-                taxon = data["results"][0]
-                photo = taxon.get("default_photo")
-                thumb = photo.get("square_url") if photo else None
-                return {
-                    "scientific_name": taxon.get("name"),
-                    "common_name": taxon.get("preferred_common_name"),
-                    "taxa_id": taxon.get("id"),
-                    "thumbnail_url": thumb,
-                }
         except Exception as e:
             log.warning("iNaturalist lookup failed", query=name, error=str(e))
+            raise TaxonomyLookupUnavailable(str(e)) from e
+
+        if data.get("total_results", 0) > 0:
+            taxon = data["results"][0]
+            photo = taxon.get("default_photo")
+            thumb = photo.get("square_url") if photo else None
+            return {
+                "scientific_name": taxon.get("name"),
+                "common_name": taxon.get("preferred_common_name"),
+                "taxa_id": taxon.get("id"),
+                "thumbnail_url": thumb,
+            }
 
         return None
 

--- a/backend/tests/test_taxonomy_service.py
+++ b/backend/tests/test_taxonomy_service.py
@@ -2,7 +2,11 @@ import pytest
 import aiosqlite
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, patch
-from app.services.taxonomy.taxonomy_service import TaxonomyService, _parenthetical_aliases
+from app.services.taxonomy.taxonomy_service import (
+    TaxonomyLookupUnavailable,
+    TaxonomyService,
+    _parenthetical_aliases,
+)
 
 
 @pytest.fixture
@@ -184,3 +188,49 @@ async def test_run_background_sync_prefers_stored_scientific_name_for_repair(tax
 
     assert row == ("Cyanistes caeruleus", "Blue Tit", 303)
     await db.close()
+
+
+@pytest.mark.asyncio
+async def test_get_names_does_not_cache_not_found_when_the_lookup_is_unavailable(taxonomy_service):
+    """A provider that cannot answer must not be recorded as "no such species".
+
+    An unreachable or rate-limited provider is unrelated to whether the taxon
+    exists. Caching that as not-found leaves a species without its common name
+    until something else repairs the row.
+    """
+    with (
+        patch.object(taxonomy_service, "_get_from_cache", AsyncMock(return_value=None)),
+        patch.object(
+            taxonomy_service,
+            "_lookup_inaturalist",
+            AsyncMock(side_effect=TaxonomyLookupUnavailable("timeout")),
+        ),
+        patch.object(taxonomy_service, "_save_to_cache", AsyncMock()) as mock_save,
+    ):
+        result = await taxonomy_service.get_names("Dryobates pubescens")
+
+    assert result["scientific_name"] == "Dryobates pubescens"
+    assert result["common_name"] is None
+    mock_save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_inaturalist_raises_when_the_request_fails(taxonomy_service):
+    failing_client = AsyncMock()
+    failing_client.get = AsyncMock(side_effect=RuntimeError("connection reset"))
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=failing_client)):
+        with pytest.raises(TaxonomyLookupUnavailable):
+            await taxonomy_service._lookup_inaturalist("Dryobates pubescens")
+
+
+@pytest.mark.asyncio
+async def test_lookup_inaturalist_returns_none_when_the_provider_reports_no_match(taxonomy_service):
+    response = AsyncMock()
+    response.raise_for_status = lambda: None
+    response.json = lambda: {"total_results": 0, "results": []}
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
+        assert await taxonomy_service._lookup_inaturalist("Nonexistent species") is None


### PR DESCRIPTION
## Outcome

A transient iNaturalist failure no longer leaves a species permanently without its common name. This is the underlying cause behind #132, where `Dryobates pubescens` displays without "Downy Woodpecker".

## Scope

- **Included:** `_lookup_inaturalist` raises `TaxonomyLookupUnavailable` when the request fails, and returns `None` only when iNaturalist answered with no match. `get_names` writes the `is_not_found` cache entry only in the latter case. Three tests.
- **Explicitly excluded:** repairing rows already poisoned (see below — this needs its own change), a user-facing manual common-name override, any negative-cache TTL, and eBird enrichment.
- **Issue or roadmap outcome:** addresses the cause of #132; the feature request itself is untouched.

## Verification

`_lookup_inaturalist` collapsed two unrelated outcomes into `None`:

```python
except Exception as e:
    log.warning("iNaturalist lookup failed", query=name, error=str(e))
return None
```

A timeout, DNS failure, HTTP 500, or rate-limit 429 was indistinguishable from "this taxon does not exist", and the caller then wrote `is_not_found: True` with no expiry.

This is observable on a live deployment. Four rows are cached as not-found, and three are common birds iNaturalist certainly holds:

```text
scientific_name          common_name  taxa_id  last_updated
-----------------------  -----------  -------  --------------------------
Unknown Bird                                   2026-07-05 11:16:43
Dryobates villosus                             2026-07-05 20:34:38
Chloris chloris                                2026-07-16 20:17:34
Troglodytes troglodytes                        2026-07-28 21:06:28
```

Hairy Woodpecker, European Greenfinch and Eurasian Wren, poisoned on three separate dates and still poisoned weeks later. `Dryobates villosus` is the sister species of the bird reported in #132.

### Correction: there is no automatic recovery

An earlier version of this description claimed `run_background_sync` force-refreshes rows with a null `taxa_id` and repairs these. That was wrong on two counts:

- `run_background_sync` is defined at `taxonomy_service.py:318` and called from nowhere in `app/` or `scripts/`.
- The path that *is* wired up, `canonical_identity_repair_service`, calls `get_names(candidate, db=db)` without `force_refresh`, and `get_names` returns a cached `is_not_found` before reaching the network.

So a poisoned row is permanent, which the dates above confirm. That makes this change the only defence rather than a complement to an existing one, and it means **already-poisoned rows still need a separate repair**. Those three species will be saved without a common name the first time they are detected.

```text
backend $ .venv/bin/python -m pytest tests/test_taxonomy_service.py -q
-> 9 passed

backend $ .venv/bin/python -m pytest -q
-> 1823 passed, 44 skipped in 59.69s

repo root $ ruff check .           -> All checks passed!
repo root $ ruff format --check .  -> 395 files already formatted
```

The pre-existing `test_get_names_not_found` still passes unchanged: a provider answering with no match is still cached, which is the behaviour that test was written for.

## Data integrity and risk

- Detection-history or configuration risk: none. No schema or ingest change. The narrow behavioural change is that fewer negative cache rows are written, so a failed lookup is retried later instead of being treated as settled.
- Migration/recovery path, if data changes: none needed here. Existing `is_not_found` rows are untouched and, as established above, are not currently repaired by anything — a follow-up should clear or re-check them.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: no new `is_not_found` rows should appear for species iNaturalist holds. Existing ones persist until a repair is added.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.