### PR TITLE
Make the field log usable on a phone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The field log fits a phone.** Rows were around 225 pixels tall because the action button sat on
+  its own line with nothing beside it, so four visits filled a screen. The action now shares the row,
+  the score and camera appear under the species name instead of being hidden, and the thumbnail
+  stack shows one frame rather than three, which stops long species names truncating. Eight visits
+  now fit where four did. The day bar keeps its live indicator inline, and "See full history" stays
+  on the heading row.
+
 - **The review queue is owner only.** "Needs your call", its walk-through, and the Identify action
   on a flagged row were visible on an unauthenticated dashboard, where the identify and hide calls
   they offer are refused. They are now gated on owner access, so a guest sees the day without being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Every frame in a visit previews itself.** Hovering any thumbnail in a folded group showed the
+  same clearest frame. Each thumbnail is now its own trigger with its own preview, stating which
+  frame it is, and clicking one opens that frame rather than the visit's best.
+
+- **Explorer puts the facets beside the results.** They were hidden behind a Filters button and
+  opened full width above the grid, which is not the layout that was chosen: the facet rail is now
+  persistent alongside the photographs on desktop, and collapses behind the button only where there
+  is no room for it.
+
 - **The field log fits a phone.** Rows were around 225 pixels tall because the action button sat on
   its own line with nothing beside it, so four visits filled a screen. The action now shares the row,
   the score and camera appear under the species name instead of being hidden, and the thumbnail

--- a/apps/ui/src/lib/components/DayBar.svelte
+++ b/apps/ui/src/lib/components/DayBar.svelte
@@ -28,7 +28,7 @@
         {$_('dashboard.day_bar.today', { default: 'Today' })}
     </h1>
 
-    <dl class="flex flex-wrap items-baseline gap-x-5 gap-y-2 text-xs">
+    <dl class="flex flex-wrap items-baseline gap-x-4 gap-y-1.5 text-xs sm:gap-x-5 sm:gap-y-2">
         <div class="flex items-baseline gap-1.5">
             <dd class="font-display text-base font-bold tabular-nums text-slate-900 dark:text-white">
                 {visitCount}
@@ -81,7 +81,7 @@
         {/if}
     </dl>
 
-    <p class="ml-auto flex items-center gap-1.5 text-xs font-semibold">
+    <p class="flex items-center gap-1.5 text-xs font-semibold sm:ml-auto">
         <span
             class="h-1.5 w-1.5 rounded-full {connected
                 ? 'bg-emerald-500'

--- a/apps/ui/src/lib/components/DetectionPreview.svelte
+++ b/apps/ui/src/lib/components/DetectionPreview.svelte
@@ -131,6 +131,8 @@
                 <span
                     class="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-white bg-slate-100 text-slate-300 dark:border-slate-900 dark:bg-slate-800 dark:text-slate-600"
                     class:-ml-2={index > 0}
+                    class:hidden={index > 0}
+                    class:sm:flex={index > 0}
                     aria-hidden="true"
                 >
                     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
@@ -147,12 +149,19 @@
                     height="36"
                     class="h-9 w-9 rounded-lg border-2 border-white object-cover dark:border-slate-900"
                     class:-ml-2={index > 0}
+                    class:hidden={index > 0}
+                    class:sm:block={index > 0}
                     onerror={() => markFailed(frame.frigate_event)}
                 />
             {/if}
         {/each}
