### PR TITLE
Recover leaderboard names from cached taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Leaderboard rows now recover common names already present in the taxonomy cache.** Historic
+  detections that predated successful taxonomy enrichment no longer remain scientific-name-only in
+  the rolling or all-time rankings. Cached taxonomy identifiers, provider names, and durable manual
+  overrides are applied locally without adding external requests to the leaderboard path.
+
 - **Manual observation uploads now pass through the bundled Nginx proxies at their documented
   limits.** The exact upload route accepts a bounded 256 MiB multipart request and streams it to
   the backend, which continues to enforce the 25 MiB image and 250 MiB video file limits. The

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -2870,14 +2870,16 @@ class DetectionRepository:
 
     async def get_species_leaderboard_base(self) -> list[dict]:
         """Get leaderboard base stats per species with taxonomy and time bounds."""
-        query = """
+        canonical_key = self._canonical_key_sql()
+        taxonomy_join = self._taxonomy_join_sql()
+        query = f"""
             SELECT 
-                COALESCE(CAST(d.taxa_id AS VARCHAR), LOWER(d.scientific_name), LOWER(d.display_name)) as unified_id,
+                {canonical_key} as unified_id,
                 COUNT(*) as total_count, 
-                MAX(d.scientific_name) as scientific_name, 
-                MAX(d.common_name) as common_name,
+                COALESCE(MAX(tc.scientific_name), MAX(d.scientific_name)) as scientific_name,
+                COALESCE(MAX(tc.manual_common_name), MAX(d.common_name), MAX(tc.common_name)) as common_name,
                 MAX(d.display_name) as display_name,
-                MAX(d.taxa_id) as taxa_id,
+                COALESCE(MAX(d.taxa_id), MAX(tc.taxa_id)) as taxa_id,
                 MIN(d.detection_time) as first_seen,
                 MAX(d.detection_time) as last_seen,
                 AVG(d.score) as avg_confidence,
@@ -2885,8 +2887,9 @@ class DetectionRepository:
                 MIN(d.score) as min_confidence,
                 COUNT(DISTINCT d.camera_name) as camera_count
             FROM detections d
+            {taxonomy_join}
             WHERE (d.is_hidden = 0 OR d.is_hidden IS NULL)
-            GROUP BY unified_id
+            GROUP BY {canonical_key}
             ORDER BY total_count DESC
         """
         async with self.db.execute(query) as cursor:
@@ -2921,13 +2924,15 @@ class DetectionRepository:
         - Uses detection_time timestamps (not rollups) so it supports 24h windows.
         - Returns rows for any species that appears in either window; caller can filter to window_count > 0.
         """
-        query = """
+        canonical_key = self._canonical_key_sql()
+        taxonomy_join = self._taxonomy_join_sql()
+        query = f"""
             SELECT
-                COALESCE(CAST(d.taxa_id AS VARCHAR), LOWER(d.scientific_name), LOWER(d.display_name)) as unified_id,
-                MAX(d.scientific_name) as scientific_name,
-                MAX(d.common_name) as common_name,
+                {canonical_key} as unified_id,
+                COALESCE(MAX(tc.scientific_name), MAX(d.scientific_name)) as scientific_name,
+                COALESCE(MAX(tc.manual_common_name), MAX(d.common_name), MAX(tc.common_name)) as common_name,
                 MAX(d.display_name) as display_name,
-                MAX(d.taxa_id) as taxa_id,
+                COALESCE(MAX(d.taxa_id), MAX(tc.taxa_id)) as taxa_id,
 
                 SUM(CASE WHEN d.detection_time >= ? AND d.detection_time < ? THEN 1 ELSE 0 END) as window_count,
                 SUM(CASE WHEN d.detection_time >= ? AND d.detection_time < ? THEN 1 ELSE 0 END) as prev_count,
@@ -2938,10 +2943,11 @@ class DetectionRepository:
                 AVG(CASE WHEN d.detection_time >= ? AND d.detection_time < ? THEN d.score ELSE NULL END) as window_avg_confidence,
                 COUNT(DISTINCT CASE WHEN d.detection_time >= ? AND d.detection_time < ? THEN d.camera_name ELSE NULL END) as window_camera_count
             FROM detections d
+            {taxonomy_join}
             WHERE (d.is_hidden = 0 OR d.is_hidden IS NULL)
               AND d.detection_time >= ?
               AND d.detection_time < ?
