### PR TITLE
chore(deps): consolidate and harden reviewed dependency updates

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Check out full history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Dependencies:** Reviewed and consolidated the outstanding runtime, UI, telemetry Worker, and
+  workflow dependency updates against current `dev`. The OpenVINO floor is consistent across both
+  Intel-capable image flavours, CPU ONNX Runtime 1.28 is covered across CPU/Intel/ARM64 paths while
+  the CUDA compatibility ceiling remains unchanged, and the markdown-it 15 migration preserves
+  existing bare-domain links while using its bundled TypeScript declarations. The telemetry test
+  toolchain also overrides its vulnerable transitive Undici range to the patched 7.29 release.
+
 - **Ten more bird facts in the footer ticker**, weighted towards birds that turn up at feeders.
   Broad claims were narrowed to the species, measurement or observation the research supports,
   including chickadee cache recovery after 28 days and the British record of 61 wrens roosting

--- a/apps/telemetry-worker/package-lock.json
+++ b/apps/telemetry-worker/package-lock.json
@@ -8,12 +8,12 @@
       "name": "yawamf-telemetry-worker",
       "version": "1.0.0",
       "dependencies": {
-        "hono": "4.12.32"
+        "hono": "4.13.1"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260730.1",
+        "@cloudflare/workers-types": "5.20260813.1",
         "miniflare": "4.20260730.0",
-        "wrangler": "4.116.0"
+        "wrangler": "4.122.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260730.1.tgz",
-      "integrity": "sha512-3e1cBXcPTwXBk2ur0CfxZKQKL6X7vUZlOn1R7VYU0zZVJcSKFcq1AoOZM+ps0LuL0uTAxdcLg+qwXrBXVu+UuQ==",
+      "version": "5.20260813.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260813.1.tgz",
+      "integrity": "sha512-RQNfm7xD10hNHEQZFxQPmyGMJ9+aDGPcdFZ0x1LtmjRoLFcgZkGvfaqJAbOMQBAUFSESO3bYJS4p9mOLv28Ihg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1303,9 +1303,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1436,9 +1436,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1477,9 +1477,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.116.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.116.0.tgz",
-      "integrity": "sha512-wP1PXxH5KJajfGEjty0NNqyxAirTFvMZpGyB5CRqEIiY0fL/SiCKtIYAJB9HXq0MP0sMXB/i/YSls+WObahAhw==",
+      "version": "4.122.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.122.0.tgz",
+      "integrity": "sha512-qkskzgQ76Y1qvVe5JARgvc3RISq6BC2rPoxQhFoKH1dKIwQc3GDFttQ/7m2OfeQ+tmQRzynv2dy/DXnxFCj2Lw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1487,10 +1487,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260730.0",
+        "miniflare": "5.20260811.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260730.1"
+        "workerd": "1.20260811.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1504,12 +1504,136 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260730.1"
+        "@cloudflare/workers-types": "^5.20260811.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
+      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
+      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
+      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "5.20260811.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.0-alpha.tgz",
+      "integrity": "sha512-sypXsD5fjY88fZNedPqnwrwR1dwfnfbfW7MfvMyIfPJdtRiCCOpUnjWGeFVYYZ+0fQVICye6Juu+vZgzTEx8XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260811.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
+      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260811.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
+        "@cloudflare/workerd-linux-64": "1.20260811.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
+        "@cloudflare/workerd-windows-64": "1.20260811.1"
       }
     },
     "node_modules/ws": {

--- a/apps/telemetry-worker/package.json
+++ b/apps/telemetry-worker/package.json
@@ -14,11 +14,14 @@
     "db:migrate:health": "wrangler d1 execute yawamf-health-issues --remote --yes --file=./migrations/health/0001_report_batches.sql"
   },
   "dependencies": {
-    "hono": "4.12.32"
+    "hono": "4.13.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260730.1",
+    "@cloudflare/workers-types": "5.20260813.1",
     "miniflare": "4.20260730.0",
-    "wrangler": "4.116.0"
+    "wrangler": "4.122.0"
+  },
+  "overrides": {
+    "undici": "7.29.0"
   }
 }

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -8,25 +8,24 @@
             "name": "wamf-ui",
             "version": "2.9.15",
             "dependencies": {
-                "apexcharts": "^6.6.1",
+                "apexcharts": "^6.8.0",
                 "flatpickr": "^4.6.13",
                 "leaflet": "^1.9.4",
-                "markdown-it": "^14.1.0",
+                "markdown-it": "^15.0.0",
                 "svelte-i18n": "^4.0.1"
             },
             "devDependencies": {
                 "@sveltejs/vite-plugin-svelte": "^7.2.0",
                 "@tsconfig/svelte": "^5.0.4",
-                "@types/leaflet": "^1.9.21",
-                "@types/markdown-it": "^14.1.2",
+                "@types/leaflet": "^1.9.22",
                 "autoprefixer": "^10.5.4",
-                "postcss": "^8.5.25",
+                "postcss": "^8.5.26",
                 "svelte": "^5.56.8",
                 "svelte-check": "^4.7.4",
                 "tailwindcss": "^3.4.1",
                 "tslib": "^2.6.2",
                 "typescript": "^5.9.0",
-                "vite": "^8.2.0",
+                "vite": "^8.2.1",
                 "vitest": "^4.1.10"
             }
         },
