### PR TITLE
Re-test cached not-found taxonomy after a retry window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A species recorded as unknown to iNaturalist is checked again instead of staying unknown
+  forever.** A single lookup that found nothing was trusted permanently, so a species that was
+  temporarily unresolvable never regained its common name. Those entries are now re-tested after a
+  week (`TAXONOMY_NOT_FOUND_RETRY_SECONDS`), which also repairs installations already carrying one.
+  Species that resolved successfully are unaffected, however old the entry.
+
 - **The species picker no longer lists the same species twice.** Blocking a species could show two
   identical rows, both marked as already added, when a taxonomy id resolved for the classifier
   label but not the stored detection label. Matching species are now merged on their scientific

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -1,8 +1,9 @@
 import httpx
+import os
 import structlog
 import asyncio
 import aiosqlite
-from typing import Optional, Dict
+from typing import Any, Optional, Dict
 from datetime import datetime
 from app.database import get_db
 from app.config import settings
@@ -10,6 +11,47 @@ from app.services.ebird_service import ebird_service
 from app.utils.enrichment import get_effective_enrichment_settings
 
 log = structlog.get_logger()
+
+
+# A cached "not found" records that one lookup found nothing, which is a weaker
+# claim than the species not existing. Re-test it periodically so a wrong negative
+# cannot withhold a name indefinitely.
+TAXONOMY_NOT_FOUND_RETRY_SECONDS = max(
+    3600.0,
+    float(os.getenv("TAXONOMY_NOT_FOUND_RETRY_SECONDS", str(7 * 24 * 3600))),
+)
+
+
+def _negative_entry_expired(last_updated: Any, *, now: Optional[datetime] = None) -> bool:
+    """Whether a cached not-found result is old enough to re-test.
+
+    An unreadable or missing timestamp counts as expired: the cost of one extra
+    lookup is smaller than withholding a species name forever.
+    """
+    if not last_updated:
+        return True
+
+    reference = now or datetime.now()
+    if isinstance(last_updated, datetime):
+        recorded = last_updated
+    else:
+        text = str(last_updated).strip()
+        recorded = None
+        for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+            try:
+                recorded = datetime.strptime(text, fmt)
+                break
+            except ValueError:
+                continue
+        if recorded is None:
+            try:
+                recorded = datetime.fromisoformat(text)
+            except ValueError:
+                return True
+
+    if recorded.tzinfo is not None:
+        recorded = recorded.replace(tzinfo=None)
+    return (reference - recorded).total_seconds() > TAXONOMY_NOT_FOUND_RETRY_SECONDS
 
 
 def _parenthetical_aliases(value: str) -> tuple[Optional[str], Optional[str]]:
@@ -135,11 +177,14 @@ class TaxonomyService:
 
     async def _query_cache(self, db: aiosqlite.Connection, name: str) -> Optional[Dict]:
         async with db.execute(
-            "SELECT scientific_name, common_name, taxa_id, is_not_found, thumbnail_url FROM taxonomy_cache WHERE LOWER(scientific_name) = LOWER(?) OR LOWER(common_name) = LOWER(?)",
+            "SELECT scientific_name, common_name, taxa_id, is_not_found, thumbnail_url, last_updated FROM taxonomy_cache WHERE LOWER(scientific_name) = LOWER(?) OR LOWER(common_name) = LOWER(?)",
             (name, name),
         ) as cursor:
             row = await cursor.fetchone()
             if row:
