### PR TITLE
feat(runtime): support legacy Intel GPU compute safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- **Legacy Intel GPU compute support for Gen8, Gen9, and Gen11 hardware.** The `full` and `intel`
+  images now include Intel's pinned `legacy1` OpenCL and Level Zero packages alongside the modern
+  driver stack, restoring OpenVINO discovery on hardware such as Coffee Lake. Every downloaded
+  package is checksum-verified, and the install retains the current `libigdgmm12` instead of
+  downgrading a shared modern-driver dependency
+  ([#177](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/pull/177)).
+
 ### Changed
 
 - **Ten more bird facts in the footer ticker**, weighted towards birds that turn up at feeders.

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,38 @@ RUN set -eux; \
             libze-intel-gpu1 \
             libze1 \
             ocl-icd-libopencl1; \
+        # Intel publishes the last Gen8/Gen9/Gen11 compute runtime as `legacy1`.
+        # Install it beside the modern ICD instead of replacing the current stack.
+        # The current libigdgmm12 satisfies the legacy package's >=22.5 dependency;
+        # deliberately do not downgrade it to the older release-bundled build.
+        LEGACY_IGC_VER=1.0.17537.24; \
+        LEGACY_COMPUTE_VER=24.35.30872.36; \
+        LEGACY_LEVEL_ZERO_VER=1.5.30872.36; \
+        LEGACY_IGC_REL="https://github.com/intel/intel-graphics-compiler/releases/download/igc-${LEGACY_IGC_VER}"; \
+        LEGACY_COMPUTE_REL="https://github.com/intel/compute-runtime/releases/download/${LEGACY_COMPUTE_VER}"; \
+        ( cd /tmp \
+          && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+                 -O "${LEGACY_IGC_REL}/intel-igc-core_${LEGACY_IGC_VER}_amd64.deb" \
+          && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+                 -O "${LEGACY_IGC_REL}/intel-igc-opencl_${LEGACY_IGC_VER}_amd64.deb" \
+          && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+                 -O "${LEGACY_COMPUTE_REL}/intel-level-zero-gpu-legacy1_${LEGACY_LEVEL_ZERO_VER}_amd64.deb" \
+          && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+                 -O "${LEGACY_COMPUTE_REL}/intel-opencl-icd-legacy1_${LEGACY_COMPUTE_VER}_amd64.deb" \
+          && echo "c1e1ecdfe2064c047c552651cfdcdafc504f2033afafba65654338b880048b67  intel-igc-core_${LEGACY_IGC_VER}_amd64.deb" | sha256sum -c - \
+          && echo "dd016400f87fa2b6a9fa9fbcca7eb4a2629174a29de679709f9bec5cede88b0e  intel-igc-opencl_${LEGACY_IGC_VER}_amd64.deb" | sha256sum -c - \
+          && echo "40dfbd15ab62de036a00824b304a2aa1fa2d81ad60ef83da09cfe3c5a80c429f  intel-level-zero-gpu-legacy1_${LEGACY_LEVEL_ZERO_VER}_amd64.deb" | sha256sum -c - \
+          && echo "bbe71e4f414259e06a10cde72c29a2bd78d41b2bb2f6f8463b1806797fe66e85  intel-opencl-icd-legacy1_${LEGACY_COMPUTE_VER}_amd64.deb" | sha256sum -c - \
+          && apt-get install -y --no-install-recommends \
+                 "./intel-igc-core_${LEGACY_IGC_VER}_amd64.deb" \
+                 "./intel-igc-opencl_${LEGACY_IGC_VER}_amd64.deb" \
+                 "./intel-level-zero-gpu-legacy1_${LEGACY_LEVEL_ZERO_VER}_amd64.deb" \
+                 "./intel-opencl-icd-legacy1_${LEGACY_COMPUTE_VER}_amd64.deb" \
+          && rm -f \
+                 "/tmp/intel-igc-core_${LEGACY_IGC_VER}_amd64.deb" \
+                 "/tmp/intel-igc-opencl_${LEGACY_IGC_VER}_amd64.deb" \
+                 "/tmp/intel-level-zero-gpu-legacy1_${LEGACY_LEVEL_ZERO_VER}_amd64.deb" \
+                 "/tmp/intel-opencl-icd-legacy1_${LEGACY_COMPUTE_VER}_amd64.deb" ); \
         # Intel NPU ("AI Boost") driver for the OpenVINO `intel_npu` provider on
         # Core Ultra. These are NOT in the intel-graphics apt repo, so install the
         # release .debs (firmware + Level-Zero driver + compiler). This pinned version

--- a/backend/tests/test_deployment_contract.py
+++ b/backend/tests/test_deployment_contract.py
@@ -266,3 +266,23 @@ def test_intel_npu_assets_are_pinned_verified_and_required() -> None:
     assert "24309e17063e94729330ae9c02c5f2ea8ca5c27cdb067303e4e26ad1f4656a13" in dockerfile
     assert "07ee5332d0523661f5b3cec69593197fecc95439c8a9a401905e05cb7690097b" in dockerfile
     assert '|| echo "WARN: Intel NPU driver install failed' not in dockerfile
+
+
+def test_legacy_intel_gpu_assets_are_pinned_verified_and_do_not_downgrade_gmmlib() -> None:
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "LEGACY_IGC_VER=1.0.17537.24" in dockerfile
+    assert "LEGACY_COMPUTE_VER=24.35.30872.36" in dockerfile
+    assert "LEGACY_LEVEL_ZERO_VER=1.5.30872.36" in dockerfile
+    for checksum in (
+        "c1e1ecdfe2064c047c552651cfdcdafc504f2033afafba65654338b880048b67",
+        "dd016400f87fa2b6a9fa9fbcca7eb4a2629174a29de679709f9bec5cede88b0e",
+        "40dfbd15ab62de036a00824b304a2aa1fa2d81ad60ef83da09cfe3c5a80c429f",
+        "bbe71e4f414259e06a10cde72c29a2bd78d41b2bb2f6f8463b1806797fe66e85",
+    ):
+        assert checksum in dockerfile
+
+    assert "intel-opencl-icd-legacy1_${LEGACY_COMPUTE_VER}_amd64.deb" in dockerfile
+    assert "intel-level-zero-gpu-legacy1_${LEGACY_LEVEL_ZERO_VER}_amd64.deb" in dockerfile
+    assert "libigdgmm12_22.5.0_amd64.deb" not in dockerfile
+    assert "./*.deb" not in dockerfile

--- a/docs/setup/hardware-acceleration.md
+++ b/docs/setup/hardware-acceleration.md
@@ -105,6 +105,12 @@ also settable via the `CLASSIFICATION__INFERENCE_PROVIDER` environment variable)
 
 `Auto` is recommended unless you have a reason to pin a device.
 
+The `full` and `intel` images also carry Intel's pinned `legacy1` OpenCL/Level Zero runtime for
+Gen8, Gen9, and Gen11 integrated graphics (including Broadwell, Skylake/Kaby Lake, Coffee Lake, and
+Ice Lake families). It coexists with the current driver rather than replacing it. Hardware support
+still depends on the host kernel/device mapping, so run the normal compatibility sweep before
+selecting `intel_gpu`; an enumerated device alone is not treated as validated inference.
+
 The selector is capability-aware. It only offers providers that are included in
 the running image, pass the host runtime/device probe, and are safe in the global
 model contract or pass that model's current installation sweep. Options begin


### PR DESCRIPTION
## Outcome

The `full` and `intel` images support Intel's official `legacy1` compute runtime for Gen8, Gen9, and Gen11 integrated GPUs while retaining the modern Intel driver path.

Supersedes #177 with its author credited for the hardware finding and locally validated package set.

## Scope

- **Included:** pinned official legacy OpenCL/Level Zero/IGC assets; SHA-256 verification; explicit package install/cleanup; modern-driver coexistence; deployment contract test; operator documentation and changelog.
- **Explicitly excluded:** VA-API media packages (not required for OpenVINO inference), downgrading the shared GMM library, and changing provider-selection policy.
- **Issue or roadmap outcome:** restores a supported `intel_gpu` candidate on legacy Intel hardware, still subject to the normal per-host model validation gate.

## Verification

```text
python -m pytest backend/tests/test_deployment_contract.py -q
17 passed

python -m pytest
1887 passed, 44 skipped

npm run check
0 errors and 0 warnings

npm test -- --run
714 passed

npm run build
passed (Vite 8.2.0)

python -m ruff check .
All checks passed

python -m ruff format --check .
506 files already formatted
```

The four package digests were independently matched against GitHub's release-asset SHA-256 metadata. Intel's current package metadata uses `libigc2`/`libigdfcl2` for the modern runtime, while the legacy packages use the older exact-version IGC package names, so both ICDs remain installable. The current `libigdgmm12 >=22.7.2` satisfies the legacy `>=22.5.0` requirement and is deliberately not downgraded.

## Data integrity and risk

- Detection-history or configuration risk: none.
- Migration/recovery path, if data changes: no persistent data or schema change; selecting `Auto`/CPU remains the fallback.
- Security or secret-handling risk: remote build assets are immutable-versioned and checksum-bound before installation.
- Deployment verification, if deployed: pending CI image build and Quark hardware validation through the Dockhand-managed image pull.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head. (No schema change.)
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.