### PR TITLE
Harden access logs and migration backup retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Authentication tokens no longer appear in monolithic container access logs.** Nginx now logs
+  the request path without its query string, the duplicate Uvicorn access log is disabled, and the
+  recommended Compose deployment rotates JSON logs at 10 MB while retaining three files.
+
+- **Automatic database migration backups no longer grow without a limit.** YA-WAMF keeps the 10
+  newest timestamped restore points by default and removes older automatic backups only after a
+  new backup succeeds. `DB_PRE_MIGRATION_BACKUP_RETENTION` can raise that limit, at least one
+  restore point is always kept, and manual backups are unaffected.
+
 - **A detection no longer claims nothing was heard when audio was heard on an unmapped
   microphone.** The audio panel distinguishes a silent window from audio excluded by the
   camera-to-audio-source mapping. The established array response remains compatible with existing

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -22,6 +22,10 @@ DB_POOL_SLOW_ACQUIRE_WARN_MS = float(os.environ.get("DB_POOL_SLOW_ACQUIRE_WARN_M
 DB_POOL_WAIT_WINDOW_SECONDS = float(os.environ.get("DB_POOL_WAIT_WINDOW_SECONDS", "300"))
 # Hard cap on in-memory samples to bound memory under sustained load.
 DB_POOL_WAIT_SAMPLE_CAP = int(os.environ.get("DB_POOL_WAIT_SAMPLE_CAP", "4096"))
+DEFAULT_PRE_MIGRATION_BACKUP_RETENTION = max(
+    1,
+    int(os.environ.get("DB_PRE_MIGRATION_BACKUP_RETENTION", "10")),
+)
 
 
 def _is_testing() -> bool:
@@ -119,14 +123,44 @@ REQUIRED_COLUMNS = {
 }
 
 
-def _backup_db(db_path: str) -> Optional[str]:
+def _prune_pre_migration_backups(database: Path, retention: int) -> None:
+    backups = sorted(
+        database.parent.glob(f"{database.stem}.pre-migration-*{database.suffix}"),
+        key=lambda path: path.name,
+        reverse=True,
+    )
+    removed = 0
+    for stale_backup in backups[max(1, retention) :]:
+        try:
+            stale_backup.unlink()
+            removed += 1
+        except OSError as error:
+            log.warning(
+                "Could not remove stale pre-migration database backup",
+                backup_path=str(stale_backup),
+                error=str(error),
+            )
+    if removed:
+        log.info(
+            "Stale pre-migration database backups removed",
+            removed_count=removed,
+            retained_count=min(len(backups), max(1, retention)),
+        )
+
+
+def _backup_db(
+    db_path: str,
+    *,
+    retention: int = DEFAULT_PRE_MIGRATION_BACKUP_RETENTION,
+) -> Optional[str]:
     """
     Copy the database to a timestamped backup file in the same directory.
 
     Called before running migrations so users have a restore point when
-    switching between image versions (e.g. live ↔ dev).  Returns the
-    backup path on success, None if the DB does not exist yet or the copy
-    fails (non-fatal — a missing backup is better than blocking startup).
+    switching between image versions (e.g. live ↔ dev).  Successful backups
+    are pruned to the configured retention count.  Returns the backup path on
+    success, None if the DB does not exist yet or the copy fails (non-fatal —
+    a missing backup is better than blocking startup).
     """
     src = Path(db_path)
     if not src.exists():
@@ -136,6 +170,7 @@ def _backup_db(db_path: str) -> Optional[str]:
     try:
         shutil.copy2(src, dst)
         log.info("Pre-migration database backup created", backup_path=str(dst))
+        _prune_pre_migration_backups(src, retention)
         return str(dst)
     except Exception as e:
         log.warning("Could not create pre-migration database backup", error=str(e))

--- a/backend/tests/test_database_backups.py
+++ b/backend/tests/test_database_backups.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from app.database import _backup_db
+
+
+def test_backup_db_keeps_only_the_newest_restore_points(tmp_path: Path) -> None:
+    database = tmp_path / "speciesid.db"
+    database.write_bytes(b"current database")
+    oldest = tmp_path / "speciesid.pre-migration-20260101T000000Z.db"
+    newer = tmp_path / "speciesid.pre-migration-20260201T000000Z.db"
+    unrelated = tmp_path / "manual-backup.db"
+    oldest.write_bytes(b"oldest")
+    newer.write_bytes(b"newer")
+    unrelated.write_bytes(b"manual")
+
+    backup_path = _backup_db(str(database), retention=2)
+
+    assert backup_path is not None
+    created = Path(backup_path)
+    assert created.read_bytes() == b"current database"
+    assert not oldest.exists()
+    assert newer.exists()
+    assert unrelated.read_bytes() == b"manual"
+    assert sorted(tmp_path.glob("speciesid.pre-migration-*.db")) == sorted([newer, created])
+
+
+def test_backup_db_never_prunes_the_last_restore_point(tmp_path: Path) -> None:
+    database = tmp_path / "speciesid.db"
+    database.write_bytes(b"current database")
+
+    backup_path = _backup_db(str(database), retention=0)
+
+    assert backup_path is not None
+    assert list(tmp_path.glob("speciesid.pre-migration-*.db")) == [Path(backup_path)]
+
+
+def test_backup_db_does_nothing_when_database_is_missing(tmp_path: Path) -> None:
+    database = tmp_path / "speciesid.db"
+
+    assert _backup_db(str(database), retention=2) is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_backup_db_does_not_prune_when_new_backup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "speciesid.db"
+    database.write_bytes(b"current database")
+    oldest = tmp_path / "speciesid.pre-migration-20260101T000000Z.db"
+    newer = tmp_path / "speciesid.pre-migration-20260201T000000Z.db"
+    oldest.write_bytes(b"oldest")
+    newer.write_bytes(b"newer")
+
+    def fail_copy(_source: Path, _destination: Path) -> None:
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr("app.database.shutil.copy2", fail_copy)
+
+    assert _backup_db(str(database), retention=1) is None
+    assert oldest.read_bytes() == b"oldest"
+    assert newer.read_bytes() == b"newer"

--- a/backend/tests/test_frontend_delivery_config.py
+++ b/backend/tests/test_frontend_delivery_config.py
@@ -50,3 +50,25 @@ def test_monolith_serves_live_startup_status_without_caching() -> None:
     assert 'add_header Cache-Control "no-store, max-age=0" always;' in config
     assert "YA_WAMF_STARTUP_STATUS_PATH" in entrypoint
     assert 'write_startup_status "starting" "launching" 5' in entrypoint
+
+
+def test_monolith_access_logs_omit_query_strings() -> None:
+    main_config = (REPOSITORY_ROOT / "docker/monolith/nginx-main.conf").read_text(encoding="utf-8")
+    entrypoint = (REPOSITORY_ROOT / "docker/monolith/entrypoint.sh").read_text(encoding="utf-8")
+
+    assert '"$request_method $uri $server_protocol"' in main_config
+    assert "access_log /dev/stdout safe_access;" in main_config
+    assert "access_log /dev/stdout;" not in main_config
+    assert "$args" not in main_config
+    assert "$request_uri" not in main_config
+    assert "$http_referer" not in main_config
+    assert "--no-access-log" in entrypoint
+
+
+def test_monolith_compose_rotates_container_logs() -> None:
+    compose = (REPOSITORY_ROOT / "docker-compose.monolith.yml").read_text(encoding="utf-8")
+
+    assert "logging:" in compose
+    assert 'max-size: "${CONTAINER_LOG_MAX_SIZE:-10m}"' in compose
+    assert 'max-file: "${CONTAINER_LOG_MAX_FILES:-3}"' in compose
+    assert "DB_PRE_MIGRATION_BACKUP_RETENTION=${DB_PRE_MIGRATION_BACKUP_RETENTION:-10}" in compose

--- a/docker-compose.monolith.yml
+++ b/docker-compose.monolith.yml
@@ -23,6 +23,9 @@ name: YetAnother-WhosAtMyFeeder-Monolith
 #   MQTT_PASSWORD          - MQTT password (if auth enabled)
 #   CLASSIFIER_IMAGE_MAX_CONCURRENT - Maximum concurrent image classifications (default: 2)
 #   CLASSIFIER_IMAGE_ADMISSION_TIMEOUT_SECONDS - Queue wait before rejecting background work (default: 0.5)
+#   DB_PRE_MIGRATION_BACKUP_RETENTION - Newest automatic migration backups to retain (default: 10)
+#   CONTAINER_LOG_MAX_SIZE - Rotate each container log file at this size (default: 10m)
+#   CONTAINER_LOG_MAX_FILES - Number of rotated container log files to retain (default: 3)
 #   FRIGATE__CLIPS_ENABLED - Enable Frigate clip workflows (default: true)
 #   TZ                     - Timezone (default: UTC)
 #   DOCKER_NETWORK         - External Docker network to join (required for MQTT/Frigate connectivity)
@@ -32,6 +35,11 @@ services:
     image: ${YAWAMF_MONALITHIC_IMAGE:-ghcr.io/jellman86/yawamf-monalithic}:${YAWAMF_MONALITHIC_TAG:-latest}
     container_name: yawamf-monalithic
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "${CONTAINER_LOG_MAX_SIZE:-10m}"
+        max-file: "${CONTAINER_LOG_MAX_FILES:-3}"
     user: "${PUID:-1000}:${PGID:-1000}"
     networks:
       - yawamf_network
@@ -71,6 +79,7 @@ services:
       - FRIGATE__CLIPS_ENABLED=${FRIGATE__CLIPS_ENABLED:-true}
       - CLASSIFIER_IMAGE_MAX_CONCURRENT=${CLASSIFIER_IMAGE_MAX_CONCURRENT:-2}
       - CLASSIFIER_IMAGE_ADMISSION_TIMEOUT_SECONDS=${CLASSIFIER_IMAGE_ADMISSION_TIMEOUT_SECONDS:-0.5}
+      - DB_PRE_MIGRATION_BACKUP_RETENTION=${DB_PRE_MIGRATION_BACKUP_RETENTION:-10}
       - SYSTEM__DEBUG_UI_ENABLED=${DEBUG_UI_ENABLED:-false}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]

--- a/docker/monolith/entrypoint.sh
+++ b/docker/monolith/entrypoint.sh
@@ -42,7 +42,7 @@ mkdir -p \
 
 write_startup_status "starting" "launching" 5
 
-uvicorn app.main:app --host 127.0.0.1 --port 8000 &
+uvicorn app.main:app --host 127.0.0.1 --port 8000 --no-access-log &
 backend_pid=$!
 
 nginx -g 'daemon off;' &

--- a/docker/monolith/nginx-main.conf
+++ b/docker/monolith/nginx-main.conf
@@ -10,7 +10,11 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log /dev/stdout;
+    log_format safe_access '$remote_addr [$time_local] '
+                           '"$request_method $uri $server_protocol" '
+                           '$status $body_bytes_sent $request_time '
+                           '"$http_user_agent"';
+    access_log /dev/stdout safe_access;
     sendfile on;
     tcp_nopush on;
     keepalive_timeout 65;

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -115,6 +115,7 @@ does not rewrite **Inference Provider**, `/config`, or `/data`.
 
 ## Data Management
 - **Retention Policy:** Choose how long to keep sightings in your history (`maintenance.retention_days`; `0` keeps everything). Scheduled cleanup permanently deletes both visual detections and BirdNET-Go audio detections older than this window — purged history cannot be recovered. Favourited detections are preserved.
+- **Migration backups:** Before applying database migrations, YA-WAMF creates a timestamped restore point beside `speciesid.db`. It keeps the newest 10 automatic backups by default and removes older automatic backups only after a new backup succeeds. Set `DB_PRE_MIGRATION_BACKUP_RETENTION` to retain more; at least one restore point is always kept, and manual backups are never matched or removed.
 - **Media Cache:** Toggle local caching of snapshots and video clips to reduce load on Frigate and speed up the UI.
 - **Best available event snapshots:** When enabled under **Settings → Data → Snapshot quality**, YA-WAMF starts with Frigate's completed-event clean best frame and tracked-object crop, then samples high-quality clip frames. A clip frame replaces that protected baseline only after a compatible species result improves classifier confidence by at least two points. JPEG quality remains configurable; crop source selection is automatic.
 - **Taxonomy Repair:** Manually trigger a sync to normalize all species names using iNaturalist data.

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -46,6 +46,9 @@ settings and do not follow the `SECTION__FIELD` precedence rules above.
 | `YA_WAMF_API_KEY` | _(unset)_ | Require `X-API-Key` on all API requests when set. |
 | `CONFIG_FILE` | `/config/config.json` | Path to the persisted config file. |
 | `LOG_LEVEL` | `INFO` | Log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+| `DB_PRE_MIGRATION_BACKUP_RETENTION` | `10` | Number of newest automatic pre-migration database backups to keep; values below `1` still retain one restore point. Manual backups are unaffected. |
+| `CONTAINER_LOG_MAX_SIZE` | `10m` | Compose-only size at which the monolithic container's JSON log rotates. |
+| `CONTAINER_LOG_MAX_FILES` | `3` | Compose-only number of rotated monolithic container log files to retain. |
 | `SPECIES_INFO__SOURCE` | `auto` | Species info source: `auto`, `inat`, `wikipedia`. |
 | `DISPLAY__DATE_FORMAT` | `locale` | Date format: `locale`, `mdy`, `dmy`, `ymd`. |
 


### PR DESCRIPTION
## Outcome

Prevents authentication and share-token query parameters from being retained in monolithic access logs, bounds automatic migration-backup storage, and rotates the recommended container JSON logs.

## Included

- log only request paths (without query strings) through Nginx
- disable the duplicate unsanitized Uvicorn access log
- rotate monolithic JSON logs at 10 MB with three retained files by default
- retain the newest 10 automatic pre-migration backups by default
- never prune the final restore point or prune after a failed backup
- document the new deployment controls and behavior
- add regression coverage for logging and backup safety

## Excluded

- no database schema change
- no automatic deployment or container restart
- no deletion of manual backups

## Verification

- `pytest -q`: 1833 passed, 44 skipped
- `ruff check .`: passed
- `ruff format --check .`: passed
- `python backend/scripts/docs_consistency_check.py`: passed (168 routes)
- `git diff --check`: passed
- monolithic Compose YAML parse: passed
- entrypoint shell syntax check: passed

## Risk

On the first successful migration backup after deployment, automatic `speciesid.pre-migration-*.db` files older than the configured retention count are permanently removed. The default retains 10, the minimum is one, cleanup occurs only after a new backup succeeds, and unrelated/manual backup names are not matched.