### PR TITLE
Fix dashboard review and worker recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,22 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Review confirmations now persist and leave the queue immediately.** Choosing the species a
+  detection already shows, including a translated alias of the same taxon, records the human
+  confirmation without rewriting its canonical taxonomy or adding false correction feedback. The
+  API and dashboard synchronise `manual_tagged` immediately instead of depending on a later live
+  update.
+
+- **Dashboard review and camera state now follows saved settings.** The review queue uses the
+  configured classification threshold instead of a fixed 60% floor. The camera section shows only
+  selected cameras when a selection exists, keeps configured cameras with unavailable health as
+  unknown, and counts grouped visits rather than raw Frigate frames.
+
+- **Active video workers no longer time out while reporting progress.** Every valid worker protocol
+  event now refreshes liveness, so a long frame-analysis run is not killed merely because a heartbeat
+  and a progress event crossed. Manual and maintenance jobs recover from a genuine worker failure by
+  using the existing snapshot fallback and retain a diagnostic record of the recovery.
+
 - **Every frame in a visit previews itself.** Hovering any thumbnail in a folded group showed the
   same clearest frame. Each thumbnail is now its own trigger with its own preview, stating which
   frame it is, and clicking one opens that frame rather than the visit's best.

--- a/apps/ui/src/lib/api/classifier.ts
+++ b/apps/ui/src/lib/api/classifier.ts
@@ -112,13 +112,7 @@ export async function downloadDefaultModel(): Promise<DownloadModelResult> {
 
 export type ReclassifyResult = paths['/api/events/{event_id}/reclassify']['post']['response'];
 
-export interface UpdateDetectionResult {
-    status: string;
-    event_id: string;
-    old_species?: string;
-    new_species?: string;
-    species?: string;
-}
+export type UpdateDetectionResult = paths['/api/events/{event_id}']['patch']['response'];
 
 export type BulkUpdateDetectionResult = paths['/api/events/bulk/manual-tag']['patch']['response'];
 

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -1061,8 +1061,10 @@ export interface components {
     status: "saved";
 };
     ManualTagResponse: {
+    category_name?: string | null;
     common_name?: string | null;
     event_id: string;
+    manual_tagged: boolean;
     new_species: string;
     old_species?: string | null;
     scientific_name?: string | null;

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -11,7 +11,7 @@ export interface Detection {
     detection_time: string;
     camera_name: string;
     detection_index?: number;
-    category_name?: string;
+    category_name?: string | null;
     has_clip?: boolean;
     has_snapshot?: boolean;
     has_frigate_event?: boolean;
@@ -36,9 +36,9 @@ export interface Detection {
     weather_precipitation?: number;
     weather_rain?: number;
     weather_snowfall?: number;
-    scientific_name?: string;
-    common_name?: string;
-    taxa_id?: number;
+    scientific_name?: string | null;
+    common_name?: string | null;
+    taxa_id?: number | null;
     video_classification_score?: number;
     video_classification_label?: string;
     video_classification_timestamp?: string;

--- a/apps/ui/src/lib/components/DeskContextCards.svelte
+++ b/apps/ui/src/lib/components/DeskContextCards.svelte
@@ -2,6 +2,8 @@
     import { onMount } from 'svelte';
     import { fetchCameraStatuses } from '../api';
     import type { AudioSummaryResponse, CameraStatusResponse, Detection } from '../api';
+    import type { DetectionVisit } from '../utils/visit-grouping';
+    import { buildDashboardCameraRows } from '../utils/dashboard-cameras';
     import { formatTime } from '../utils/datetime';
     import { formatTemperature } from '../utils/temperature';
     import { getTemperatureUnitForSystem, resolveWeatherUnitSystem } from '../utils/weather-units';
@@ -14,12 +16,13 @@
     interface Props {
         /** The detections the log is showing, newest first. */
         detections: Detection[];
+        visits: DetectionVisit[];
         birdnetEnabled?: boolean;
         /** Fetched once by the page and shared with the day bar. */
         audioSummary?: AudioSummaryResponse | null;
     }
 
-    let { detections, birdnetEnabled = false, audioSummary = null }: Props = $props();
+    let { detections, visits, birdnetEnabled = false, audioSummary = null }: Props = $props();
 
     let cameraStatus = $state<CameraStatusResponse | null>(null);
 
@@ -43,49 +46,13 @@
         return () => controller.abort();
     });
 
-    interface CameraRow {
-        name: string;
-        visits: number;
-        status: 'online' | 'offline' | 'unknown';
-        /** The most recent visit, so a quiet camera is visibly quiet. */
-        lastSeen: string | null;
-    }
-
-    const cameraRows = $derived.by<CameraRow[]>(() => {
-        const visitsByCamera = new Map<string, number>();
-        const lastSeenByCamera = new Map<string, string>();
-        for (const detection of detections) {
-            const camera = detection.camera_name;
-            if (!camera) continue;
-            visitsByCamera.set(camera, (visitsByCamera.get(camera) ?? 0) + 1);
-            const seen = lastSeenByCamera.get(camera);
-            if (!seen || detection.detection_time > seen) {
-                lastSeenByCamera.set(camera, detection.detection_time);
-            }
-        }
-
-        const known = cameraStatus?.cameras ?? [];
-        const rows: CameraRow[] = known.map((camera) => ({
-            name: camera.camera,
-            visits: visitsByCamera.get(camera.camera) ?? 0,
-            status: camera.status,
-            lastSeen: lastSeenByCamera.get(camera.camera) ?? null
-        }));
-
-        // A camera that produced detections but is missing from the status list still belongs here.
-        for (const [name, visits] of visitsByCamera) {
-            if (!rows.some((row) => row.name === name)) {
-                rows.push({
-                    name,
-                    visits,
-                    status: 'unknown',
-                    lastSeen: lastSeenByCamera.get(name) ?? null
-                });
-            }
-        }
-
-        return rows.sort((left, right) => right.visits - left.visits || left.name.localeCompare(right.name));
-    });
+    const cameraRows = $derived(
+        buildDashboardCameraRows({
+            cameraStatus,
+            visits,
+            configuredCameras: settingsStore.settings?.cameras ?? null
+        })
+    );
 
     const crossConfirmed = $derived(
         detections.reduce((total, detection) => total + (detection.audio_confirmed ? 1 : 0), 0)

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -1026,7 +1026,7 @@
         const needsEbirdNearby = ebirdEnabled && showEbirdNearby;
         const needsEbirdNotable = ebirdEnabled && showEbirdNotable;
         if (needsEbirdNearby) {
-            void loadEbirdNearby(detection.display_name, detection.scientific_name);
+            void loadEbirdNearby(detection.display_name, detection.scientific_name ?? undefined);
         }
         if (needsEbirdNotable) {
             void loadEbirdNotable();

--- a/apps/ui/src/lib/components/ReviewQueueModal.svelte
+++ b/apps/ui/src/lib/components/ReviewQueueModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { fetchSnapshotCandidates, getThumbnailUrl } from '../api';
     import type { Detection, SnapshotCandidate } from '../api';
     import { advance, createReviewSession, remaining, type ReviewSession } from '../utils/review-session';
@@ -21,7 +22,7 @@
 
     let { queue, labels = [], suggestions = [], onidentify, onhide, onopen, onclose }: Props = $props();
 
-    let session = $state<ReviewSession>(createReviewSession(queue));
+    let session = $state<ReviewSession>(untrack(() => createReviewSession(queue)));
     // A wide feeder shot does not settle what a 56% blur is; the crop the classifier
     // scored does. Crops exist only for events that have been scanned, so this is a
     // best-effort enrichment rather than something the flow depends on.

--- a/apps/ui/src/lib/pages/Dashboard.svelte
+++ b/apps/ui/src/lib/pages/Dashboard.svelte
@@ -28,6 +28,7 @@
     import { getBirdNames } from '../naming';
     import { groupDetectionsIntoVisits, withinDeskWindow } from '../utils/visit-grouping';
     import { buildReviewQueue } from '../utils/review-queue';
+    import { applyManualTagResult } from '../utils/manual-tag';
 
     interface Props {
         onnavigate?: (path: string) => void;
@@ -95,9 +96,10 @@
 
     // One window for the whole desk, so the day bar, the log and the context cards agree.
     let deskDetections = $derived(withinDeskWindow(detectionsStore.detections));
+    let reviewThreshold = $derived(settingsStore.settings?.classification_threshold ?? null);
 
     // The day reads as visits, not frames: repeat frames of one bird fold into one row.
-    let allVisits = $derived(groupDetectionsIntoVisits(deskDetections));
+    let allVisits = $derived(groupDetectionsIntoVisits(deskDetections, { reviewThreshold }));
     let visits = $derived(allVisits.slice(0, VISIT_ROW_LIMIT));
     let hiddenVisitCount = $derived(Math.max(allVisits.length - visits.length, 0));
 
@@ -133,7 +135,8 @@
 
     async function identifyFromQueue(detection: Detection, species: string): Promise<void> {
         try {
-            await updateDetectionSpecies(detection.frigate_event, species);
+            const result = await updateDetectionSpecies(detection.frigate_event, species);
+            detectionsStore.updateDetection(applyManualTagResult(detection, result));
             toastStore.show($_('detection.species_updated', { default: 'Species updated' }), 'success');
         } catch (e) {
             toastStore.show(getErrorMessage(e), 'error');
@@ -152,7 +155,7 @@
     }
 
     // Detections still waiting on a person, oldest first.
-    let reviewQueue = $derived(buildReviewQueue(deskDetections));
+    let reviewQueue = $derived(buildReviewQueue(deskDetections, { reviewThreshold }));
 
     // Derive reclassification progress for the modal
     let modalReclassifyProgress = $derived(
@@ -387,12 +390,9 @@
         updatingTag = true;
         try {
             const eventId = selectedEvent.frigate_event;
-            await updateDetectionSpecies(eventId, newSpecies);
-            selectedEvent.display_name = newSpecies;
-            selectedEvent.category_name = newSpecies;
-            selectedEvent.manual_tagged = true;
-            // Optimistically update store
-            detectionsStore.updateDetection({ ...selectedEvent, display_name: newSpecies, category_name: newSpecies, manual_tagged: true });
+            const result = await updateDetectionSpecies(eventId, newSpecies);
+            selectedEvent = applyManualTagResult(selectedEvent, result);
+            detectionsStore.updateDetection(selectedEvent);
             if (recordingClipFetchEnabled) {
                 await fullVisitStore.ensureAvailability(eventId, { refresh: true });
             }
@@ -495,6 +495,7 @@
 
             <DeskContextCards
                 detections={deskDetections}
+                visits={allVisits}
                 {birdnetEnabled}
                 {audioSummary}
             />
@@ -526,7 +527,10 @@
 
 {#if reviewSessionOpen && canReview}
     <ReviewQueueModal
-        queue={buildReviewQueue(deskDetections, Number.MAX_SAFE_INTEGER).items}
+        queue={buildReviewQueue(deskDetections, {
+            reviewThreshold,
+            limit: Number.MAX_SAFE_INTEGER
+        }).items}
         labels={classifierLabels}
         suggestions={recentSpecies}
         onidentify={identifyFromQueue}

--- a/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
+++ b/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
@@ -41,8 +41,8 @@ describe('dashboard field desk layout', () => {
     });
 
     it('folds repeat frames into visits instead of printing one card per frame', () => {
-        expect(dashboardSource).toContain('groupDetectionsIntoVisits(deskDetections)');
-        expect(dashboardSource).toContain('buildReviewQueue(deskDetections)');
+        expect(dashboardSource).toContain('groupDetectionsIntoVisits(deskDetections, { reviewThreshold })');
+        expect(dashboardSource).toContain('buildReviewQueue(deskDetections, { reviewThreshold })');
         expect(dashboardSource).not.toContain('LatestDetectionHero');
         expect(dashboardSource).not.toContain('data-dashboard-discovery-feed');
     });

--- a/apps/ui/src/lib/utils/dashboard-cameras.test.ts
+++ b/apps/ui/src/lib/utils/dashboard-cameras.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { CameraStatusResponse, Detection } from '../api';
+import type { DetectionVisit } from './visit-grouping';
+import { buildDashboardCameraRows } from './dashboard-cameras';
+
+function visit(camera: string, eventId: string, endTime: string): DetectionVisit {
+    const detection = {
+        frigate_event: eventId,
+        camera_name: camera,
+        display_name: 'Blue Tit',
+        detection_time: endTime,
+        score: 0.9
+    } as Detection;
+    return {
+        key: eventId,
+        species: detection.display_name,
+        camera,
+        frames: [detection],
+        lead: detection,
+        best: detection,
+        startTime: endTime,
+        endTime,
+        needsReview: false
+    };
+}
+
+const status: CameraStatusResponse = {
+    checked_at: '2026-08-12T09:00:00Z',
+    cameras: [
+        { camera: 'front', status: 'online' },
+        { camera: 'garden', status: 'online' },
+        { camera: 'garage', status: 'offline' }
+    ]
+};
+
+describe('buildDashboardCameraRows', () => {
+    it('shows only configured cameras and excludes historical or unrelated Frigate cameras', () => {
+        const rows = buildDashboardCameraRows({
+            cameraStatus: status,
+            visits: [
+                visit('front', 'front-1', '2026-08-12T08:00:00Z'),
+                visit('garage', 'garage-1', '2026-08-12T07:00:00Z')
+            ],
+            configuredCameras: ['front', 'garden']
+        });
+
+        expect(rows.map((row) => row.name)).toEqual(['front', 'garden']);
+        expect(rows[0]).toMatchObject({ visits: 1, status: 'online' });
+        expect(rows[1]).toMatchObject({ visits: 0, status: 'online' });
+    });
+
+    it('keeps a configured camera visible with unknown health when Frigate omits it', () => {
+        const rows = buildDashboardCameraRows({
+            cameraStatus: status,
+            visits: [],
+            configuredCameras: ['nest']
+        });
+
+        expect(rows).toEqual([{ name: 'nest', visits: 0, status: 'unknown', lastSeen: null }]);
+    });
+
+    it('uses all reporting and visiting cameras when the configured list is deliberately empty', () => {
+        const rows = buildDashboardCameraRows({
+            cameraStatus: status,
+            visits: [visit('side', 'side-1', '2026-08-12T08:30:00Z')],
+            configuredCameras: []
+        });
+
+        expect(rows.map((row) => row.name)).toEqual(['side', 'front', 'garage', 'garden']);
+    });
+
+    it('does not expose status-only cameras before settings have loaded', () => {
+        const rows = buildDashboardCameraRows({
+            cameraStatus: status,
+            visits: [visit('front', 'front-1', '2026-08-12T08:00:00Z')],
+            configuredCameras: null
+        });
+
+        expect(rows.map((row) => row.name)).toEqual(['front']);
+    });
+});

--- a/apps/ui/src/lib/utils/dashboard-cameras.ts
+++ b/apps/ui/src/lib/utils/dashboard-cameras.ts
@@ -1,0 +1,55 @@
+import type { CameraStatusResponse } from '../api';
+import type { DetectionVisit } from './visit-grouping';
+
+export interface DashboardCameraRow {
+    name: string;
+    visits: number;
+    status: 'online' | 'offline' | 'unknown';
+    lastSeen: string | null;
+}
+
+interface DashboardCameraRowsInput {
+    cameraStatus: CameraStatusResponse | null;
+    visits: readonly DetectionVisit[];
+    /** Null while settings load; an empty list deliberately means every camera. */
+    configuredCameras: readonly string[] | null;
+}
+
+export function buildDashboardCameraRows({
+    cameraStatus,
+    visits,
+    configuredCameras
+}: DashboardCameraRowsInput): DashboardCameraRow[] {
+    const visitsByCamera = new Map<string, number>();
+    const lastSeenByCamera = new Map<string, string>();
+    for (const visit of visits) {
+        if (!visit.camera) continue;
+        visitsByCamera.set(visit.camera, (visitsByCamera.get(visit.camera) ?? 0) + 1);
+        const seen = lastSeenByCamera.get(visit.camera);
+        if (!seen || visit.endTime > seen) lastSeenByCamera.set(visit.camera, visit.endTime);
+    }
+
+    const statusByCamera = new Map(
+        (cameraStatus?.cameras ?? []).map((camera) => [camera.camera, camera.status] as const)
+    );
+    const cameraNames = new Set<string>();
+    if (configuredCameras === null) {
+        for (const name of visitsByCamera.keys()) cameraNames.add(name);
+    } else if (configuredCameras.length > 0) {
+        for (const name of configuredCameras) {
+            if (name) cameraNames.add(name);
+        }
+    } else {
+        for (const name of statusByCamera.keys()) cameraNames.add(name);
+        for (const name of visitsByCamera.keys()) cameraNames.add(name);
+    }
+
+    return [...cameraNames]
+        .map((name) => ({
+            name,
+            visits: visitsByCamera.get(name) ?? 0,
+            status: statusByCamera.get(name) ?? 'unknown',
+            lastSeen: lastSeenByCamera.get(name) ?? null
+        }))
+        .sort((left, right) => right.visits - left.visits || left.name.localeCompare(right.name));
+}

--- a/apps/ui/src/lib/utils/manual-tag.test.ts
+++ b/apps/ui/src/lib/utils/manual-tag.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { Detection, UpdateDetectionResult } from '../api';
+import { applyManualTagResult } from './manual-tag';
+
+const detection = {
+    frigate_event: 'event-1',
+    display_name: 'Blue Tit',
+    category_name: 'Cyanistes caeruleus',
+    scientific_name: 'Cyanistes caeruleus',
+    common_name: 'Blue Tit',
+    taxa_id: 144028,
+    manual_tagged: false,
+    camera_name: 'front',
+    detection_time: '2026-08-12T08:00:00Z',
+    score: 0.52
+} as Detection;
+
+describe('applyManualTagResult', () => {
+    it('removes a same-species confirmation from the local queue without waiting for SSE', () => {
+        const result = {
+            status: 'unchanged',
+            event_id: 'event-1',
+            new_species: 'Blue Tit',
+            species: 'Blue Tit',
+            old_species: 'Blue Tit',
+            category_name: 'Cyanistes caeruleus',
+            scientific_name: 'Cyanistes caeruleus',
+            common_name: 'Blue Tit',
+            taxa_id: 144028,
+            manual_tagged: true
+        } satisfies UpdateDetectionResult;
+
+        expect(applyManualTagResult(detection, result)).toMatchObject({
+            display_name: 'Blue Tit',
+            category_name: 'Cyanistes caeruleus',
+            manual_tagged: true
+        });
+    });
+
+    it('applies the canonical names returned by the server after a correction', () => {
+        const result = {
+            status: 'updated',
+            event_id: 'event-1',
+            new_species: 'Great Tit',
+            old_species: 'Blue Tit',
+            category_name: 'Parus major',
+            scientific_name: 'Parus major',
+            common_name: 'Great Tit',
+            taxa_id: 145252,
+            manual_tagged: true
+        } satisfies UpdateDetectionResult;
+
+        expect(applyManualTagResult(detection, result)).toMatchObject({
+            display_name: 'Great Tit',
+            category_name: 'Parus major',
+            scientific_name: 'Parus major',
+            common_name: 'Great Tit',
+            taxa_id: 145252,
+            manual_tagged: true
+        });
+    });
+});

--- a/apps/ui/src/lib/utils/manual-tag.ts
+++ b/apps/ui/src/lib/utils/manual-tag.ts
@@ -1,0 +1,13 @@
+import type { Detection, UpdateDetectionResult } from '../api';
+
+export function applyManualTagResult(detection: Detection, result: UpdateDetectionResult): Detection {
+    return {
+        ...detection,
+        display_name: result.new_species,
+        category_name: result.category_name ?? result.scientific_name ?? result.new_species,
+        scientific_name: result.scientific_name,
+        common_name: result.common_name,
+        taxa_id: result.taxa_id,
+        manual_tagged: result.manual_tagged
+    };
+}

--- a/apps/ui/src/lib/utils/review-queue.test.ts
+++ b/apps/ui/src/lib/utils/review-queue.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Detection } from '../api';
-import { buildReviewQueue } from './review-queue';
+import { buildReviewQueue as buildQueue } from './review-queue';
 
 function detection(overrides: Partial<Detection> & { frigate_event: string }): Detection {
     return {
@@ -12,7 +12,23 @@ function detection(overrides: Partial<Detection> & { frigate_event: string }): D
     } as Detection;
 }
 
+function buildReviewQueue(detections: readonly Detection[], limit: number = 4) {
+    return buildQueue(detections, { reviewThreshold: 0.6, limit });
+}
+
 describe('buildReviewQueue', () => {
+    it('uses the configured naming threshold when deciding what needs a person', () => {
+        const queue = buildQueue(
+            [
+                detection({ frigate_event: 'accepted', score: 0.52 }),
+                detection({ frigate_event: 'weak', score: 0.22 })
+            ],
+            { reviewThreshold: 0.3 }
+        );
+
+        expect(queue.items.map((item) => item.frigate_event)).toEqual(['weak']);
+    });
+
     it('collects unnamed and low-confidence detections and leaves confident ones alone', () => {
         const queue = buildReviewQueue([
             detection({ frigate_event: 'named', score: 0.98 }),

--- a/apps/ui/src/lib/utils/review-queue.ts
+++ b/apps/ui/src/lib/utils/review-queue.ts
@@ -13,11 +13,16 @@ export interface ReviewQueue {
 
 export const REVIEW_QUEUE_PREVIEW_LIMIT = 4;
 
-function isOpen(detection: Detection): boolean {
+export interface ReviewQueueOptions {
+    reviewThreshold: number | null;
+    limit?: number;
+}
+
+function isOpen(detection: Detection, reviewThreshold: number | null): boolean {
     if (detection.is_hidden) return false;
     // A manual tag is the human decision this queue is asking for.
     if (detection.manual_tagged) return false;
-    return needsReview(detection);
+    return needsReview(detection, reviewThreshold);
 }
 
 function oldestFirst(left: Detection, right: Detection): number {
@@ -34,9 +39,9 @@ function oldestFirst(left: Detection, right: Detection): number {
  */
 export function buildReviewQueue(
     detections: readonly Detection[],
-    limit: number = REVIEW_QUEUE_PREVIEW_LIMIT
+    { reviewThreshold, limit = REVIEW_QUEUE_PREVIEW_LIMIT }: ReviewQueueOptions
 ): ReviewQueue {
-    const open = detections.filter(isOpen).sort(oldestFirst);
+    const open = detections.filter((detection) => isOpen(detection, reviewThreshold)).sort(oldestFirst);
 
     return {
         items: open.slice(0, limit),

--- a/apps/ui/src/lib/utils/visit-grouping.test.ts
+++ b/apps/ui/src/lib/utils/visit-grouping.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { Detection } from '../api';
-import { VISIT_GAP_MS, groupDetectionsIntoVisits, withinDeskWindow } from './visit-grouping';
+import {
+    VISIT_GAP_MS,
+    groupDetectionsIntoVisits as groupVisits,
+    needsReview,
+    withinDeskWindow
+} from './visit-grouping';
 
 function detection(overrides: Partial<Detection> & { frigate_event: string }): Detection {
     return {
@@ -12,7 +17,20 @@ function detection(overrides: Partial<Detection> & { frigate_event: string }): D
     } as Detection;
 }
 
+function groupDetectionsIntoVisits(detections: readonly Detection[], gapMs: number = VISIT_GAP_MS) {
+    return groupVisits(detections, { reviewThreshold: 0.6, gapMs });
+}
+
 describe('groupDetectionsIntoVisits', () => {
+    it('uses the saved classification threshold instead of a hard-coded review floor', () => {
+        const named = detection({ frigate_event: 'named', score: 0.52 });
+
+        expect(needsReview(named, 0.3)).toBe(false);
+        expect(needsReview(named, 0.6)).toBe(true);
+        expect(needsReview(named, null)).toBe(false);
+        expect(needsReview(detection({ frigate_event: 'unknown', display_name: 'Unknown Bird' }), null)).toBe(true);
+    });
+
     it('folds repeat frames of one species on one camera into a single visit', () => {
         const visits = groupDetectionsIntoVisits([
             detection({ frigate_event: 'b', detection_time: '2026-08-11T11:34:45Z', score: 0.72 }),

--- a/apps/ui/src/lib/utils/visit-grouping.ts
+++ b/apps/ui/src/lib/utils/visit-grouping.ts
@@ -27,20 +27,24 @@ export const VISIT_GAP_MS = 10 * 60 * 1000;
 /** The dashboard is a "today" surface; Explorer holds the longer history. */
 export const DESK_WINDOW_MS = 24 * 60 * 60 * 1000;
 
-/** Below this the classifier does not assign a species, so a human has to. */
-export const REVIEW_CONFIDENCE_THRESHOLD = 0.6;
-
 const UNRESOLVED_LABEL = 'unknown bird';
+
+export interface VisitGroupingOptions {
+    /** The saved classifier naming threshold. Null means it has not been loaded. */
+    reviewThreshold: number | null;
+    gapMs?: number;
+}
 
 function timestamp(detection: Detection): number {
     const parsed = Date.parse(detection.detection_time);
     return Number.isNaN(parsed) ? Number.NaN : parsed;
 }
 
-export function needsReview(detection: Detection): boolean {
+export function needsReview(detection: Detection, reviewThreshold: number | null): boolean {
     const label = (detection.display_name ?? '').trim().toLowerCase();
     if (!label || label === UNRESOLVED_LABEL) return true;
-    return (detection.score ?? 0) < REVIEW_CONFIDENCE_THRESHOLD;
+    if (reviewThreshold === null || !Number.isFinite(reviewThreshold)) return false;
+    return (detection.score ?? 0) < reviewThreshold;
 }
 
 function belongsToVisit(previous: Detection, candidate: Detection, gapMs: number): boolean {
@@ -56,7 +60,7 @@ function belongsToVisit(previous: Detection, candidate: Detection, gapMs: number
     return Math.abs(previousAt - candidateAt) <= gapMs;
 }
 
-function toVisit(frames: Detection[]): DetectionVisit {
+function toVisit(frames: Detection[], reviewThreshold: number | null): DetectionVisit {
     const lead = frames[0];
     const best = frames.reduce(
         (strongest, frame) => ((frame.score ?? 0) > (strongest.score ?? 0) ? frame : strongest),
@@ -73,7 +77,7 @@ function toVisit(frames: Detection[]): DetectionVisit {
         best,
         startTime: oldest.detection_time,
         endTime: lead.detection_time,
-        needsReview: frames.every(needsReview)
+        needsReview: frames.every((frame) => needsReview(frame, reviewThreshold))
     };
 }
 
@@ -100,7 +104,7 @@ export function withinDeskWindow(
  */
 export function groupDetectionsIntoVisits(
     detections: readonly Detection[],
-    gapMs: number = VISIT_GAP_MS
+    { reviewThreshold, gapMs = VISIT_GAP_MS }: VisitGroupingOptions
 ): DetectionVisit[] {
     if (detections.length === 0) return [];
 
@@ -125,5 +129,5 @@ export function groupDetectionsIntoVisits(
         }
     }
 
-    return visits.map(toVisit);
+    return visits.map((frames) => toVisit(frames, reviewThreshold));
 }

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1974,6 +1974,13 @@ class DetectionRepository:
             ),
         )
 
+    async def confirm_manual_species_tag(self, *, frigate_event: str) -> None:
+        """Record a human confirmation without rewriting the stored species identity."""
+        await self.db.execute(
+            "UPDATE detections SET manual_tagged = 1 WHERE frigate_event = ?",
+            (frigate_event,),
+        )
+
     async def get_favorite_frigate_event_ids(self) -> set[str]:
         """Get Frigate event IDs that are marked as favorites."""
         async with self.db.execute(

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -66,9 +66,11 @@ class ManualTagResponse(BaseModel):
     new_species: str
     species: str | None = None
     old_species: str | None = None
+    category_name: str | None = None
     scientific_name: str | None = None
     common_name: str | None = None
     taxa_id: int | None = None
+    manual_tagged: bool
 
 
 def _build_event_classification_input_context(
@@ -1148,13 +1150,36 @@ async def _apply_manual_tag_update(
         frigate_event=detection.frigate_event,
     )
 
-    if _normalize_species_name(old_species) == _normalize_species_name(new_species):
+    async def confirm_existing_species() -> dict:
+        await repo.confirm_manual_species_tag(frigate_event=event_id)
+        await db.commit()
+
+        refreshed_detection = await repo.get_by_frigate_event(event_id)
+        payload_source = refreshed_detection or detection
+        await broadcaster.broadcast(
+            {
+                "type": "detection_updated",
+                "data": _detection_updated_payload(
+                    payload_source,
+                    overrides={"manual_tagged": True},
+                ),
+            }
+        )
         return {
             "status": "unchanged",
             "event_id": event_id,
             "species": old_species or new_species,
+            "old_species": old_species,
             "new_species": old_species or new_species,
+            "category_name": detection.category_name,
+            "scientific_name": detection.scientific_name,
+            "common_name": detection.common_name,
+            "taxa_id": detection.taxa_id,
+            "manual_tagged": True,
         }
+
+    if _normalize_species_name(old_species) == _normalize_species_name(new_species):
+        return await confirm_existing_species()
 
     unknown_labels = {
         *(label.lower() for label in settings.classification.unknown_bird_labels),
@@ -1177,12 +1202,7 @@ async def _apply_manual_tag_update(
             scientific_name=resolved_aliases.get("scientific_name"),
             taxa_id=resolved_aliases.get("taxa_id"),
         )
-        return {
-            "status": "unchanged",
-            "event_id": event_id,
-            "species": old_species or new_species,
-            "new_species": old_species or new_species,
-        }
+        return await confirm_existing_species()
 
     taxonomy_lookup_name = (
         resolved_aliases.get("scientific_name") or resolved_aliases.get("common_name") or normalized_label
@@ -1317,9 +1337,11 @@ async def _apply_manual_tag_update(
         "event_id": event_id,
         "old_species": old_species,
         "new_species": stored_display_name,
+        "category_name": stored_category_name,
         "scientific_name": sci_name,
         "common_name": com_name,
         "taxa_id": t_id,
+        "manual_tagged": True,
     }
 
 

--- a/backend/app/services/auto_video_classifier_service.py
+++ b/backend/app/services/auto_video_classifier_service.py
@@ -1739,6 +1739,10 @@ class AutoVideoClassifierService:
                         source in {"manual", "maintenance"} or frigate_event in self._manual_requested_ids
                     ) and snapshot_fallback_requested():
                         timeout_context["snapshot_fallback_attempted"] = True
+                        await self._broadcast_snapshot_fallback(
+                            frigate_event,
+                            reason="video_timeout",
+                        )
                         snapshot_error = await self._classify_from_snapshot(
                             frigate_event,
                             camera,
@@ -1781,12 +1785,41 @@ class AutoVideoClassifierService:
                     return
                 except VideoClassificationWorkerError as exc:
                     reason_code = exc.reason_code
+                    worker_context = {"error": reason_code}
+                    if snapshot_fallback_requested():
+                        worker_context["snapshot_fallback_attempted"] = True
+                        await self._broadcast_snapshot_fallback(
+                            frigate_event,
+                            reason=reason_code,
+                        )
+                        snapshot_error = await self._classify_from_snapshot(
+                            frigate_event,
+                            camera,
+                            event_data=event_data,
+                            manual_tagged=manual_reclassification_requested(),
+                        )
+                        worker_context["snapshot_fallback_recovered"] = snapshot_error is None
+                        if snapshot_error is not None:
+                            worker_context["snapshot_fallback_error"] = snapshot_error
+                        self._record_diagnostic(
+                            frigate_event,
+                            reason_code=reason_code,
+                            message="Video classification worker failed; snapshot fallback was attempted",
+                            severity="warning" if snapshot_error is None else "error",
+                            context=worker_context,
+                        )
+                        if snapshot_error is None:
+                            self._record_success(frigate_event, source=source)
+                        else:
+                            self._record_failure(frigate_event, snapshot_error, source=source)
+                        return
+
                     self._record_diagnostic(
                         frigate_event,
                         reason_code=reason_code,
                         message="Video classification worker failed before producing results",
                         severity="error",
-                        context={"error": reason_code},
+                        context=worker_context,
                     )
                     await self._update_status(frigate_event, "failed", error=reason_code, broadcast=True)
                     self._record_failure(frigate_event, reason_code, source=source)

--- a/backend/app/services/classifier_supervisor.py
+++ b/backend/app/services/classifier_supervisor.py
@@ -670,11 +670,15 @@ class ClassifierSupervisor:
                     if assignment is None:
                         continue
                     now = time.monotonic()
-                    last_heartbeat = status.get("last_heartbeat_monotonic")
-                    if (
-                        isinstance(last_heartbeat, (int, float))
-                        and now - float(last_heartbeat) > self._heartbeat_timeout_seconds
-                    ):
+                    last_activity = status.get("last_activity_monotonic")
+                    if not isinstance(last_activity, (int, float)):
+                        last_activity = status.get("last_heartbeat_monotonic")
+                    liveness_reference = (
+                        max(float(last_activity), assignment.started_at)
+                        if isinstance(last_activity, (int, float))
+                        else assignment.started_at
+                    )
+                    if now - liveness_reference > self._heartbeat_timeout_seconds:
                         await self._replace_worker(
                             priority,
                             index,

--- a/backend/app/services/classifier_worker_client.py
+++ b/backend/app/services/classifier_worker_client.py
@@ -34,6 +34,7 @@ class ClassifierWorkerClient:
         self._wait_task: asyncio.Task[None] | None = None
         self._event_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self._last_heartbeat_monotonic: float | None = None
+        self._last_activity_monotonic: float | None = None
         self._last_stderr_monotonic: float | None = None
         self._busy = False
         self._current_request_id: str | None = None
@@ -111,6 +112,7 @@ class ClassifierWorkerClient:
             "busy": self._busy,
             "current_request_id": self._current_request_id,
             "last_heartbeat_monotonic": self._last_heartbeat_monotonic,
+            "last_activity_monotonic": self._last_activity_monotonic,
             "last_stderr_monotonic": self._last_stderr_monotonic,
             "heartbeat_timeout_seconds": self.heartbeat_timeout_seconds,
             "exit_code": self._exit_code,
@@ -131,6 +133,7 @@ class ClassifierWorkerClient:
                     continue
                 if message.get("worker_generation") not in {None, self.worker_generation}:
                     continue
+                self._last_activity_monotonic = time.monotonic()
                 message_type = message["type"]
                 if message_type == "ready":
                     self._ready.set()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7346,6 +7346,17 @@
       "ManualTagResponse": {
         "description": "Response returned after applying or skipping a manual species tag.",
         "properties": {
+          "category_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Name"
+          },
           "common_name": {
             "anyOf": [
               {
@@ -7360,6 +7371,10 @@
           "event_id": {
             "title": "Event Id",
             "type": "string"
+          },
+          "manual_tagged": {
+            "title": "Manual Tagged",
+            "type": "boolean"
           },
           "new_species": {
             "title": "New Species",
@@ -7421,7 +7436,8 @@
         "required": [
           "status",
           "event_id",
-          "new_species"
+          "new_species",
+          "manual_tagged"
         ],
         "title": "ManualTagResponse",
         "type": "object"

--- a/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
+++ b/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
@@ -751,6 +751,71 @@ async def test_process_event_records_backend_diagnostic_for_worker_failure():
 
 
 @pytest.mark.asyncio
+async def test_process_event_worker_failure_falls_back_to_snapshot_for_manual_retry():
+    service = AutoVideoClassifierService()
+    service._classifier = MagicMock()
+    service._classifier.classify_video_async = AsyncMock(
+        side_effect=VideoClassificationWorkerError("video_worker_heartbeat_timeout")
+    )
+    service._update_status = AsyncMock()  # type: ignore[method-assign]
+    service._save_results = AsyncMock()  # type: ignore[method-assign]
+    service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._classify_from_snapshot = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    service._broadcast_snapshot_fallback = AsyncMock()  # type: ignore[method-assign]
+    service._record_success = MagicMock()  # type: ignore[method-assign]
+    service._record_failure = MagicMock()  # type: ignore[method-assign]
+    error_diagnostics_history.clear()
+
+    try:
+        with (
+            patch.object(
+                auto_video_classifier_module.frigate_client,
+                "get_event_with_error",
+                new=AsyncMock(return_value=({"has_clip": True}, None)),
+            ),
+            patch.object(auto_video_classifier_module.broadcaster, "broadcast", new=AsyncMock()),
+        ):
+            await service._process_event(
+                "evt-video-worker-fallback",
+                "cam1",
+                skip_delay=True,
+                fallback_to_snapshot=True,
+                source="manual",
+            )
+
+        service._classify_from_snapshot.assert_awaited_once_with(
+            "evt-video-worker-fallback",
+            "cam1",
+            event_data={"has_clip": True},
+            manual_tagged=True,
+        )
+        service._broadcast_snapshot_fallback.assert_awaited_once_with(
+            "evt-video-worker-fallback",
+            reason="video_worker_heartbeat_timeout",
+        )
+        service._record_success.assert_called_once_with("evt-video-worker-fallback", source="manual")
+        service._record_failure.assert_not_called()
+        failed_updates = [
+            call for call in service._update_status.await_args_list if len(call.args) > 1 and call.args[1] == "failed"
+        ]
+        assert failed_updates == []
+
+        snapshot = error_diagnostics_history.snapshot(limit=20)
+        event = next(
+            item
+            for item in snapshot["events"]
+            if item["event_id"] == "evt-video-worker-fallback"
+            and item["reason_code"] == "video_worker_heartbeat_timeout"
+        )
+        assert event["severity"] == "warning"
+        assert event["context"]["snapshot_fallback_attempted"] is True
+        assert event["context"]["snapshot_fallback_recovered"] is True
+    finally:
+        error_diagnostics_history.clear()
+
+
+@pytest.mark.asyncio
 async def test_process_event_diagnostic_includes_inference_provider_context():
     service = AutoVideoClassifierService()
     service._classifier = MagicMock()

--- a/backend/tests/test_classifier_supervisor.py
+++ b/backend/tests/test_classifier_supervisor.py
@@ -70,6 +70,18 @@ class _FakeWorker:
         }
 
 
+class _ActivityAwareFakeWorker(_FakeWorker):
+    def __init__(self, worker_name: str, worker_generation: int) -> None:
+        super().__init__(worker_name, worker_generation)
+        self.last_activity_monotonic = self.last_heartbeat_monotonic
+
+    def get_status(self) -> dict:
+        return {
+            **super().get_status(),
+            "last_activity_monotonic": self.last_activity_monotonic,
+        }
+
+
 class _SlowReadyWorker(_FakeWorker):
     def __init__(self, worker_name: str, worker_generation: int, *, ready_delay_seconds: float) -> None:
         super().__init__(worker_name, worker_generation)
@@ -309,6 +321,57 @@ async def test_classifier_supervisor_replaces_worker_after_heartbeat_timeout():
     assert created[0].killed is True
     assert supervisor.get_metrics()["live"]["restarts"] == 1
 
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_classifier_supervisor_keeps_busy_worker_when_progress_is_recent():
+    created: list[_ActivityAwareFakeWorker] = []
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        worker = _ActivityAwareFakeWorker(worker_name, worker_generation)
+        created.append(worker)
+        return worker
+
+    supervisor = ClassifierSupervisor(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.05,
+        hard_deadline_seconds=1.0,
+        worker_factory=_factory,
+        watchdog_interval_seconds=0.01,
+    )
+    await supervisor.start()
+
+    task = asyncio.create_task(
+        supervisor.classify(
+            priority="live",
+            work_id="live-progress",
+            lease_token=2,
+            image_b64="payload",
+            camera_name="front",
+            model_id="default",
+        )
+    )
+    await asyncio.sleep(0.01)
+    created[0].last_heartbeat_monotonic = time.monotonic() - 1.0
+    created[0].last_activity_monotonic = time.monotonic()
+    await asyncio.sleep(0.03)
+
+    assert task.done() is False
+    assert created[0].killed is False
+
+    await created[0].events.put(
+        {
+            "type": "result",
+            "worker_generation": 1,
+            "request_id": created[0].current_request_id,
+            "work_id": "live-progress",
+            "lease_token": 2,
+            "results": [],
+        }
+    )
+    assert await task == []
     await supervisor.shutdown()
 
 

--- a/backend/tests/test_classifier_worker_client.py
+++ b/backend/tests/test_classifier_worker_client.py
@@ -6,6 +6,7 @@ from app.services.classifier_worker_client import ClassifierWorkerClient
 from app.services.classifier_worker_protocol import (
     build_classify_request,
     build_heartbeat_event,
+    build_progress_event,
     build_ready_event,
     build_runtime_recovery_event,
     encode_protocol_message,
@@ -136,6 +137,44 @@ async def test_classifier_worker_client_tracks_heartbeat_state():
     assert status["busy"] is True
     assert status["last_heartbeat_monotonic"] is not None
 
+    process.finish()
+    await client.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_classifier_worker_client_treats_progress_as_worker_liveness():
+    process = _FakeProcess()
+
+    async def _factory(**_kwargs):
+        return process
+
+    client = ClassifierWorkerClient(
+        worker_name="video-progress",
+        worker_generation=12,
+        heartbeat_timeout_seconds=5.0,
+        process_factory=_factory,
+    )
+    await client.start()
+    process.feed(build_ready_event(worker_generation=12))
+    await asyncio.wait_for(client.wait_until_ready(), timeout=0.2)
+    ready_activity = client.get_status()["last_activity_monotonic"]
+
+    await asyncio.sleep(0.01)
+    process.feed(
+        build_progress_event(
+            worker_generation=12,
+            request_id="req-progress",
+            work_id="video-progress-1",
+            lease_token=3,
+            current_frame=19,
+            total_frames=20,
+            frame_score=0.91,
+            top_label="Blue Tit",
+        )
+    )
+    await asyncio.wait_for(client.next_event(), timeout=0.2)
+
+    assert client.get_status()["last_activity_monotonic"] > ready_activity
     process.finish()
     await client.wait_closed()
 

--- a/backend/tests/test_event_manual_update_api.py
+++ b/backend/tests/test_event_manual_update_api.py
@@ -108,10 +108,12 @@ async def test_manual_update_treats_localized_alias_of_same_species_as_unchanged
         assert response.status_code == 200, response.text
         payload = response.json()
         assert payload["status"] == "unchanged"
+        assert payload["manual_tagged"] is True
 
         mock_get_names.assert_not_awaited()
         mock_audio.assert_not_awaited()
-        mock_broadcast.assert_not_awaited()
+        mock_broadcast.assert_awaited_once()
+        assert mock_broadcast.await_args.args[0]["data"]["manual_tagged"] is True
 
         async with get_db() as db:
             async with db.execute(
@@ -126,7 +128,65 @@ async def test_manual_update_treats_localized_alias_of_same_species_as_unchanged
         assert row[2] == "Cyanistes caeruleus"
         assert row[3] == "Blue Tit"
         assert row[4] == taxa_id
-        assert row[5] == 0
+        assert row[5] == 1
+    finally:
+        await _cleanup_detection_and_taxonomy(event_id=event_id, taxa_id=taxa_id)
+
+
+@pytest.mark.asyncio
+async def test_manual_update_confirms_exact_existing_species_without_rewriting_taxonomy(client: httpx.AsyncClient):
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+
+    event_id = f"manual-{uuid.uuid4().hex[:10]}"
+    taxa_id = 915000 + int(uuid.uuid4().hex[:4], 16)
+    await _seed_detection_and_taxonomy(event_id=event_id, taxa_id=taxa_id)
+
+    try:
+        with (
+            patch("app.routers.events.taxonomy_service.get_names", new=AsyncMock()) as mock_get_names,
+            patch("app.routers.events.audio_service.correlate_species", new=AsyncMock()) as mock_audio,
+            patch("app.routers.events.broadcaster.broadcast", new=AsyncMock()) as mock_broadcast,
+        ):
+            response = await client.patch(
+                f"/api/events/{event_id}",
+                json={"display_name": "Blue Tit"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "status": "unchanged",
+            "event_id": event_id,
+            "new_species": "Blue Tit",
+            "species": "Blue Tit",
+            "old_species": "Blue Tit",
+            "category_name": "Blue Tit",
+            "scientific_name": "Cyanistes caeruleus",
+            "common_name": "Blue Tit",
+            "taxa_id": taxa_id,
+            "manual_tagged": True,
+        }
+        mock_get_names.assert_not_awaited()
+        mock_audio.assert_not_awaited()
+        mock_broadcast.assert_awaited_once()
+
+        async with get_db() as db:
+            async with db.execute(
+                """
+                SELECT display_name, category_name, scientific_name, common_name, taxa_id, manual_tagged
+                FROM detections WHERE frigate_event = ?
+                """,
+                (event_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            async with db.execute(
+                "SELECT COUNT(*) FROM classification_feedback WHERE frigate_event = ?",
+                (event_id,),
+            ) as cursor:
+                feedback_count = (await cursor.fetchone())[0]
+
+        assert tuple(row) == ("Blue Tit", "Blue Tit", "Cyanistes caeruleus", "Blue Tit", taxa_id, 1)
+        assert feedback_count == 0
     finally:
         await _cleanup_detection_and_taxonomy(event_id=event_id, taxa_id=taxa_id)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -114,6 +114,13 @@ This is the current route map (grouped). Use OpenAPI for full schemas.
 - `POST /api/events/{event_id}/reclassify` (owner)
 - `POST /api/events/{event_id}/classify-wildlife` (owner)
 
+`PATCH /api/events/{event_id}` accepts `{"display_name": "Blue Tit"}`. A successful response
+always includes `manual_tagged: true` and the retained taxonomy fields. If the requested name is
+the current species or another known name for the same taxon, `status` is `unchanged`: YA-WAMF
+records the human confirmation but preserves the stored display, scientific and common names and
+does not create correction feedback. A different species returns `status: "updated"` after the
+canonical taxonomy and manual tag have been committed.
+
 Event rows and `GET /api/events/{event_id}/classification-status` expose
 `video_classification_input_source` when YA-WAMF knows which representation produced the retained
 analysis result. Current video values are `full_frame`, `frigate_hint_crop`, `model_crop`, or

--- a/docs/standards/layout-patterns.md
+++ b/docs/standards/layout-patterns.md
@@ -120,11 +120,14 @@ readme and `docs/` hold the feature list.
 | `InstancePipeline` | Deployment state as a flow | Use it as a settings surface |
 | `ReviewQueueModal` | Working a queue item by item | Use for viewing one record; that is `DetectionModal` |
 
-Pure logic lives in `apps/ui/src/lib/utils/`: `visit-grouping.ts` (grouping, the desk window, the
-review threshold) and `review-queue.ts` (queue selection and ordering). New decision rules go
-there, with unit tests, and never inside a component.
+Pure logic lives in `apps/ui/src/lib/utils/`: `visit-grouping.ts` (grouping, the desk window and
+threshold-aware review decisions), `review-queue.ts` (queue selection and ordering), and
+`dashboard-cameras.ts` (configured-camera scope and visit counts). New decision rules go there,
+with unit tests, and never inside a component.
 
-`REVIEW_CONFIDENCE_THRESHOLD` is 0.6 and matches the backend naming floor. If one moves, both move.
+The review threshold comes from the saved `classification_threshold` setting. Do not copy its
+current value into frontend code. Until owner settings load, explicitly unknown detections still
+need review, but a named detection is not flagged against an invented threshold.
 
 **Pickers open on what is likely, not on what is first.** The classifier knows eleven thousand
 labels and sorts them alphabetically, so an unfiltered list opens on earthworms and spiders. Any


### PR DESCRIPTION
## Outcome

Fixes the confirmed dashboard review, camera scoping, and classifier-worker recovery defects reported in #171 and #172.

## What changed

- Persist same-species and same-taxon manual confirmations without rewriting taxonomy or recording false correction feedback.
- Return the persisted manual-tag state through OpenAPI and update dashboard state immediately rather than waiting for SSE.
- Use the saved classification threshold for review decisions.
- Scope dashboard camera rows to configured cameras and count grouped visits rather than raw frames.
- Treat every valid worker protocol event as liveness and use snapshot fallback after video-worker failures for manual and maintenance work.
- Update generated contracts, API documentation, layout guidance, and the changelog.

## Root causes

- Same-species requests returned before setting `manual_tagged`.
- Dashboard review logic duplicated a fixed 0.6 threshold.
- Camera status rows were built from every Frigate camera regardless of the configured selection.
- The supervisor watched heartbeat messages only, so valid progress could still be followed by a false timeout.

## Validation

- Backend: 1,884 passed, 44 skipped.
- Frontend: 679 passed.
- `npm run check`: 0 errors, 0 warnings.
- Production frontend build passed.
- `ruff check .` and `ruff format --check .` passed.
- Documentation consistency and generated OpenAPI freshness checks passed.

## Risk

No schema migration. Existing taxonomy fields are preserved for confirmation-only updates. Automatic video jobs retain their prior failure behavior; snapshot recovery is limited to explicit manual or maintenance fallback paths.
