### PR TITLE
fix(ui): respect naming preferences in species filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The responsive Events species filter now honours the configured naming preference**
+  ([#180](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/180)). Filter values remain
+  canonical, while their visible labels use the same common/scientific-name pairing as detection
+  cards instead of exposing only the model's scientific label.
+
 - **The leaderboard stops printing a percentage it cannot stand behind.** Every camera trend read
   "+76 (0.0%)" because the previous window holds no camera data to compare against, so the figure was
   the same on every row and meant nothing. A trend now shows its percentage only when there is a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,9 @@ delivered → release-defining initiatives → non-blocking backlog → breaking
 
 - [ ] The UI simplification pass has made Settings and the primary owner/guest journeys coherent,
   responsive, keyboard-operable, and honest about loading, empty, error, and destructive states.
+- [ ] A separately versioned SQLite species catalogue maps every supported model output index to
+  a canonical taxon and supplies common, scientific, and translated names without requiring model
+  label text files at runtime; migration from existing taxonomy data is lossless and reversible.
 - [ ] Native editorial review is complete for locales presented as fully supported, or any residual
   language-quality limitations are labelled honestly in the release notes.
 - [x] Stable installation and recovery docs match the shipped Compose defaults and first-run auth
@@ -109,6 +112,27 @@ All four recommendations from the
 
 The headline work that makes `3.0` a major version: a guided first run, a cleaner product
 surface, a codebase reviewed to the gold standard, and complete translations.
+
+#### Versioned species catalogue and model mapping 🐦
+**Priority:** P1 | **Effort:** L | **Status:** ☐ Not started — required before `3.0`
+
+Create a separate, enrichable SQLite catalogue whose stable taxon records own scientific names,
+locale-specific common names, aliases, regions, and provenance. A versioned mapping table will bind
+each immutable model artifact and raw output index to one canonical taxon. Model sidecars may still
+declare the mapping asset/version needed to validate a download, but production inference will emit
+the model ID, output index, score, and resolved taxon identity rather than treating mutable label
+text as identity.
+
+The catalogue must be independently backed up and upgraded, use Alembic-safe attached-database
+migrations or an equivalently reversible versioned importer, and retain the current application DB
+as the owner of detections and user choices. Offline installs keep a bundled baseline; enrichment is
+an explicit, checksum/versioned transaction that never silently rewrites historical identity.
+
+**Acceptance:** every shipped classifier and crop-independent species model has complete,
+checksum-bound index coverage; missing or ambiguous mappings fail closed; common/scientific/locale
+switches do not change filtering or analytics identity; existing `taxonomy_cache` and translation
+rows migrate without loss; backup/restore and rollback are exercised; and tests prove two models
+with different label orders resolve the same bird to the same taxon.
 
 #### First-run setup wizard 🧭
 **Priority:** P1 | **Effort:** L | **Status:** ✅ Shipped on `dev` — multi-part, hardware-validating, re-runnable from the Settings navigation ([design](docs/plans/2026-07-12-first-run-setup-wizard-design.md))
@@ -316,6 +340,23 @@ Automated highlight reels and time-based browsing. Shipped: video preview pipeli
 day-bucket timeline strip with keyboard nav. Remaining:
 - Fuller grouped-browsing timeline UI + advanced keyboard UX.
 - Highlight scoring (confidence, rarity, activity) and clip stitching/preview thumbnails.
+
+#### Durable media archive and retention floors 📚
+**Priority:** P2 | **Effort:** M | **Status:** ☐ Proposed
+([#178](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/178))
+
+Favourites already protect their detection row and existing cached snapshot/clip from scheduled and
+manual retention cleanup. Complete the stronger durability contract requested in #178: when a visit
+is favourited, durably acquire its best snapshot and available clip into a dedicated archive before
+Frigate rotates them; expose acquisition state and failures; and make unfavourite/archive deletion
+an explicit owner choice. Add bounded rolling snapshot retention with both an age window and a
+configurable per-species minimum, without automatically downloading every video.
+
+**Acceptance:** archive writes are atomic and restart-safe; a favourite is not reported protected
+until requested assets are durable (or an honest unavailable state is recorded); normal cache clear
+cannot remove archived media; storage usage and destructive actions are visible; per-species floors
+are canonical-taxon based; backup/restore is documented; and tests cover Frigate expiry, concurrent
+favourite/unfavourite, partial downloads, cleanup order, and disk-pressure failure.
 
 #### Analytics: insights panel + camera comparison 📊
 **Priority:** P2 | **Effort:** M | **Status:** ☐ Not started

--- a/apps/ui/src/lib/pages/Events.layout.test.ts
+++ b/apps/ui/src/lib/pages/Events.layout.test.ts
@@ -17,6 +17,13 @@ describe('Explorer page layout', () => {
         expect(filtersSource).toContain('let panelOpen = $state(false)');
     });
 
+    it('passes naming-aware species labels to the responsive filter panel', () => {
+        expect(eventsSource).toContain('let displaySpecies = $derived(');
+        expect(eventsSource).toContain('display_name: formatSpeciesLabel(item)');
+        expect(eventsSource).toContain('species={displaySpecies}');
+        expect(eventsSource).not.toContain('species={availableSpecies}');
+    });
+
     it('presents the timeline as a quiet divided control instead of another card', () => {
         expect(eventsSource).toContain('data-events-timeline');
         expect(eventsSource).toMatch(/data-events-timeline[^>]+border-y/);

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -160,6 +160,16 @@
         return naming.secondary ? `${naming.primary} (${naming.secondary})` : naming.primary;
     }
 
+    // The API's display name is a stable fallback, not necessarily the owner's chosen
+    // naming presentation. Keep the canonical filter value intact while deriving the
+    // visible label from the same common/scientific-name policy as detection cards.
+    let displaySpecies = $derived(
+        availableSpecies.map((item) => ({
+            ...item,
+            display_name: formatSpeciesLabel(item)
+        }))
+    );
+
     let dateRange = $derived.by(() => {
         const today = new Date();
         const fmt = (d: Date) => toLocalYMD(d);
@@ -1082,7 +1092,7 @@
     <div class="grid gap-6 lg:grid-cols-[14rem_minmax(0,1fr)] lg:items-start" data-explorer-layout>
         <div class="lg:sticky lg:top-4">
         <ExplorerFilters
-            species={availableSpecies}
+            species={displaySpecies}
             cameras={availableCameras}
             filters={eventFilters}
             {datePreset}


### PR DESCRIPTION
## Outcome

The responsive Events species filter now uses the owner's configured common/scientific naming presentation while retaining canonical filter identities. The roadmap also records the separately versioned species catalogue required before 3.0 and the still-missing durable archive contract from #178.

Closes #180.

## Scope

- **Included:** naming-aware species option/token labels; regression coverage; changelog; concrete roadmap acceptance criteria for the species catalogue and #178.
- **Explicitly excluded:** implementing the catalogue or durable media archive in this UI bug slice.
- **Issue or roadmap outcome:** fixes #180; makes #178 and the pre-3.0 taxonomy dependency implementation-ready.

## Verification

Focused and full commands with real results:

```text
npm test -- --run src/lib/pages/Events.layout.test.ts
10 passed

npm run check
0 errors and 0 warnings

npm test -- --run
714 passed

npm run build
passed (Vite 8.2.0)

python -m pytest
1886 passed, 44 skipped

python -m ruff check .
All checks passed

python -m ruff format --check .
506 files already formatted
```

## Data integrity and risk

- Detection-history or configuration risk: none; the canonical API filter value is unchanged.
- Migration/recovery path, if data changes: no schema or data change.
- Security or secret-handling risk: none; no new input or external boundary.
- Deployment verification, if deployed: pending merge, image publication, and Dockhand pull on Quark.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head. (No schema change.)
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.