### PR TITLE
Stop proposing non-LTS Node majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,18 +35,33 @@ updates:
     schedule:
       interval: weekly
     target-branch: "dev"
+    ignore:
+      # Node ships odd-numbered majors as Current only; they never become LTS.
+      # Node 25 reached end of life on 2026-03-31. Track LTS lines deliberately.
+      - dependency-name: "node"
+        versions: ["23.x", "25.x", "27.x", "29.x"]
 
   - package-ecosystem: docker
     directory: "/backend"
     schedule:
       interval: weekly
     target-branch: "dev"
+    ignore:
+      # Node ships odd-numbered majors as Current only; they never become LTS.
+      # Node 25 reached end of life on 2026-03-31. Track LTS lines deliberately.
+      - dependency-name: "node"
+        versions: ["23.x", "25.x", "27.x", "29.x"]
 
   - package-ecosystem: docker
     directory: "/apps/ui"
     schedule:
       interval: weekly
     target-branch: "dev"
+    ignore:
+      # Node ships odd-numbered majors as Current only; they never become LTS.
+      # Node 25 reached end of life on 2026-03-31. Track LTS lines deliberately.
+      - dependency-name: "node"
+        versions: ["23.x", "25.x", "27.x", "29.x"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Outcome

Dependabot no longer proposes odd-numbered Node majors for the three Docker ecosystems, so #126 and #127 do not simply reappear next week.

## Scope

- **Included:** an `ignore` rule for `node` versions `23.x`, `25.x`, `27.x`, `29.x` on the `/`, `/backend`, and `/apps/ui` docker ecosystems.
- **Explicitly excluded:** changing the Node version in use. Both Dockerfiles stay on `node:22` (LTS).
- **Issue or roadmap outcome:** follow-up to closing #126 and #127.

## Verification

Node ships odd-numbered majors as Current only; they never enter LTS. **Node 25 reached end of life on 2026-03-31**, so #126 and #127 would have moved production builds from a supported LTS runtime onto an unsupported one receiving no security patches. Both diffs also left the comment directly above the line reading `node:22 (LTS)`, so the files would have contradicted themselves.

```text
valid yaml — update entries: 7
 docker /         -> ignore: [{'dependency-name': 'node', 'versions': ['23.x', '25.x', '27.x', '29.x']}]
 docker /backend  -> ignore: [{'dependency-name': 'node', 'versions': ['23.x', '25.x', '27.x', '29.x']}]
 docker /apps/ui  -> ignore: [{'dependency-name': 'node', 'versions': ['23.x', '25.x', '27.x', '29.x']}]
```

Even majors are unaffected, so a future bump to Node 24 (an active LTS line) will still be proposed and can be taken deliberately.

### Related gap, not addressed here

While reviewing the dependency backlog it became clear that CI cannot validate changes to `backend/requirements-provider-*.txt`. CI installs `backend/requirements.txt`, which includes `requirements-provider-full.txt` only, and on an x86_64 runner that resolves the non-ARM line. #117 edited `requirements-provider-cuda.txt` and its run installed `onnxruntime-gpu-1.26.0` — the existing pin — so the change was never exercised despite every check passing. Those files first take effect when the flavour images build after merging to `dev`.

That is worth closing separately, either by adding a resolve-only CI job per provider file or by having dependabot leave them alone so bumps are deliberate. #116 is being held for the same reason.

## Data integrity and risk

- Detection-history or configuration risk: none; CI configuration only.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none. It reduces the chance of shipping an end-of-life runtime.
- Deployment verification, if deployed: not applicable.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.