@@ -618,39 +617,14 @@
             "license": "MIT"
         },
         "node_modules/@types/leaflet": {
-            "version": "1.9.21",
-            "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
-            "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+            "version": "1.9.22",
+            "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.22.tgz",
+            "integrity": "sha512-h3lhECYEKDasG7LFHu+GiHqAvsgLuQvlJvVZzJDGONo3sEL+wUOqSFLnwkZlK0qVxnxbuGFW8iBlJNYs5wgndA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/geojson": "*"
             }
-        },
-        "node_modules/@types/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/markdown-it": {
-            "version": "14.1.2",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-            "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/linkify-it": "^5",
-                "@types/mdurl": "^2"
-            }
-        },
-        "node_modules/@types/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/trusted-types": {
             "version": "2.0.7",
@@ -828,10 +802,13 @@
             }
         },
         "node_modules/apexcharts": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-6.6.1.tgz",
-            "integrity": "sha512-958NXryBp9mtyqGQK1c8J2wzTHivc7L/lS/nsHOw13L52V2mGxbmjCfVu8oPHIbBCeBe26dYR2ZU1GjIqJkxIA==",
-            "license": "SEE LICENSE IN LICENSE"
+            "version": "6.8.0",
+            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-6.8.0.tgz",
+            "integrity": "sha512-ifEl3w/NAMsKQ60JNDD8nRCGdnGeuuKNvUzZTQpPr/3JNewoZv98H42VpXFB96sHle/8GDsHn/NQp785xsNh4A==",
+            "license": "SEE LICENSE IN LICENSE",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
         },
         "node_modules/arg": {
             "version": "5.0.2",
@@ -841,9 +818,19 @@
             "license": "MIT"
         },
         "node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+            "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "Python-2.0"
         },
         "node_modules/aria-query": {
@@ -1162,12 +1149,12 @@
             "license": "ISC"
         },
         "node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=0.12"
+                "node": ">=20.19.0"
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
@@ -1878,9 +1865,9 @@
             "license": "MIT"
         },
         "node_modules/linkify-it": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+            "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
             "funding": [
                 {
                     "type": "github",
@@ -1893,7 +1880,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "uc.micro": "^2.0.0"
+                "uc.micro": "^3.0.0"
             }
         },
         "node_modules/locate-character": {
@@ -1921,9 +1908,9 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.3.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-            "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+            "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
             "funding": [
                 {
                     "type": "github",
@@ -1936,21 +1923,21 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.5.0",
-                "linkify-it": "^5.0.2",
-                "mdurl": "^2.0.0",
+                "argparse": "^3.0.0",
+                "entities": "^8.0.0",
+                "linkify-it": "^6.0.0",
+                "mdurl": "^2.1.0",
                 "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
+                "uc.micro": "^3.0.0"
             },
             "bin": {
                 "markdown-it": "bin/markdown-it.mjs"
             }
         },
         "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+            "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
             "license": "MIT"
         },
         "node_modules/memoizee": {
@@ -2031,9 +2018,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -2164,9 +2151,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.25",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "dev": true,
             "funding": [
                 {
@@ -2184,7 +2171,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.16",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -3271,9 +3258,9 @@
             }
         },
         "node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+            "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
             "license": "MIT"
         },
         "node_modules/update-browserslist-db": {
@@ -3315,16 +3302,16 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
-            "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+            "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.33.0",
                 "picomatch": "^4.0.5",
-                "postcss": "^8.5.23",
-                "rolldown": "~1.2.0",
+                "postcss": "^8.5.25",
+                "rolldown": "~1.2.1",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -15,23 +15,22 @@
     "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.2.0",
         "@tsconfig/svelte": "^5.0.4",
-        "@types/leaflet": "^1.9.21",
-        "@types/markdown-it": "^14.1.2",
+        "@types/leaflet": "^1.9.22",
         "autoprefixer": "^10.5.4",
-        "postcss": "^8.5.25",
+        "postcss": "^8.5.26",
         "svelte": "^5.56.8",
         "svelte-check": "^4.7.4",
         "tailwindcss": "^3.4.1",
         "tslib": "^2.6.2",
         "typescript": "^5.9.0",
-        "vite": "^8.2.0",
+        "vite": "^8.2.1",
         "vitest": "^4.1.10"
     },
     "dependencies": {
-        "apexcharts": "^6.6.1",
+        "apexcharts": "^6.8.0",
         "flatpickr": "^4.6.13",
         "leaflet": "^1.9.4",
-        "markdown-it": "^14.1.0",
+        "markdown-it": "^15.0.0",
         "svelte-i18n": "^4.0.1"
     }
 }