+                if bool(row[3]) and _negative_entry_expired(row[5]):
+                    # Report a miss so the caller looks the species up again.
+                    return None
                 return {
                     "scientific_name": row[0],
                     "common_name": row[1],

--- a/backend/tests/test_taxonomy_service.py
+++ b/backend/tests/test_taxonomy_service.py
@@ -1,8 +1,14 @@
 import pytest
 import aiosqlite
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
-from app.services.taxonomy.taxonomy_service import TaxonomyService, _parenthetical_aliases
+from app.services.taxonomy.taxonomy_service import (
+    TAXONOMY_NOT_FOUND_RETRY_SECONDS,
+    TaxonomyService,
+    _negative_entry_expired,
+    _parenthetical_aliases,
+)
 
 
 @pytest.fixture
@@ -184,3 +190,51 @@ async def test_run_background_sync_prefers_stored_scientific_name_for_repair(tax
 
     assert row == ("Cyanistes caeruleus", "Blue Tit", 303)
     await db.close()
+
+
+def test_negative_cache_entry_expires_after_the_retry_window():
+    """A cached "not found" is a guess and has to be re-tested eventually."""
+    now = datetime(2026, 8, 6, 12, 0, 0)
+    fresh = now - timedelta(seconds=TAXONOMY_NOT_FOUND_RETRY_SECONDS / 2)
+    stale = now - timedelta(seconds=TAXONOMY_NOT_FOUND_RETRY_SECONDS + 60)
+
+    assert _negative_entry_expired(fresh.isoformat(sep=" "), now=now) is False
+    assert _negative_entry_expired(stale.isoformat(sep=" "), now=now) is True
+    # Both timestamp shapes are in use: datetime.now() writes microseconds,
+    # the column default writes CURRENT_TIMESTAMP without them.
+    assert _negative_entry_expired(stale.strftime("%Y-%m-%d %H:%M:%S"), now=now) is True
+    assert _negative_entry_expired(fresh.strftime("%Y-%m-%d %H:%M:%S"), now=now) is False
+    # Unknown or missing timestamps must not pin a negative result forever.
+    assert _negative_entry_expired(None, now=now) is True
+    assert _negative_entry_expired("not a timestamp", now=now) is True
+
+
+@pytest.mark.asyncio
+async def test_query_cache_treats_an_expired_negative_entry_as_a_miss(taxonomy_service):
+    stale = (datetime.now() - timedelta(seconds=TAXONOMY_NOT_FOUND_RETRY_SECONDS + 60)).isoformat(sep=" ")
+    fresh = datetime.now().isoformat(sep=" ")
+
+    async with aiosqlite.connect(":memory:") as db:
+        await db.execute(
+            """CREATE TABLE taxonomy_cache (
+                   scientific_name TEXT, common_name TEXT, taxa_id INTEGER,
+                   is_not_found INTEGER, thumbnail_url TEXT, last_updated TEXT)"""
+        )
+        await db.executemany(
+            "INSERT INTO taxonomy_cache VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("Dryobates villosus", None, None, 1, None, stale),
+                ("Chloris chloris", None, None, 1, None, fresh),
+                ("Parus major", "Great Tit", 145252, 0, None, stale),
+            ],
+        )
+        await db.commit()
+
+        # Expired negative: re-lookup instead of trusting it.
+        assert await taxonomy_service._query_cache(db, "Dryobates villosus") is None
+        # Fresh negative: still short-circuits, so a real absence is not re-fetched constantly.
+        chloris = await taxonomy_service._query_cache(db, "Chloris chloris")
+        assert chloris is not None and chloris["is_not_found"] is True
+        # A resolved row is unaffected by age.
+        parus = await taxonomy_service._query_cache(db, "Parus major")
+        assert parus is not None and parus["common_name"] == "Great Tit"


### PR DESCRIPTION
## Outcome

A species cached as unknown to iNaturalist is re-tested after a week instead of being trusted forever. This repairs installations that already carry a wrong negative, which nothing currently does.

## Scope

- **Included:** `TAXONOMY_NOT_FOUND_RETRY_SECONDS` (env-overridable, default 7 days), a `_negative_entry_expired` helper, and `_query_cache` reporting an expired negative as a miss. Two tests.
- **Explicitly excluded:** how negatives get written in the first place — that is #143, which stops new ones being created for failed requests. This change repairs the ones already stored. The two are complementary and independent.
- **Issue or roadmap outcome:** contributes to #132.

## Verification

Nothing repairs a poisoned entry today:

- `run_background_sync` is defined at `taxonomy_service.py:318` and called from nowhere in `app/` or `scripts/`.
- The path that is wired up, `canonical_identity_repair_service`, calls `get_names(candidate, db=db)` without `force_refresh`, and `get_names` returns a cached `is_not_found` before reaching the network.

A live deployment shows the consequence — four not-found entries, three of them common birds iNaturalist certainly holds, cached across three separate dates and never re-tested:

```text
scientific_name          last_updated                 species
-----------------------  ---------------------------  -------------------
Dryobates villosus       2026-07-05 20:34:38          Hairy Woodpecker
Chloris chloris          2026-07-16 20:17:34          European Greenfinch
Troglodytes troglodytes  2026-07-28 21:06:28          Eurasian Wren
```

No detection exists for any of them yet, so the damage is latent: the first time one is seen it would be saved without a common name. Replaying those exact timestamps against the new helper:

```text
retry window: 7 days

Unknown Bird               age= 32d  -> RE-LOOKUP
Dryobates villosus         age= 31d  -> RE-LOOKUP
Chloris chloris            age= 20d  -> RE-LOOKUP
Troglodytes troglodytes    age=  8d  -> RE-LOOKUP
```

`Unknown Bird` is also re-tested, which costs one lookup a week and resolves to nothing, as it should.

```text
backend $ .venv/bin/python -m pytest tests/test_taxonomy_service.py -q
-> 8 passed

backend $ .venv/bin/python -m pytest -q
-> 1822 passed, 44 skipped in 60.09s

repo root $ ruff check .           -> All checks passed!
repo root $ ruff format --check .  -> 395 files already formatted
```

Both timestamp shapes in use are covered: `datetime.now()` writes microseconds, the column default writes `CURRENT_TIMESTAMP` without them. A missing or unparseable timestamp counts as expired, because one extra lookup is cheaper than withholding a name indefinitely.

## Data integrity and risk

- Detection-history or configuration risk: none. No schema change and no migration; only the interpretation of an existing column changes. Rows that resolved successfully are returned regardless of age.
- Migration/recovery path, if data changes: none needed. Existing wrong negatives repair themselves on next lookup after the window.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: the four entries above should resolve on next lookup, and `Dryobates villosus`, `Chloris chloris` and `Troglodytes troglodytes` should gain common names.

Traffic cost is bounded: a genuinely absent name is re-checked at most once per species per week.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.