-            GROUP BY unified_id
+            GROUP BY {canonical_key}
         """
         params = (
             window_start,

--- a/backend/tests/test_species_stats_api.py
+++ b/backend/tests/test_species_stats_api.py
@@ -448,6 +448,92 @@ async def test_leaderboard_species_uses_canonical_common_name_for_variant_aliase
 
 
 @pytest.mark.asyncio
+async def test_leaderboard_species_backfills_cached_taxonomy_for_legacy_detection(client: httpx.AsyncClient):
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+
+    suffix = uuid.uuid4().hex[:8]
+    event_id = f"leaderboard-legacy-taxonomy-{suffix}"
+    scientific_name = f"Dryobates pubescens {suffix}"
+    common_name = f"Downy Woodpecker {suffix}"
+    taxa_id = 920000 + int(suffix[:4], 16)
+
+    async with get_db() as db:
+        await db.execute(
+            """
+            INSERT INTO taxonomy_cache (scientific_name, common_name, taxa_id)
+            VALUES (?, ?, ?)
+            """,
+            (scientific_name, common_name, taxa_id),
+        )
+        await db.execute(
+            """
+            INSERT INTO detections (
+                detection_time, detection_index, score, display_name, category_name,
+                frigate_event, camera_name, is_hidden, manual_tagged,
+                scientific_name, common_name, taxa_id
+            ) VALUES (?, 1, 0.93, ?, ?, ?, 'test-camera', 0, 0, ?, NULL, NULL)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(sep=" "),
+                scientific_name,
+                scientific_name,
+                event_id,
+                scientific_name,
+            ),
+        )
+        await db.commit()
+
+    try:
+        response = await client.get("/api/leaderboard/species?span=month")
+        assert response.status_code == 200, response.text
+        rows = [row for row in response.json()["species"] if row["scientific_name"] == scientific_name]
+        assert len(rows) == 1
+        assert rows[0]["species"] == common_name
+        assert rows[0]["common_name"] == common_name
+        assert rows[0]["taxa_id"] == taxa_id
+
+        all_species_response = await client.get("/api/species")
+        assert all_species_response.status_code == 200, all_species_response.text
+        all_rows = [row for row in all_species_response.json() if row["scientific_name"] == scientific_name]
+        assert len(all_rows) == 1
+        assert all_rows[0]["species"] == common_name
+        assert all_rows[0]["common_name"] == common_name
+        assert all_rows[0]["taxa_id"] == taxa_id
+
+        manual_common_name = f"Back Garden Woodpecker {suffix}"
+        async with get_db() as db:
+            await db.execute(
+                "UPDATE taxonomy_cache SET manual_common_name = ? WHERE taxa_id = ?",
+                (manual_common_name, taxa_id),
+            )
+            await db.commit()
+
+        overridden_window_response = await client.get("/api/leaderboard/species?span=month")
+        assert overridden_window_response.status_code == 200, overridden_window_response.text
+        overridden_window_rows = [
+            row for row in overridden_window_response.json()["species"] if row["scientific_name"] == scientific_name
+        ]
+        assert len(overridden_window_rows) == 1
+        assert overridden_window_rows[0]["species"] == manual_common_name
+        assert overridden_window_rows[0]["common_name"] == manual_common_name
+
+        overridden_all_response = await client.get("/api/species")
+        assert overridden_all_response.status_code == 200, overridden_all_response.text
+        overridden_all_rows = [
+            row for row in overridden_all_response.json() if row["scientific_name"] == scientific_name
+        ]
+        assert len(overridden_all_rows) == 1
+        assert overridden_all_rows[0]["species"] == manual_common_name
+        assert overridden_all_rows[0]["common_name"] == manual_common_name
+    finally:
+        async with get_db() as db:
+            await db.execute("DELETE FROM detections WHERE frigate_event = ?", (event_id,))
+            await db.execute("DELETE FROM taxonomy_cache WHERE taxa_id = ?", (taxa_id,))
+            await db.commit()
+
+
+@pytest.mark.asyncio
 async def test_species_stats_accepts_cyrillic_common_name_and_aggregates_aliases(client: httpx.AsyncClient):
     settings.auth.enabled = False
     settings.public_access.enabled = False


### PR DESCRIPTION
## Outcome

Leaderboard rows now show an available common name even when the underlying historic detections were stored before taxonomy enrichment completed. The rolling and all-time rankings now agree with Events and Species Details.

Fixes #166.

## Included

- Join leaderboard reads to the local taxonomy cache using the existing canonical species identity
- Recover the scientific name, common name, and taxonomy id without an external lookup
- Keep durable manual common-name overrides ahead of stale detection and provider values
- Cover both `/api/leaderboard/species` and the all-time `/api/species` path
- Add a regression test built from a legacy detection with missing `common_name` and `taxa_id`
- Record the fix in the Unreleased changelog

## Excluded

- No database backfill or mutation of historic detections
- No schema, migration, API-shape, or frontend changes
- No taxonomy network requests on leaderboard reads

## Verification

- Regression test reproduced the scientific-name-only row before the implementation
- Backend suite: 1,862 passed, 44 hardware-dependent tests skipped
- `ruff check .`: clean
- `ruff format --check .`: 499 files already formatted
- Quark read-only query check: 244 detections and 151 taxonomy rows produced 20 leaderboard rows in 6.03–7.15 ms across five runs
- Frontend checks were not run because no frontend files or generated API types changed

## Risk

Low. The change is read-only and reuses the repository's established taxonomy join and canonical grouping. It neither modifies user data nor calls an external provider. The added join has been measured against the live deployment's database size.