--- a/apps/ui/src/lib/utils/markdown.test.ts
+++ b/apps/ui/src/lib/utils/markdown.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from './markdown';
+
+describe('renderMarkdown', () => {
+    it('preserves bare-domain links across the markdown-it 15 upgrade', () => {
+        expect(renderMarkdown('Read example.org for details.')).toContain(
+            '<a href="http://example.org">example.org</a>'
+        );
+    });
+
+    it('keeps embedded HTML escaped', () => {
+        expect(renderMarkdown('<script>alert(1)</script>')).not.toContain('<script>');
+    });
+});

--- a/apps/ui/src/lib/utils/markdown.ts
+++ b/apps/ui/src/lib/utils/markdown.ts
@@ -7,6 +7,11 @@ const markdown = new MarkdownIt({
     typographer: true,
 });
 
+// markdown-it 15 made bare-domain linkification opt-in. Keep the existing UI
+// contract for model and help text such as "example.org" while still escaping
+// raw HTML above.
+markdown.linkify.set({ fuzzyLink: true });
+
 const isHeadingLike = (value: string) => {
     if (value.length < 3 || value.length > 40) return false;
     const cleaned = value.replace(/[:.]+$/, '').trim();

--- a/backend/requirements-base.txt
+++ b/backend/requirements-base.txt
@@ -1,6 +1,6 @@
 # Core application and runtime dependencies shared by every image flavor.
 fastapi==0.141.1
-uvicorn[standard]==0.52.0
+uvicorn[standard]==0.52.1
 pydantic==2.13.4
 pydantic-settings==2.14.2
 structlog==26.1.0
@@ -22,17 +22,17 @@ ai-edge-litert==2.1.6; python_version >= '3.12' and sys_platform == "linux" and 
 tensorflow; python_version >= '3.12' and sys_platform != "linux"
 
 aiomqtt==2.5.1
-alembic==1.18.5
+alembic==1.19.0
 prometheus-client
 slowapi==0.1.10
 
 # Authentication
 pyjwt==2.13.0
-cryptography==49.0.0
+cryptography==50.0.0
 bcrypt==5.0.0
 
 # SMTP and OAuth notifications
 aiosmtplib==5.1.2
-google-auth==2.56.2
+google-auth==2.56.3
 google-auth-oauthlib==1.4.0
 jinja2==3.1.6

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Development and CI tools. Container runtime images intentionally exclude these.
 pytest==9.1.1
 pytest-asyncio==1.4.0
-coverage==7.15.2
-ruff==0.16.0
+coverage==7.15.4
+ruff==0.16.1

--- a/backend/requirements-provider-cpu.txt
+++ b/backend/requirements-provider-cpu.txt
@@ -1,2 +1,2 @@
 # Portable ONNX CPU runtime.
-onnxruntime>=1.27.0
+onnxruntime>=1.28.0

--- a/backend/requirements-provider-full.txt
+++ b/backend/requirements-provider-full.txt
@@ -2,5 +2,5 @@
 # the CPU ORT package and omits OpenVINO; the dedicated RPi build selects the CPU
 # provider file directly.
 onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0 ; platform_machine != "aarch64" and platform_machine != "arm64"
-onnxruntime>=1.27.0 ; platform_machine == "aarch64" or platform_machine == "arm64"
-openvino>=2026.2.1,<2027.0 ; platform_machine != "aarch64" and platform_machine != "arm64"
+onnxruntime>=1.28.0 ; platform_machine == "aarch64" or platform_machine == "arm64"
+openvino>=2026.3.0,<2027.0 ; platform_machine != "aarch64" and platform_machine != "arm64"

--- a/backend/requirements-provider-intel.txt
+++ b/backend/requirements-provider-intel.txt
@@ -1,3 +1,3 @@
 # ONNX CPU fallback plus OpenVINO CPU/GPU/NPU support.
-onnxruntime>=1.27.0
-openvino>=2026.2.1,<2027.0
+onnxruntime>=1.28.0
+openvino>=2026.3.0,<2027.0

--- a/backend/tests/test_dependency_pins.py
+++ b/backend/tests/test_dependency_pins.py
@@ -37,7 +37,27 @@ def test_openvino_version_constraint():
     content = _load_requirements()
     openvino_lines = [line.strip() for line in content.splitlines() if line.strip().startswith("openvino")]
     assert openvino_lines, "openvino requirement missing"
-    assert all(line.partition(";")[0].strip() == "openvino>=2026.2.1,<2027.0" for line in openvino_lines)
+    assert all(line.partition(";")[0].strip() == "openvino>=2026.3.0,<2027.0" for line in openvino_lines)
+
+
+def test_cpu_onnxruntime_floor_is_consistent_across_runtime_flavors():
+    backend_root = Path(__file__).resolve().parents[1]
+    requirements = {
+        flavor: (backend_root / f"requirements-provider-{flavor}.txt").read_text(encoding="utf-8")
+        for flavor in ("cpu", "intel", "full")
+    }
+
+    assert "onnxruntime>=1.28.0" in requirements["cpu"]
+    assert "onnxruntime>=1.28.0" in requirements["intel"]
+    assert 'onnxruntime>=1.28.0 ; platform_machine == "aarch64"' in requirements["full"]
+    assert "onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0" in requirements["full"]
+
+
+def test_openvino_floor_is_consistent_across_intel_capable_flavors():
+    backend_root = Path(__file__).resolve().parents[1]
+    for flavor in ("intel", "full"):
+        content = (backend_root / f"requirements-provider-{flavor}.txt").read_text(encoding="utf-8")
+        assert "openvino>=2026.3.0,<2027.0" in content
 
 
 def test_msal_pin_is_compatible_with_cryptography_pin():


### PR DESCRIPTION
## Summary

Consolidates the remaining reviewed Dependabot updates on top of current `dev`, including their cross-package effects, and supersedes #116 and #154–#160.

- raises the CPU/Intel/ARM64 ONNX Runtime floor to 1.28 while deliberately retaining the x86 CUDA compatibility ceiling
- applies OpenVINO 2026.3 consistently to both Intel-capable image flavours
- updates the reviewed Python pins, UI packages, telemetry Worker packages, and pinned harden-runner action
- completes the markdown-it 15 migration by removing obsolete `@types/markdown-it`, explicitly preserving bare-domain links, and adding regression coverage
- moves the Worker toolchain beyond the vulnerable Wrangler proposal and overrides transitive Undici to patched 7.29; `npm audit` is clean

## Verification

- clean Python 3.12 environment installed every backend requirement, including ONNX Runtime 1.28, cryptography 50, and OpenVINO 2026.3
- backend: `1883 passed, 49 skipped`
- backend Ruff check and format check: pass
- dependency/deployment contract after rebasing onto the Intel runtime fix: `21 passed`
- UI: Svelte check `0 errors, 0 warnings`; Vitest `716 passed`; production build pass
- telemetry Worker: Wrangler dry-run pass; `12 passed`; `npm audit` reports zero vulnerabilities

## Data integrity and risk

No schema, persisted data, secret handling, or deletion semantics change. Package locks are regenerated. Runtime-provider contract tests guard the asymmetric CUDA ceiling and consistent CPU/OpenVINO floors.