### PR TITLE
Keep the review queue to owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The review queue is owner only.** "Needs your call", its walk-through, and the Identify action
+  on a flagged row were visible on an unauthenticated dashboard, where the identify and hide calls
+  they offer are refused. They are now gated on owner access, so a guest sees the day without being
+  offered work it cannot do.
+
 - **Top Visitors is readable on the dashboard again.** It lays out horizontally and was being
   compressed into the context rail on desktop. It now sits full width below the desk, where it
   was before, with a layout test to keep it there.

--- a/apps/ui/src/lib/components/FieldLog.svelte
+++ b/apps/ui/src/lib/components/FieldLog.svelte
@@ -11,13 +11,23 @@
         visits: DetectionVisit[];
         /** Visits in the window beyond the ones shown, so truncation is stated. */
         hiddenCount?: number;
+        /** Identifying requires owner access, so guests get a read-only row. */
+        canIdentify?: boolean;
         loading?: boolean;
         onselect?: (detection: Detection) => void;
         onidentify?: (detection: Detection) => void;
         onseeall?: () => void;
     }
 
-    let { visits, hiddenCount = 0, loading = false, onselect, onidentify, onseeall }: Props = $props();
+    let {
+        visits,
+        hiddenCount = 0,
+        canIdentify = false,
+        loading = false,
+        onselect,
+        onidentify,
+        onseeall
+    }: Props = $props();
 
     function names(detection: Detection): { primary: string; secondary: string | null } {
         return getBirdNames(
@@ -167,7 +177,7 @@
                     </span>
 
                     <span class="col-span-full flex justify-end sm:col-span-1">
-                        {#if visit.needsReview}
+                        {#if visit.needsReview && canIdentify}
                             <button
                                 class="btn btn-primary min-h-11 px-3 py-1.5 text-xs"
                                 onclick={() => onidentify?.(visit.best)}

--- a/apps/ui/src/lib/pages/Dashboard.svelte
+++ b/apps/ui/src/lib/pages/Dashboard.svelte
@@ -101,8 +101,16 @@
     let visits = $derived(allVisits.slice(0, VISIT_ROW_LIMIT));
     let hiddenVisitCount = $derived(Math.max(allVisits.length - visits.length, 0));
 
+    // Reviewing is an owner capability: the identify and hide calls require it, so a guest
+    // must not be shown the queue, the walk-through, or an Identify button that would 403.
+    let canReview = $derived(authStore.hasOwnerAccess);
+
     // The walk-through flow: a captured queue worked one at a time.
     let reviewSessionOpen = $state(false);
+
+    $effect(() => {
+        if (!canReview) reviewSessionOpen = false;
+    });
 
     // The picker opens on species this feeder actually sees, most frequent first,
     // rather than the head of an 11,000-label alphabetical list.
@@ -470,17 +478,20 @@
             visits={visits}
             hiddenCount={hiddenVisitCount}
             loading={detectionsStore.isLoading}
+            canIdentify={canReview}
             onselect={(detection) => selectedEvent = detection}
             onidentify={(detection) => selectedEvent = detection}
             onseeall={() => onnavigate?.('/events')}
         />
 
         <aside class="flex flex-col gap-7 xl:border-l xl:border-slate-200 xl:pl-8 dark:xl:border-slate-700">
-            <ReviewQueueCard
-                queue={reviewQueue}
-                onreview={(detection) => selectedEvent = detection}
-                onreviewall={() => (reviewSessionOpen = true)}
-            />
+            {#if canReview}
+                <ReviewQueueCard
+                    queue={reviewQueue}
+                    onreview={(detection) => selectedEvent = detection}
+                    onreviewall={() => (reviewSessionOpen = true)}
+                />
+            {/if}
 
             <DeskContextCards
                 detections={deskDetections}
@@ -513,7 +524,7 @@
     </section>
 </div>
 
-{#if reviewSessionOpen}
+{#if reviewSessionOpen && canReview}
     <ReviewQueueModal
         queue={buildReviewQueue(deskDetections, Number.MAX_SAFE_INTEGER).items}
         labels={classifierLabels}

--- a/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
+++ b/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
@@ -31,6 +31,15 @@ describe('dashboard field desk layout', () => {
         expect(topVisitors > aside && topVisitors < asideEnd).toBe(false);
     });
 
+    it('keeps the review queue and its actions to owners', () => {
+        // Identify and hide are owner-only calls, so a guest must not be offered them.
+        expect(dashboardSource).toContain('let canReview = $derived(authStore.hasOwnerAccess)');
+        expect(dashboardSource).toContain('{#if canReview}');
+        expect(dashboardSource).toContain('{#if reviewSessionOpen && canReview}');
+        expect(dashboardSource).toContain('canIdentify={canReview}');
+        expect(fieldLogSource).toContain('{#if visit.needsReview && canIdentify}');
+    });
+
     it('folds repeat frames into visits instead of printing one card per frame', () => {
         expect(dashboardSource).toContain('groupDetectionsIntoVisits(deskDetections)');
         expect(dashboardSource).toContain('buildReviewQueue(deskDetections)');


### PR DESCRIPTION
## Outcome

"Needs your call", its walk-through, and the Identify button on a flagged row were rendering on the unauthenticated dashboard. The identify and hide calls behind them are owner-only, so a guest was being offered work the backend refuses.

All three now gate on `authStore.hasOwnerAccess`, the flag `DetectionModal` already uses for its owner actions. An open walk-through also closes if access is lost.

A guest still sees the field log, camera and sensor context, and conditions. The day bar keeps its `unresolved` count, which is a fact about the feeder rather than an action; say the word if that should go too.

## Verification

- 669 frontend tests passing, including a new one asserting the gating so it cannot regress
- `npm run check` 0 errors, build clean
- Checked against the live public instance as a guest: the queue card is gone and every row reads "Open"