+        {#if frameCount > 1}
+            <span class="ml-1.5 text-[11px] font-semibold text-slate-500 dark:text-slate-400 sm:hidden">
+                +{frameCount - 1}
+            </span>
+        {/if}
         {#if frameCount > 3}
-            <span class="ml-1.5 text-[11px] font-semibold text-slate-500 dark:text-slate-400">
+            <span class="ml-1.5 hidden text-[11px] font-semibold text-slate-500 sm:inline dark:text-slate-400">
                 +{frameCount - 3}
             </span>
         {/if}

--- a/apps/ui/src/lib/components/DetectionPreview.svelte
+++ b/apps/ui/src/lib/components/DetectionPreview.svelte
@@ -9,15 +9,14 @@
     import { _ } from 'svelte-i18n';
 
     interface Props {
-        /** The frame worth showing: the clearest one in the visit. */
+        /** The clearest frame, used when a visit has only one. */
         detection: Detection;
-        /** Up to three frames from the visit, drawn as a stack. */
+        /** Every frame in the visit. Each one previews itself. */
         frames?: Detection[];
-        /** Frames folded into the visit, including any beyond the stack. */
         frameCount?: number;
         primaryName: string;
         secondaryName?: string | null;
-        onopen?: () => void;
+        onopen?: (detection: Detection) => void;
     }
 
     let {
@@ -29,20 +28,14 @@
         onopen
     }: Props = $props();
 
-    const stack = $derived(frames.length > 0 ? frames.slice(0, 3) : [detection]);
+    /** Desktop shows up to this many frames; the rest are counted. */
+    const VISIBLE_FRAMES = 3;
 
-    // Snapshots can disappear upstream; a missing one must degrade to a placeholder of
-    // the same size rather than leaving a hole that shifts the row (CLAUDE.md §5).
-    let failedThumbnails = $state<Set<string>>(new Set());
-    let panelImageFailed = $state(false);
+    const stack = $derived(frames.length > 0 ? frames.slice(0, VISIBLE_FRAMES) : [detection]);
 
-    function markFailed(eventId: string): void {
-        const next = new Set(failedThumbnails);
-        next.add(eventId);
-        failedThumbnails = next;
-    }
-
-    let open = $state(false);
+    // Each frame owns its preview, so hovering the second thumbnail of a visit shows the
+    // second frame rather than repeating the clearest one.
+    let openIndex = $state<number | null>(null);
     let rootEl = $state<HTMLElement | null>(null);
     let closeTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -50,23 +43,23 @@
     // first mouseleave would make the panel impossible to reach (WCAG 2.2 SC 1.4.13).
     const CLOSE_GRACE_MS = 120;
 
-    function show(): void {
+    function show(index: number): void {
         if (closeTimer) {
             clearTimeout(closeTimer);
             closeTimer = null;
         }
-        open = true;
+        openIndex = index;
     }
 
     function hide(immediate = false): void {
         if (closeTimer) clearTimeout(closeTimer);
         if (immediate) {
             closeTimer = null;
-            open = false;
+            openIndex = null;
             return;
         }
         closeTimer = setTimeout(() => {
-            open = false;
+            openIndex = null;
             closeTimer = null;
         }, CLOSE_GRACE_MS);
     }
@@ -78,7 +71,7 @@
     }
 
     function handleKeydown(event: KeyboardEvent): void {
-        if (event.key === 'Escape' && open) {
+        if (event.key === 'Escape' && openIndex !== null) {
             event.preventDefault();
             event.stopPropagation();
             hide(true);
@@ -91,135 +84,151 @@
         };
     });
 
-    const score = $derived(Math.round((detection.score ?? 0) * 100));
+    // Snapshots can disappear upstream; a missing one degrades to a placeholder of the
+    // same size rather than a hole that shifts the row (CLAUDE.md §5).
+    let failed = $state<Set<string>>(new Set());
+
+    function markFailed(eventId: string): void {
+        const next = new Set(failed);
+        next.add(eventId);
+        failed = next;
+    }
+
     const weatherUnitSystem = $derived(
         resolveWeatherUnitSystem(
             settingsStore.settings?.location_weather_unit_system ?? authStore.locationWeatherUnitSystem,
             settingsStore.settings?.location_temperature_unit ?? authStore.locationTemperatureUnit
         )
     );
-    const temperature = $derived(
-        formatTemperature(detection.temperature, getTemperatureUnitForSystem(weatherUnitSystem))
-    );
+    const temperatureUnit = $derived(getTemperatureUnitForSystem(weatherUnitSystem));
+
+    function score(frame: Detection): number {
+        return Math.round((frame.score ?? 0) * 100);
+    }
 </script>
 
 <div
     bind:this={rootEl}
-    class="relative"
+    class="relative flex items-center"
     data-detection-preview
-    onmouseenter={show}
     onmouseleave={() => hide()}
-    onfocusin={show}
     onfocusout={handleFocusOut}
     onkeydown={handleKeydown}
     role="presentation"
 >
-    <button
-        type="button"
-        class="flex items-center rounded-xl focus-ring"
-        aria-expanded={open}
-        onclick={() => onopen?.()}
-    >
-        <span class="sr-only">
-            {$_('dashboard.field_log.preview_trigger', {
-                values: { species: primaryName },
-                default: 'Preview {species}'
-            })}
-        </span>
-        {#each stack as frame, index (frame.frigate_event)}
-            {#if failedThumbnails.has(frame.frigate_event)}
-                <span
-                    class="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-white bg-slate-100 text-slate-300 dark:border-slate-900 dark:bg-slate-800 dark:text-slate-600"
-                    class:-ml-2={index > 0}
-                    class:hidden={index > 0}
-                    class:sm:flex={index > 0}
-                    aria-hidden="true"
-                >
-                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2 1.586-1.586a2 2 0 012.828 0L20 14M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                </span>
-            {:else}
-                <img
-                    src={getThumbnailUrl(frame.frigate_event)}
-                    alt=""
-                    loading="lazy"
-                    decoding="async"
-                    width="36"
-                    height="36"
-                    class="h-9 w-9 rounded-lg border-2 border-white object-cover dark:border-slate-900"
-                    class:-ml-2={index > 0}
-                    class:hidden={index > 0}
-                    class:sm:block={index > 0}
-                    onerror={() => markFailed(frame.frigate_event)}
-                />
-            {/if}
-        {/each}
-        {#if frameCount > 1}
-            <span class="ml-1.5 text-[11px] font-semibold text-slate-500 dark:text-slate-400 sm:hidden">
-                +{frameCount - 1}
-            </span>
-        {/if}
-        {#if frameCount > 3}
-            <span class="ml-1.5 hidden text-[11px] font-semibold text-slate-500 sm:inline dark:text-slate-400">
-                +{frameCount - 3}
-            </span>
-        {/if}
-    </button>
-
-    {#if open}
+    {#each stack as frame, index (frame.frigate_event)}
         <div
-            class="absolute left-1/2 top-full z-30 mt-2 w-60 -translate-x-1/2 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl shadow-slate-950/20 animate-in fade-in zoom-in-95 motion-reduce:animate-none dark:border-slate-700 dark:bg-slate-900"
-            role="tooltip"
-            data-detection-preview-panel
+            class="relative"
+            class:-ml-2={index > 0}
+            class:hidden={index > 0}
+            class:sm:block={index > 0}
+            onmouseenter={() => show(index)}
+            onfocusin={() => show(index)}
+            role="presentation"
         >
-            {#if panelImageFailed}
-                <div class="flex h-32 w-full items-center justify-center bg-slate-100 text-slate-300 dark:bg-slate-800 dark:text-slate-600">
-                    <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2 1.586-1.586a2 2 0 012.828 0L20 14M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                </div>
-            {:else}
-                <img
-                    src={getThumbnailUrl(detection.frigate_event)}
-                    alt={$_('dashboard.field_log.preview_alt', {
-                        values: { species: primaryName, camera: detection.camera_name },
-                        default: '{species} on {camera}'
+            <button
+                type="button"
+                class="block rounded-lg focus-ring"
+                aria-expanded={openIndex === index}
+                onclick={() => onopen?.(frame)}
+            >
+                <span class="sr-only">
+                    {$_('dashboard.field_log.preview_trigger', {
+                        values: { species: primaryName },
+                        default: 'Preview {species}'
                     })}
-                    loading="lazy"
-                    decoding="async"
-                    class="h-32 w-full object-cover"
-                    onerror={() => (panelImageFailed = true)}
-                />
-            {/if}
-            <div class="space-y-1 p-3">
-                <div class="flex items-baseline justify-between gap-2">
-                    <p class="truncate font-display text-sm font-bold text-slate-950 dark:text-white">
-                        {primaryName}
-                    </p>
-                    <span class="shrink-0 text-xs font-bold tabular-nums text-brand-700 dark:text-brand-300">
-                        {score}%
+                </span>
+                {#if failed.has(frame.frigate_event)}
+                    <span
+                        class="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-white bg-slate-100 text-slate-300 dark:border-slate-900 dark:bg-slate-800 dark:text-slate-600"
+                        aria-hidden="true"
+                    >
+                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2 1.586-1.586a2 2 0 012.828 0L20 14M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
                     </span>
+                {:else}
+                    <img
+                        src={getThumbnailUrl(frame.frigate_event)}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        width="36"
+                        height="36"
+                        class="h-9 w-9 rounded-lg border-2 border-white object-cover dark:border-slate-900"
+                        onerror={() => markFailed(frame.frigate_event)}
+                    />
+                {/if}
+            </button>
+
+            {#if openIndex === index}
+                <div
+                    class="absolute left-1/2 top-full z-30 mt-2 w-60 -translate-x-1/2 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl shadow-slate-950/20 animate-in fade-in zoom-in-95 motion-reduce:animate-none dark:border-slate-700 dark:bg-slate-900"
+                    role="tooltip"
+                    data-detection-preview-panel
+                >
+                    {#if failed.has(frame.frigate_event)}
+                        <div class="flex h-32 w-full items-center justify-center bg-slate-100 text-slate-300 dark:bg-slate-800 dark:text-slate-600">
+                            <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2 1.586-1.586a2 2 0 012.828 0L20 14M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                        </div>
+                    {:else}
+                        <img
+                            src={getThumbnailUrl(frame.frigate_event)}
+                            alt={$_('dashboard.field_log.preview_alt', {
+                                values: { species: primaryName, camera: frame.camera_name },
+                                default: '{species} on {camera}'
+                            })}
+                            loading="lazy"
+                            decoding="async"
+                            class="h-32 w-full object-cover"
+                            onerror={() => markFailed(frame.frigate_event)}
+                        />
+                    {/if}
+                    <div class="space-y-1 p-3">
+                        <div class="flex items-baseline justify-between gap-2">
+                            <p class="truncate font-display text-sm font-bold text-slate-950 dark:text-white">
+                                {primaryName}
+                            </p>
+                            <span class="shrink-0 text-xs font-bold tabular-nums text-brand-700 dark:text-brand-300">
+                                {score(frame)}%
+                            </span>
+                        </div>
+                        {#if secondaryName}
+                            <p class="truncate text-[11px] italic text-slate-500 dark:text-slate-400">
+                                {secondaryName}
+                            </p>
+                        {/if}
+                        <p class="text-[11px] text-slate-500 dark:text-slate-400">
+                            {formatTime(frame.detection_time)} &middot; {frame.camera_name}{frame.weather_condition
+                                ? ` · ${frame.weather_condition}`
+                                : ''}{formatTemperature(frame.temperature, temperatureUnit)
+                                ? ` ${formatTemperature(frame.temperature, temperatureUnit)}`
+                                : ''}
+                        </p>
+                        {#if frameCount > 1}
+                            <p class="text-[11px] text-slate-500 dark:text-slate-400">
+                                {$_('dashboard.field_log.preview_frame_position', {
+                                    values: { position: index + 1, count: frameCount },
+                                    default: 'Frame {position} of {count} in this visit'
+                                })}
+                            </p>
+                        {/if}
+                    </div>
                 </div>
-                {#if secondaryName}
-                    <p class="truncate text-[11px] italic text-slate-500 dark:text-slate-400">
-                        {secondaryName}
-                    </p>
-                {/if}
-                <p class="text-[11px] text-slate-500 dark:text-slate-400">
-                    {formatTime(detection.detection_time)} · {detection.camera_name}{detection.weather_condition
-                        ? ` · ${detection.weather_condition}`
-                        : ''}{temperature ? ` ${temperature}` : ''}
-                </p>
-                {#if frameCount > 1}
-                    <p class="text-[11px] text-slate-500 dark:text-slate-400">
-                        {$_('dashboard.field_log.preview_frames', {
-                            values: { count: frameCount },
-                            default: '{count} frames in this visit, clearest shown'
-                        })}
-                    </p>
-                {/if}
-            </div>
+            {/if}
         </div>
+    {/each}
+
+    {#if frameCount > 1}
+        <span class="ml-1.5 text-[11px] font-semibold text-slate-500 dark:text-slate-400 sm:hidden">
+            +{frameCount - 1}
+        </span>
+    {/if}
+    {#if frameCount > VISIBLE_FRAMES}
+        <span class="ml-1.5 hidden text-[11px] font-semibold text-slate-500 sm:inline dark:text-slate-400">
+            +{frameCount - VISIBLE_FRAMES}
+        </span>
     {/if}
 </div>

--- a/apps/ui/src/lib/components/ExplorerFilters.svelte
+++ b/apps/ui/src/lib/components/ExplorerFilters.svelte
@@ -139,7 +139,7 @@
     });
 </script>
 
-<section class="border-y border-slate-200 py-3 dark:border-slate-700" data-events-filter-bar>
+<section class="border-y border-slate-200 py-3 lg:border-0 lg:py-0" data-events-filter-bar>
     <div class="flex flex-wrap items-center gap-2">
         <p class="text-sm font-semibold text-slate-900 dark:text-white">
             {$_('events.filters.result_count', {
@@ -161,7 +161,7 @@
         {/each}
 
         <button
-            class="btn btn-secondary ml-auto min-h-11 px-3 py-2 text-xs"
+            class="btn btn-secondary ml-auto min-h-11 px-3 py-2 text-xs lg:hidden"
             aria-expanded={panelOpen}
             onclick={() => (panelOpen = !panelOpen)}
             data-explorer-filter-toggle
@@ -176,8 +176,12 @@
         {/if}
     </div>
 
-    {#if panelOpen}
-        <div class="mt-3 grid gap-5 border-t border-slate-200 pt-3 sm:grid-cols-3 dark:border-slate-700" data-explorer-facets>
+    <div
+        class="mt-3 gap-5 border-t border-slate-200 pt-3 lg:!block dark:border-slate-700 {panelOpen
+            ? 'grid grid-cols-1 sm:grid-cols-3'
+            : 'hidden'} lg:mt-0 lg:space-y-5 lg:border-t-0 lg:pt-0"
+        data-explorer-facets
+    >
             <div>
                 <p class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
                     {$_('events.filters.when', { default: 'When' })}
@@ -327,6 +331,5 @@
                     {/each}
                 </div>
             </div>
-        </div>
-    {/if}
+    </div>
 </section>

--- a/apps/ui/src/lib/components/FieldLog.svelte
+++ b/apps/ui/src/lib/components/FieldLog.svelte
@@ -57,12 +57,12 @@
 </script>
 
 <section class="space-y-4" data-dashboard-field-log>
-    <header class="flex flex-wrap items-end justify-between gap-3 border-b border-slate-200/70 pb-3 dark:border-slate-700/50">
-        <div>
+    <header class="flex items-end justify-between gap-3 border-b border-slate-200/70 pb-3 dark:border-slate-700/50">
+        <div class="min-w-0">
             <h2 class="font-display text-xl font-bold text-slate-950 dark:text-white">
                 {$_('dashboard.field_log.title', { default: 'Field log' })}
             </h2>
-            <p class="text-sm text-slate-500 dark:text-slate-400">
+            <p class="hidden text-sm text-slate-500 sm:block dark:text-slate-400">
                 {$_('dashboard.field_log.subtitle', {
                     default: 'Repeat frames of the same bird are folded into one visit'
                 })}
@@ -70,7 +70,7 @@
         </div>
         <button
             onclick={() => onseeall?.()}
-            class="inline-flex min-h-11 items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-50 focus-ring dark:text-brand-300 dark:hover:bg-brand-950/40"
+            class="inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-xl px-2 py-2 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-50 focus-ring sm:px-3 dark:text-brand-300 dark:hover:bg-brand-950/40"
         >
             {$_('dashboard.see_full_history')}
             <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
@@ -102,7 +102,7 @@
                 {@const naming = names(visit.lead)}
                 {@const score = visit.best.score ?? 0}
                 <li
-                    class="grid grid-cols-[4.5rem_0.75rem_auto_minmax(0,1fr)] items-stretch sm:items-center gap-x-3 gap-y-2 rounded-xl border-b border-slate-200/60 px-2 py-2.5 last:border-b-0 sm:grid-cols-[4.5rem_0.75rem_auto_minmax(0,1fr)_auto_auto_5rem] dark:border-slate-700/40"
+                    class="grid grid-cols-[3.4rem_0.6rem_auto_minmax(0,1fr)_auto] items-center gap-x-2.5 gap-y-1 rounded-xl border-b border-slate-200/60 px-2 py-2 last:border-b-0 sm:grid-cols-[4.5rem_0.75rem_auto_minmax(0,1fr)_auto_auto_5rem] sm:gap-x-3 sm:py-2.5 dark:border-slate-700/40"
                     class:bg-gradient-to-r={visit.needsReview}
                     class:from-accent-50={visit.needsReview}
                     class:dark:from-accent-950={visit.needsReview}
@@ -143,6 +143,9 @@
                                 </span>
                             {/if}
                         </p>
+                        <p class="text-[11px] tabular-nums text-slate-500 sm:hidden dark:text-slate-400">
+                            {Math.round(score * 100)}% &middot; {visit.camera}
+                        </p>
                         {#if visit.needsReview}
                             <p class="truncate text-[11px] font-medium text-accent-700 dark:text-accent-300">
                                 {$_('dashboard.field_log.needs_name', {
@@ -176,17 +179,17 @@
                         </span>
                     </span>
 
-                    <span class="col-span-full flex justify-end sm:col-span-1">
+                    <span class="flex justify-end">
                         {#if visit.needsReview && canIdentify}
                             <button
-                                class="btn btn-primary min-h-11 px-3 py-1.5 text-xs"
+                                class="btn btn-primary min-h-11 px-2.5 py-1.5 text-xs sm:px-3"
                                 onclick={() => onidentify?.(visit.best)}
                             >
                                 {$_('dashboard.field_log.identify', { default: 'Identify' })}
                             </button>
                         {:else}
                             <button
-                                class="btn btn-ghost min-h-11 px-3 py-1.5 text-xs"
+                                class="btn btn-ghost min-h-11 px-2.5 py-1.5 text-xs sm:px-3"
                                 onclick={() => onselect?.(visit.best)}
                             >
                                 {$_('dashboard.field_log.open', { default: 'Open' })}

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -299,7 +299,8 @@
       "preview_trigger": "Vorschau für {species}",
       "preview_alt": "{species} auf {camera}",
       "preview_frames": "{count} Aufnahmen in diesem Besuch, die klarste wird gezeigt",
-      "earlier": "{count} frühere Besuche heute"
+      "earlier": "{count} frühere Besuche heute",
+      "preview_frame_position": "Aufnahme {position} von {count} in diesem Besuch"
     },
     "day_bar": {
       "today": "Heute",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -299,7 +299,8 @@
       "preview_trigger": "Preview {species}",
       "preview_alt": "{species} on {camera}",
       "preview_frames": "{count} frames in this visit, clearest shown",
-      "earlier": "{count} earlier visits today"
+      "earlier": "{count} earlier visits today",
+      "preview_frame_position": "Frame {position} of {count} in this visit"
     },
     "day_bar": {
       "today": "Today",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -299,7 +299,8 @@
       "preview_trigger": "Vista previa de {species}",
       "preview_alt": "{species} en {camera}",
       "preview_frames": "{count} fotogramas en esta visita, se muestra el más nítido",
-      "earlier": "{count} visitas anteriores hoy"
+      "earlier": "{count} visitas anteriores hoy",
+      "preview_frame_position": "Fotograma {position} de {count} de esta visita"
     },
     "day_bar": {
       "today": "Hoy",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -299,7 +299,8 @@
       "preview_trigger": "Aperçu de {species}",
       "preview_alt": "{species} sur {camera}",
       "preview_frames": "{count} images dans cette visite, la plus nette est affichée",
-      "earlier": "{count} visites plus tôt aujourd’hui"
+      "earlier": "{count} visites plus tôt aujourd’hui",
+      "preview_frame_position": "Image {position} sur {count} de cette visite"
     },
     "day_bar": {
       "today": "Aujourd’hui",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -299,7 +299,8 @@
       "preview_trigger": "Anteprima di {species}",
       "preview_alt": "{species} su {camera}",
       "preview_frames": "{count} fotogrammi in questa visita, viene mostrato il più nitido",
-      "earlier": "{count} visite precedenti oggi"
+      "earlier": "{count} visite precedenti oggi",
+      "preview_frame_position": "Fotogramma {position} di {count} di questa visita"
     },
     "day_bar": {
       "today": "Oggi",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -299,7 +299,8 @@
       "preview_trigger": "{species} をプレビュー",
       "preview_alt": "{camera} の {species}",
       "preview_frames": "この訪問の {count} フレームのうち、最も鮮明なものを表示しています",
-      "earlier": "今日はほかに {count} 件の訪問"
+      "earlier": "今日はほかに {count} 件の訪問",
+      "preview_frame_position": "この訪問の {count} フレーム中 {position} 枚目"
     },
     "day_bar": {
       "today": "今日",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -299,7 +299,8 @@
       "preview_trigger": "Pré-visualizar {species}",
       "preview_alt": "{species} em {camera}",
       "preview_frames": "{count} fotogramas nesta visita, é mostrado o mais nítido",
-      "earlier": "{count} visitas anteriores hoje"
+      "earlier": "{count} visitas anteriores hoje",
+      "preview_frame_position": "Fotograma {position} de {count} desta visita"
     },
     "day_bar": {
       "today": "Hoje",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -299,7 +299,8 @@
       "preview_trigger": "Предпросмотр: {species}",
       "preview_alt": "{species} на камере {camera}",
       "preview_frames": "Кадров в этом визите: {count}, показан самый чёткий",
-      "earlier": "Ещё {count} визитов сегодня"
+      "earlier": "Ещё {count} визитов сегодня",
+      "preview_frame_position": "Кадр {position} из {count} в этом визите"
     },
     "day_bar": {
       "today": "Сегодня",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -299,7 +299,8 @@
       "preview_trigger": "预览 {species}",
       "preview_alt": "{camera} 上的 {species}",
       "preview_frames": "本次到访共 {count} 帧，显示最清晰的一帧",
-      "earlier": "今天更早的 {count} 次到访"
+      "earlier": "今天更早的 {count} 次到访",
+      "preview_frame_position": "本次到访的第 {position} 帧，共 {count} 帧"
     },
     "day_bar": {
       "today": "今天",

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -1079,101 +1079,81 @@
         </div>
     {/if}
 
-    <ExplorerFilters
-        species={availableSpecies}
-        cameras={availableCameras}
-        filters={eventFilters}
-        {datePreset}
-        {speciesFilter}
-        {cameraFilter}
-        {favoritesOnly}
-        {audioConfirmedOnly}
-        {showHidden}
-        {hiddenCount}
-        {customStartDate}
-        {customEndDate}
-        canSeeHidden={authStore.hasOwnerAccess}
-        refreshing={refreshingFilterOptions}
-        resultCount={totalCount}
-        onchange={(next) => {
-            if (next.datePreset !== undefined) datePreset = next.datePreset;
-            if (next.speciesFilter !== undefined) speciesFilter = next.speciesFilter;
-            if (next.cameraFilter !== undefined) cameraFilter = next.cameraFilter;
-            if (next.favoritesOnly !== undefined) favoritesOnly = next.favoritesOnly;
-            if (next.audioConfirmedOnly !== undefined) audioConfirmedOnly = next.audioConfirmedOnly;
-            if (next.showHidden !== undefined) showHidden = next.showHidden;
-            if (next.customStartDate !== undefined) customStartDate = next.customStartDate;
-            if (next.customEndDate !== undefined) customEndDate = next.customEndDate;
-            currentPage = 1;
-            loadEvents();
-        }}
-        onclear={() => {
-            datePreset = 'all';
-            speciesFilter = '';
-            cameraFilter = '';
-            favoritesOnly = false;
-            audioConfirmedOnly = false;
-            showHidden = false;
-            customStartDate = '';
-            customEndDate = '';
-            currentPage = 1;
-            loadEvents();
-        }}
-        onrefresh={() => refreshEventMetadata(true, true)}
-    />
-
-
-    {#if error}
-        <div class="p-4 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 border border-red-200 dark:border-red-800">
-            {error}
-            <button onclick={loadEvents} class="ml-2 underline">{$_('common.retry')}</button>
+    <div class="grid gap-6 lg:grid-cols-[14rem_minmax(0,1fr)] lg:items-start" data-explorer-layout>
+        <div class="lg:sticky lg:top-4">
+        <ExplorerFilters
+            species={availableSpecies}
+            cameras={availableCameras}
+            filters={eventFilters}
+            {datePreset}
+            {speciesFilter}
+            {cameraFilter}
+            {favoritesOnly}
+            {audioConfirmedOnly}
+            {showHidden}
+            {hiddenCount}
+            {customStartDate}
+            {customEndDate}
+            canSeeHidden={authStore.hasOwnerAccess}
+            refreshing={refreshingFilterOptions}
+            resultCount={totalCount}
+            onchange={(next) => {
+                if (next.datePreset !== undefined) datePreset = next.datePreset;
+                if (next.speciesFilter !== undefined) speciesFilter = next.speciesFilter;
+                if (next.cameraFilter !== undefined) cameraFilter = next.cameraFilter;
+                if (next.favoritesOnly !== undefined) favoritesOnly = next.favoritesOnly;
+                if (next.audioConfirmedOnly !== undefined) audioConfirmedOnly = next.audioConfirmedOnly;
+                if (next.showHidden !== undefined) showHidden = next.showHidden;
+                if (next.customStartDate !== undefined) customStartDate = next.customStartDate;
+                if (next.customEndDate !== undefined) customEndDate = next.customEndDate;
+                currentPage = 1;
+                loadEvents();
+            }}
+            onclear={() => {
+                datePreset = 'all';
+                speciesFilter = '';
+                cameraFilter = '';
+                favoritesOnly = false;
+                audioConfirmedOnly = false;
+                showHidden = false;
+                customStartDate = '';
+                customEndDate = '';
+                currentPage = 1;
+                loadEvents();
+            }}
+            onrefresh={() => refreshEventMetadata(true, true)}
+        />
         </div>
-    {/if}
 
-    {#if !loading && timelineBuckets.length > 0}
-        <section data-events-timeline class="border-y border-slate-200 py-3 dark:border-slate-700">
-            <div class="flex flex-wrap items-center gap-2">
-                <button
-                    type="button"
-                    class="inline-flex min-h-11 items-center gap-2 rounded-full border px-3 py-2 text-xs font-semibold transition-colors
-                        {selectedTimelineBucket === 'all'
-                            ? 'bg-brand-100/90 dark:bg-brand-500/20 border-brand-300/80 dark:border-brand-400/60 text-brand-700 dark:text-brand-100 shadow-sm'
-                            : 'bg-white/80 dark:bg-slate-800/60 border-slate-300/80 dark:border-slate-600/70 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700/70'}"
-                    onclick={() => selectedTimelineBucket = 'all'}
-                >
-                    <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                        <circle cx="10" cy="10" r="6"></circle>
-                        <path d="M4.5 10h11"></path>
-                    </svg>
-                    <span>{$_('common.all', { default: 'All' })}</span>
-                    <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold normal-case tracking-normal
-                        {selectedTimelineBucket === 'all'
-                            ? 'bg-brand-200/80 dark:bg-brand-400/25 text-brand-800 dark:text-brand-100'
-                            : 'bg-slate-100 dark:bg-slate-700/60 text-slate-700 dark:text-slate-200'}"
-                    >
-                        <svg class="h-3 w-3" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                            <path d="M4 14h12"></path>
-                            <path d="M7 14V9M10 14V6M13 14v-3"></path>
-                        </svg>
-                        {events.length}
-                    </span>
-                </button>
-                {#each timelineBuckets as bucket}
+        <div class="min-w-0">
+
+
+
+        {#if error}
+            <div class="p-4 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 border border-red-200 dark:border-red-800">
+                {error}
+                <button onclick={loadEvents} class="ml-2 underline">{$_('common.retry')}</button>
+            </div>
+        {/if}
+
+        {#if !loading && timelineBuckets.length > 0}
+            <section data-events-timeline class="border-y border-slate-200 py-3 dark:border-slate-700">
+                <div class="flex flex-wrap items-center gap-2">
                     <button
                         type="button"
                         class="inline-flex min-h-11 items-center gap-2 rounded-full border px-3 py-2 text-xs font-semibold transition-colors
-                            {selectedTimelineBucket === bucket.key
+                            {selectedTimelineBucket === 'all'
                                 ? 'bg-brand-100/90 dark:bg-brand-500/20 border-brand-300/80 dark:border-brand-400/60 text-brand-700 dark:text-brand-100 shadow-sm'
                                 : 'bg-white/80 dark:bg-slate-800/60 border-slate-300/80 dark:border-slate-600/70 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700/70'}"
-                        onclick={() => selectedTimelineBucket = bucket.key}
+                        onclick={() => selectedTimelineBucket = 'all'}
                     >
                         <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                            <rect x="3" y="4" width="14" height="13" rx="2"></rect>
-                            <path d="M3 8h14"></path>
+                            <circle cx="10" cy="10" r="6"></circle>
+                            <path d="M4.5 10h11"></path>
                         </svg>
-                        <span>{bucket.label}</span>
+                        <span>{$_('common.all', { default: 'All' })}</span>
                         <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold normal-case tracking-normal
-                            {selectedTimelineBucket === bucket.key
+                            {selectedTimelineBucket === 'all'
                                 ? 'bg-brand-200/80 dark:bg-brand-400/25 text-brand-800 dark:text-brand-100'
                                 : 'bg-slate-100 dark:bg-slate-700/60 text-slate-700 dark:text-slate-200'}"
                         >
@@ -1181,64 +1161,92 @@
                                 <path d="M4 14h12"></path>
                                 <path d="M7 14V9M10 14V6M13 14v-3"></path>
                             </svg>
-                            {bucket.count}
+                            {events.length}
                         </span>
                     </button>
+                    {#each timelineBuckets as bucket}
+                        <button
+                            type="button"
+                            class="inline-flex min-h-11 items-center gap-2 rounded-full border px-3 py-2 text-xs font-semibold transition-colors
+                                {selectedTimelineBucket === bucket.key
+                                    ? 'bg-brand-100/90 dark:bg-brand-500/20 border-brand-300/80 dark:border-brand-400/60 text-brand-700 dark:text-brand-100 shadow-sm'
+                                    : 'bg-white/80 dark:bg-slate-800/60 border-slate-300/80 dark:border-slate-600/70 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700/70'}"
+                            onclick={() => selectedTimelineBucket = bucket.key}
+                        >
+                            <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                                <rect x="3" y="4" width="14" height="13" rx="2"></rect>
+                                <path d="M3 8h14"></path>
+                            </svg>
+                            <span>{bucket.label}</span>
+                            <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold normal-case tracking-normal
+                                {selectedTimelineBucket === bucket.key
+                                    ? 'bg-brand-200/80 dark:bg-brand-400/25 text-brand-800 dark:text-brand-100'
+                                    : 'bg-slate-100 dark:bg-slate-700/60 text-slate-700 dark:text-slate-200'}"
+                            >
+                                <svg class="h-3 w-3" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                                    <path d="M4 14h12"></path>
+                                    <path d="M7 14V9M10 14V6M13 14v-3"></path>
+                                </svg>
+                                {bucket.count}
+                            </span>
+                        </button>
+                    {/each}
+                </div>
+                <p class="mt-2 hidden items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400 sm:inline-flex">
+                    <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                        <path d="M6 7h8M6 10h8M6 13h5"></path>
+                        <rect x="3" y="4" width="14" height="12" rx="2"></rect>
+                    </svg>
+                    {$_('events.timeline_keyboard_hint', { default: 'Timeline keyboard: [ previous day, ] next day, 0 reset' })}
+                </p>
+            </section>
+        {/if}
+
+        {#if !loading && visibleEvents.length === 0}
+            <div class="border-y border-dashed border-slate-200 py-12 text-center dark:border-slate-700">
+                <svg class="mx-auto mb-4 h-10 w-10 text-brand-600 dark:text-brand-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16 7h.01M3.5 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.3-2.3L2 20" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m20 7 2 .5-2 .5M10 18v3m4-3.25V21M7 18a6 6 0 0 0 3.8-10.6" />
+                </svg>
+                <h3 class="text-lg font-semibold text-slate-900 dark:text-white">{$_('events.empty_title')}</h3>
+                <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">{$_('events.empty_desc')}</p>
+            </div>
+        {:else}
+            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                {#each visibleEvents as event, index (eventKey(event))}
+                    <DetectionCard 
+                        detection={event} 
+                        {index}
+                        onclick={() => handleEventCardClick(event)}
+                        onPlay={() => {
+                            videoEventId = event.frigate_event;
+                            videoShareToken = null;
+                            videoPlayIntent = 'user';
+                            showVideo = true;
+                            selectedEvent = null;
+                        }}
+                        onFetchFullVisit={recordingClipFetchEnabled ? () => handleFetchFullVisit(event) : undefined}
+                        fullVisitAvailable={fullVisitAvailability[event.frigate_event] === 'available'}
+                        fullVisitFetched={fullVisitFetchState[event.frigate_event] === 'ready'}
+                        fullVisitFetchState={fullVisitFetchState[event.frigate_event] ?? 'idle'}
+                        hideProgress={selectedEvent?.frigate_event === event.frigate_event}
+                        selectionMode={selectionMode}
+                        selected={selectedEventIds.includes(event.frigate_event)}
+                    />
                 {/each}
             </div>
-            <p class="mt-2 hidden items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400 sm:inline-flex">
-                <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                    <path d="M6 7h8M6 10h8M6 13h5"></path>
-                    <rect x="3" y="4" width="14" height="12" rx="2"></rect>
-                </svg>
-                {$_('events.timeline_keyboard_hint', { default: 'Timeline keyboard: [ previous day, ] next day, 0 reset' })}
-            </p>
-        </section>
-    {/if}
+        {/if}
 
-    {#if !loading && visibleEvents.length === 0}
-        <div class="border-y border-dashed border-slate-200 py-12 text-center dark:border-slate-700">
-            <svg class="mx-auto mb-4 h-10 w-10 text-brand-600 dark:text-brand-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M16 7h.01M3.5 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.3-2.3L2 20" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="m20 7 2 .5-2 .5M10 18v3m4-3.25V21M7 18a6 6 0 0 0 3.8-10.6" />
-            </svg>
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">{$_('events.empty_title')}</h3>
-            <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">{$_('events.empty_desc')}</p>
+        <Pagination
+            {currentPage}
+            {totalPages}
+            totalItems={totalCount}
+            itemsPerPage={pageSize}
+            onPageChange={handlePageChange}
+            onPageSizeChange={handlePageSizeChange}
+        />
         </div>
-    {:else}
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {#each visibleEvents as event, index (eventKey(event))}
-                <DetectionCard 
-                    detection={event} 
-                    {index}
-                    onclick={() => handleEventCardClick(event)}
-                    onPlay={() => {
-                        videoEventId = event.frigate_event;
-                        videoShareToken = null;
-                        videoPlayIntent = 'user';
-                        showVideo = true;
-                        selectedEvent = null;
-                    }}
-                    onFetchFullVisit={recordingClipFetchEnabled ? () => handleFetchFullVisit(event) : undefined}
-                    fullVisitAvailable={fullVisitAvailability[event.frigate_event] === 'available'}
-                    fullVisitFetched={fullVisitFetchState[event.frigate_event] === 'ready'}
-                    fullVisitFetchState={fullVisitFetchState[event.frigate_event] ?? 'idle'}
-                    hideProgress={selectedEvent?.frigate_event === event.frigate_event}
-                    selectionMode={selectionMode}
-                    selected={selectedEventIds.includes(event.frigate_event)}
-                />
-            {/each}
-        </div>
-    {/if}
-
-    <Pagination
-        {currentPage}
-        {totalPages}
-        totalItems={totalCount}
-        itemsPerPage={pageSize}
-        onPageChange={handlePageChange}
-        onPageSizeChange={handlePageSizeChange}
-    />
+    </div>
 </div>
 
 {#if selectedEvent}

--- a/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
+++ b/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
@@ -79,14 +79,17 @@ describe('dashboard field desk layout', () => {
     });
 
     it('opens the capture preview on hover and on keyboard focus, and dismisses it', () => {
-        expect(previewSource).toContain('onmouseenter={show}');
-        expect(previewSource).toContain('onfocusin={show}');
+        // Every frame in a visit previews itself, so the handlers take the frame index.
+        expect(previewSource).toContain('onmouseenter={() => show(index)}');
+        expect(previewSource).toContain('onfocusin={() => show(index)}');
+        expect(previewSource).toContain('let openIndex = $state<number | null>(null)');
+        expect(previewSource).toContain('dashboard.field_log.preview_frame_position');
         expect(previewSource).toContain('onfocusout={handleFocusOut}');
         expect(previewSource).toContain("event.key === 'Escape'");
         // The pointer must be able to travel into the panel (WCAG 2.2 SC 1.4.13).
         expect(previewSource).toContain('CLOSE_GRACE_MS');
         expect(previewSource).toContain('motion-reduce:animate-none');
-        expect(previewSource).toContain('aria-expanded={open}');
+        expect(previewSource).toContain('aria-expanded={openIndex === index}');
         expect(previewSource).toContain('focus-ring');
     });
 
@@ -94,6 +97,7 @@ describe('dashboard field desk layout', () => {
         expect(previewSource).toContain("import { getThumbnailUrl } from '../api'");
         expect(previewSource).toContain('loading="lazy"');
         expect(previewSource.match(/getThumbnailUrl/g) ?? []).toHaveLength(3);
+        expect(previewSource).toContain('onopen?.(frame)');
     });
 
 


### PR DESCRIPTION
## Outcome

A polish pass over the surfaces built this session, reviewed at 390px.

No page overflows horizontally, which is the main thing I wanted to confirm. The field log was the real problem: its action button sat in a full-width row of its own, so each visit took roughly 225 pixels and only four fitted on a phone screen.

- The action shares the row, so rows are ~144px and eight visits fit
- Score and camera now appear under the species name rather than being hidden entirely at phone width
- The thumbnail stack shows one frame plus a count instead of three, which was truncating species names to "Europ..."
- The day bar keeps its live indicator inline once the metrics wrap
- "See full history" stays on the heading row instead of dropping below the subtitle

## Verification

- 671 frontend tests passing, `npm run check` 0 errors, build clean
- Captured all four rebuilt surfaces at 390px; none overflow