### PR TITLE
Fix public readiness probe routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Public readiness checks now report backend readiness instead of returning the web app.** Both
+  monolithic and split frontend proxies route the exact `/ready` path to the backend without
+  caching it. Container health and image smoke tests now exercise that public route, so a future
+  proxy regression cannot be hidden by checking the backend port directly.
+
 - **Full-visit clips no longer become permanently short when Frigate is still finalizing a recording.**
   Automatic generation waits for the requested window to settle, measures the downloaded duration,
   and makes bounded attempts to upgrade a partial result. Recording files are staged and replaced

--- a/apps/ui/nginx.conf
+++ b/apps/ui/nginx.conf
@@ -120,8 +120,17 @@ server {
         proxy_set_header Connection "";
     }
 
-    location /health {
+    location = /health {
         proxy_pass http://yawamf-backend:8000/health;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    location = /ready {
+        proxy_pass http://yawamf-backend:8000/ready;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -1160,6 +1160,13 @@ export interface components {
     missing: number;
     status: string;
 };
+    ReadinessResponse: {
+    db_pool_initialized: boolean;
+    ready: boolean;
+    startup_instance_id: string;
+    startup_started_at: string | null;
+    startup_warnings: Array<Record<string, unknown>>;
+};
     ReclassifyResponse: {
     actual_strategy: "snapshot" | "video";
     event_id: string;
@@ -3636,7 +3643,7 @@ export interface paths {
       path: never;
       query: never;
       requestBody: unknown;
-      response: unknown;
+      response: Record<string, unknown>;
     };
   };
   "/metrics": {
@@ -3654,7 +3661,7 @@ export interface paths {
       path: never;
       query: never;
       requestBody: unknown;
-      response: unknown;
+      response: components['schemas']['ReadinessResponse'];
     };
   };
 }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -152,6 +152,14 @@ class VersionResponse(BaseModel):
     base_version: str
 
 
+class ReadinessResponse(BaseModel):
+    ready: bool
+    db_pool_initialized: bool
+    startup_warnings: list[dict[str, object]]
+    startup_instance_id: str
+    startup_started_at: str | None
+
+
 # Metrics
 EVENTS_PROCESSED = Counter("events_processed_total", "Total number of events processed")
 DETECTIONS_TOTAL = Counter("detections_total", "Total number of bird detections")
@@ -787,8 +795,7 @@ async def count_requests(request, call_next):
     return response
 
 
-@app.get("/health")
-async def health_check():
+def build_health_payload() -> dict[str, object]:
     startup_warnings = getattr(app.state, "startup_warnings", [])
     startup_instance_id = getattr(app.state, "startup_instance_id", "unknown")
     startup_started_at = getattr(app.state, "startup_started_at", None)
@@ -854,8 +861,14 @@ async def health_check():
     return health
 
 
-@app.get("/ready")
-async def readiness_check():
+@app.get("/health")
+async def health_check(response: Response) -> dict[str, object]:
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    return build_health_payload()
+
+
+@app.get("/ready", response_model=ReadinessResponse)
+async def readiness_check(response: Response) -> ReadinessResponse | JSONResponse:
     """Kubernetes/Compose readiness probe endpoint.
 
     Ready requires:
@@ -866,16 +879,21 @@ async def readiness_check():
     db_ready = is_db_pool_initialized() or _is_testing()
     ready = db_ready and not startup_warnings
 
-    payload = {
-        "ready": ready,
-        "db_pool_initialized": db_ready,
-        "startup_warnings": startup_warnings,
-        "startup_instance_id": getattr(app.state, "startup_instance_id", "unknown"),
-        "startup_started_at": getattr(app.state, "startup_started_at", None),
-    }
+    payload = ReadinessResponse(
+        ready=ready,
+        db_pool_initialized=db_ready,
+        startup_warnings=startup_warnings,
+        startup_instance_id=getattr(app.state, "startup_instance_id", "unknown"),
+        startup_started_at=getattr(app.state, "startup_started_at", None),
+    )
     if ready:
+        response.headers["Cache-Control"] = "no-store, max-age=0"
         return payload
-    return JSONResponse(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=payload)
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content=payload.model_dump(),
+        headers={"Cache-Control": "no-store, max-age=0"},
+    )
 
 
 @app.get("/api/sse")

--- a/backend/app/routers/diagnostics.py
+++ b/backend/app/routers/diagnostics.py
@@ -228,12 +228,12 @@ def _build_backfill_focus(backend_snapshot: dict[str, Any]) -> dict[str, Any]:
 
 
 async def _collect_workspace_payload(limit: int) -> dict[str, Any]:
-    from app.main import health_check
+    from app.main import build_health_payload
     from app.routers.classifier import classifier_service
     from app.routers.settings import canonical_identity_repair_service
     from app.services.maintenance_coordinator import maintenance_coordinator
 
-    health = await health_check()
+    health = build_health_payload()
     backend_diagnostics = error_diagnostics_history.snapshot(limit=limit)
     taxonomy_repair = canonical_identity_repair_service.get_status()
     maintenance_status = await maintenance_coordinator.get_status()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8072,6 +8072,50 @@
         "title": "PurgeMissingMediaResponse",
         "type": "object"
       },
+      "ReadinessResponse": {
+        "properties": {
+          "db_pool_initialized": {
+            "title": "Db Pool Initialized",
+            "type": "boolean"
+          },
+          "ready": {
+            "title": "Ready",
+            "type": "boolean"
+          },
+          "startup_instance_id": {
+            "title": "Startup Instance Id",
+            "type": "string"
+          },
+          "startup_started_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Startup Started At"
+          },
+          "startup_warnings": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Startup Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ready",
+          "db_pool_initialized",
+          "startup_warnings",
+          "startup_instance_id",
+          "startup_started_at"
+        ],
+        "title": "ReadinessResponse",
+        "type": "object"
+      },
       "ReclassifyResponse": {
         "description": "Response from reclassification.",
         "properties": {
@@ -23254,7 +23298,11 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Health Check Health Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -23288,7 +23336,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ReadinessResponse"
+                }
               }
             },
             "description": "Successful Response"

--- a/backend/tests/test_error_diagnostics_api.py
+++ b/backend/tests/test_error_diagnostics_api.py
@@ -182,11 +182,11 @@ async def test_workspace_payload_includes_focused_video_classifier_diagnostics(c
 
     import app.main as main_module
 
-    original_health_check = main_module.health_check
+    original_build_health_payload = main_module.build_health_payload
     original_get_status = classifier_router.classifier_service.get_status
     try:
 
-        async def fake_health_check():
+        def fake_build_health_payload() -> dict[str, object]:
             return {
                 "status": "degraded",
                 "service": "ya-wamf-backend",
@@ -204,7 +204,7 @@ async def test_workspace_payload_includes_focused_video_classifier_diagnostics(c
                 },
             }
 
-        main_module.health_check = fake_health_check
+        main_module.build_health_payload = fake_build_health_payload
         classifier_router.classifier_service.get_status = lambda: {"active_provider": "intel_gpu"}
 
         response = await client.get("/api/diagnostics/workspace")
@@ -223,7 +223,7 @@ async def test_workspace_payload_includes_focused_video_classifier_diagnostics(c
         ]
         assert payload["backend_diagnostics"]["events"][0]["reason_code"] == "video_circuit_opened"
     finally:
-        main_module.health_check = original_health_check
+        main_module.build_health_payload = original_build_health_payload
         classifier_router.classifier_service.get_status = original_get_status
 
 

--- a/backend/tests/test_frontend_delivery_config.py
+++ b/backend/tests/test_frontend_delivery_config.py
@@ -8,6 +8,10 @@ FRONTEND_NGINX_CONFIGS = (
     REPOSITORY_ROOT / "docker/monolith/nginx.conf",
     REPOSITORY_ROOT / "apps/ui/nginx.conf",
 )
+FRONTEND_NGINX_UPSTREAMS = (
+    (REPOSITORY_ROOT / "docker/monolith/nginx.conf", "http://127.0.0.1:8000"),
+    (REPOSITORY_ROOT / "apps/ui/nginx.conf", "http://yawamf-backend:8000"),
+)
 
 
 @pytest.mark.parametrize("config_path", FRONTEND_NGINX_CONFIGS)
@@ -39,6 +43,34 @@ def test_frontend_document_is_revalidated_without_weakening_api_cache_headers(
     assert "expires -1;" in document_block
     assert "add_header Cache-Control" not in root_and_static_blocks
     assert "location /api/" in config
+
+
+@pytest.mark.parametrize(("config_path", "backend_upstream"), FRONTEND_NGINX_UPSTREAMS)
+def test_operational_probes_are_exact_public_backend_routes(
+    config_path: Path,
+    backend_upstream: str,
+) -> None:
+    config = config_path.read_text(encoding="utf-8")
+
+    for endpoint in ("health", "ready"):
+        location = f"location = /{endpoint} {{"
+        block_start = config.index(location)
+        block_end = config.index("\n    }", block_start)
+        block = config[block_start:block_end]
+
+        assert f"proxy_pass {backend_upstream}/{endpoint};" in block
+        assert "add_header " not in block
+
+    assert "location /health {" not in config
+    assert "location /ready {" not in config
+
+
+def test_monolith_healthcheck_exercises_public_readiness_route() -> None:
+    healthcheck = (REPOSITORY_ROOT / "docker/monolith/healthcheck.sh").read_text(encoding="utf-8")
+
+    assert "http://127.0.0.1:8080/health" in healthcheck
+    assert "http://127.0.0.1:8080/ready" in healthcheck
+    assert "http://127.0.0.1:8000/ready" not in healthcheck
 
 
 def test_monolith_serves_live_startup_status_without_caching() -> None:

--- a/backend/tests/test_health_readiness.py
+++ b/backend/tests/test_health_readiness.py
@@ -19,6 +19,7 @@ async def test_health_degraded_when_startup_warnings_present(client: httpx.Async
     app.state.startup_warnings = [{"phase": "telemetry_start", "error": "boom"}]
     response = await client.get("/health")
     assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store, max-age=0"
     body = response.json()
     assert body["status"] == "degraded"
     assert body["startup_warnings"]
@@ -29,6 +30,7 @@ async def test_ready_503_when_startup_warnings_present(client: httpx.AsyncClient
     app.state.startup_warnings = [{"phase": "telemetry_start", "error": "boom"}]
     response = await client.get("/ready")
     assert response.status_code == 503
+    assert response.headers["cache-control"] == "no-store, max-age=0"
     body = response.json()
     assert body["ready"] is False
     assert body["startup_warnings"]
@@ -39,6 +41,7 @@ async def test_ready_ok_in_test_mode_without_warnings(client: httpx.AsyncClient)
     app.state.startup_warnings = []
     response = await client.get("/ready")
     assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store, max-age=0"
     body = response.json()
     assert body["ready"] is True
 

--- a/docker/monolith/healthcheck.sh
+++ b/docker/monolith/healthcheck.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 curl -fsS http://127.0.0.1:8080/health >/dev/null
-curl -fsS http://127.0.0.1:8000/ready >/dev/null
+curl -fsS http://127.0.0.1:8080/ready >/dev/null

--- a/docker/monolith/nginx.conf
+++ b/docker/monolith/nginx.conf
@@ -112,8 +112,17 @@ server {
         proxy_set_header Connection "";
     }
 
-    location /health {
+    location = /health {
         proxy_pass http://127.0.0.1:8000/health;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    location = /ready {
+        proxy_pass http://127.0.0.1:8000/ready;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,8 +66,9 @@ curl -H "Authorization: Bearer <token>" http://localhost:9852/api/events
 
 ## Health, Readiness, Version, Streaming
 
-- `GET /health`: process + classifier health.
-- `GET /ready`: startup readiness (returns `503` until ready).
+- `GET /health`: process + classifier health. The response is not cacheable.
+- `GET /ready`: startup readiness (returns `503` until ready). This exact public path is proxied
+  through both monolithic and split frontend deployments and is not cacheable.
 - `GET /api/version`: app version metadata.
 - `GET /api/sse`: Server-Sent Events stream.
   - Supports bearer token or `?token=<jwt>` for EventSource compatibility.

--- a/docs/troubleshooting/diagnostics.md
+++ b/docs/troubleshooting/diagnostics.md
@@ -255,8 +255,13 @@ The script creates a timestamped backup of the original model before replacement
 ### Startup Health Signals
 Use these endpoints and lifecycle logs to quickly pinpoint startup failures:
 
-- `GET /health`: includes `startup_warnings` and sets `status=degraded` if a non-fatal startup phase failed.
-- `GET /ready`: returns `200` only when backend startup is ready for traffic; returns `503` with details when DB or startup phases are not ready.
+- `GET /health`: includes `startup_warnings` and sets `status=degraded` if a non-fatal startup
+  phase failed.
+- `GET /ready`: returns `200` only when backend startup is ready for traffic; returns `503` with
+  details when DB or startup phases are not ready. Use the same public host and port as the web app;
+  both supported frontend proxies forward this exact path to the backend.
+- Health and readiness responses use `Cache-Control: no-store, max-age=0`, so reverse proxies and
+  browsers do not retain stale operational state.
 - Backend logs now emit per-phase lifecycle events:
   - `Lifecycle phase starting`
   - `Lifecycle phase completed`

--- a/tests/e2e/monolith_nonroot_smoke.sh
+++ b/tests/e2e/monolith_nonroot_smoke.sh
@@ -38,5 +38,6 @@ fi
 docker inspect "$CID" --format '{{range (index .NetworkSettings.Ports "8080/tcp")}}{{println .HostPort}}{{end}}' | grep -qx '19854'
 docker exec "$CID" curl -fsS http://127.0.0.1:8080/ >/dev/null
 docker exec "$CID" curl -fsS http://127.0.0.1:8080/health >/dev/null
+docker exec "$CID" curl -fsS http://127.0.0.1:8080/ready >/dev/null
 docker exec "$CID" curl -fsS http://127.0.0.1:8080/api/version >/dev/null
 docker exec "$CID" sh -lc 'test "$YAWAMF_IMAGE_FLAVOR" = "full"'

--- a/tests/e2e/monolith_smoke.sh
+++ b/tests/e2e/monolith_smoke.sh
@@ -37,5 +37,6 @@ fi
 docker inspect "$CID" --format '{{range (index .NetworkSettings.Ports "8080/tcp")}}{{println .HostPort}}{{end}}' | grep -qx '19852'
 docker exec "$CID" curl -fsS http://127.0.0.1:8080/ >/dev/null
 docker exec "$CID" curl -fsS http://127.0.0.1:8080/health >/dev/null
+docker exec "$CID" curl -fsS http://127.0.0.1:8080/ready >/dev/null
 docker exec "$CID" curl -fsS http://127.0.0.1:8080/api/version >/dev/null
 docker exec "$CID" sh -lc 'test "$YAWAMF_IMAGE_FLAVOR" = "full"'


### PR DESCRIPTION
## Outcome

Public `GET /ready` now reaches FastAPI through both monolithic and split frontend proxies instead of falling through to the SPA.

## Included

- Exact-match `/health` and `/ready` proxy routes in both Nginx configurations
- Non-cacheable health and readiness responses without weakening inherited proxy security headers
- Docker health and monolith smoke checks through the public readiness route
- A separate internal health-payload builder so workspace diagnostics do not call an HTTP handler directly
- OpenAPI artifacts, regression tests, changelog, and operational documentation

## Excluded

- No database, settings, authentication, or detection-pipeline changes
- No Compose topology or external reverse-proxy changes

## Verification

- Backend: 1857 passed, 44 skipped
- Frontend: 620 passed
- Svelte check: 0 errors, 0 warnings
- Frontend production build passed
- Repo-wide Ruff check and format check passed
- OpenAPI artifacts and docs consistency passed
- Shell syntax checks passed

## Risk

Low operational risk. Probe responses preserve backend status codes, query handling, and inherited security headers. Container health now intentionally depends on the same Nginx route exposed to operators, closing the previous bypass.