### PR TITLE
Fix instance card overflow on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **About:** The owner instance card now stays within the phone viewport when the issue-report
+  fingerprint contains a long model identifier. The availability strip shrinks with its card,
+  while the fingerprint wraps above a full-width Copy action on narrow screens.
+
 - **Dependencies:** Reviewed and consolidated the outstanding runtime, UI, telemetry Worker, and
   workflow dependency updates against current `dev`. The OpenVINO floor is consistent across both
   Intel-capable image flavours, CPU ONNX Runtime 1.28 is covered across CPU/Intel/ARM64 paths while

--- a/apps/ui/src/lib/components/InstanceSummary.svelte
+++ b/apps/ui/src/lib/components/InstanceSummary.svelte
@@ -128,7 +128,7 @@
 </script>
 
 {#if isOwner}
-    <section class="card-base space-y-4 p-6" data-about-instance aria-labelledby="about-instance-heading">
+    <section class="card-base min-w-0 max-w-full space-y-4 p-6" data-about-instance aria-labelledby="about-instance-heading">
         <div class="flex flex-wrap items-center gap-3">
             <h2 id="about-instance-heading" class="font-display text-xl font-bold text-slate-900 dark:text-white">
                 {$_('about.instance.title', { default: 'This instance' })}
@@ -167,12 +167,12 @@
             {/if}
         </div>
 
-        <div class="grid gap-6 sm:grid-cols-[minmax(0,0.7fr)_minmax(0,0.7fr)_minmax(0,1.6fr)]">
-            <div>
+        <div class="grid min-w-0 gap-6 sm:grid-cols-[minmax(0,0.7fr)_minmax(0,0.7fr)_minmax(0,1.6fr)]">
+            <div class="min-w-0">
                 <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
                     {$_('about.instance.acceleration', { default: 'Acceleration' })}
                 </p>
-                <p class="font-display text-2xl font-bold text-slate-900 dark:text-white">{acceleration}</p>
+                <p class="break-words font-display text-2xl font-bold text-slate-900 dark:text-white">{acceleration}</p>
                 {#if classifier?.fallback_reason}
                     <p class="mt-1 text-[11px] leading-snug text-slate-500 dark:text-slate-400">
                         {classifier.fallback_reason}
@@ -180,7 +180,7 @@
                 {/if}
             </div>
 
-            <div data-instance-uptime>
+            <div data-instance-uptime class="min-w-0">
                 <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
                     {$_('about.instance.uptime', { default: 'Running for' })}
                 </p>
@@ -198,7 +198,7 @@
                         </p>
                     {/if}
                     <div
-                        class="mt-2 flex gap-[2px]"
+                        class="mt-2 flex w-full min-w-0 max-w-full gap-[2px]"
                         role="img"
                         aria-label={$_('about.instance.strip_label', {
                             values: { hours: 24 },
@@ -208,7 +208,7 @@
                     >
                         {#each uptimeWindow.buckets as bucket (bucket.start)}
                             <span
-                                class="h-4 flex-1 rounded-[2px] {bucket.state === 'up'
+                                class="h-4 min-w-0 flex-1 rounded-[2px] {bucket.state === 'up'
                                     ? 'bg-emerald-500/80'
                                     : bucket.state === 'down'
                                       ? 'bg-accent-500'
@@ -243,18 +243,18 @@
                         {/if}
                     </p>
                 {:else if uptimeLoadState === 'loading'}
-                    <div class="mt-2 flex gap-[2px]" aria-hidden="true">
+                    <div class="mt-2 flex w-full min-w-0 max-w-full gap-[2px]" aria-hidden="true">
                         {#each { length: 24 } as _, slot (slot)}
-                            <span class="h-4 flex-1 rounded-[2px] bg-slate-200/70 dark:bg-slate-700/50"></span>
+                            <span class="h-4 min-w-0 flex-1 rounded-[2px] bg-slate-200/70 dark:bg-slate-700/50"></span>
                         {/each}
                     </div>
                     <p class="mt-1.5 text-[11px] text-slate-500 dark:text-slate-400">
                         {$_('about.instance.history_loading', { default: 'Loading availability…' })}
                     </p>
                 {:else if uptimeLoadState === 'error'}
-                    <div class="mt-2 flex gap-[2px]" aria-hidden="true">
+                    <div class="mt-2 flex w-full min-w-0 max-w-full gap-[2px]" aria-hidden="true">
                         {#each { length: 24 } as _, slot (slot)}
-                            <span class="h-4 flex-1 rounded-[2px] bg-slate-200/70 dark:bg-slate-700/50"></span>
+                            <span class="h-4 min-w-0 flex-1 rounded-[2px] bg-slate-200/70 dark:bg-slate-700/50"></span>
                         {/each}
                     </div>
                     <p class="mt-1.5 text-[11px] text-slate-500 dark:text-slate-400">
@@ -273,15 +273,15 @@
                 {/if}
             </div>
 
-            <div>
+            <div class="min-w-0" data-instance-report>
                 <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
                     {$_('about.instance.for_issue', { default: 'For an issue report' })}
                 </p>
-                <div class="mt-1.5 flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-900/50">
-                    <code class="min-w-0 flex-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
+                <div class="mt-1.5 flex min-w-0 flex-col items-stretch gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 sm:flex-row sm:items-center dark:border-slate-700 dark:bg-slate-900/50">
+                    <code class="min-w-0 max-w-full whitespace-normal break-all font-mono text-xs leading-relaxed text-slate-700 sm:flex-1 sm:truncate sm:whitespace-nowrap dark:text-slate-200">
                         {supportSummary}
                     </code>
-                    <button class="btn btn-secondary min-h-11 shrink-0 px-3 py-1.5 text-xs" onclick={copySummary}>
+                    <button class="btn btn-secondary min-h-11 w-full sm:w-auto shrink-0 px-3 py-1.5 text-xs" onclick={copySummary}>
                         {copied
                             ? $_('about.instance.copied', { default: 'Copied' })
                             : $_('about.instance.copy', { default: 'Copy' })}

--- a/apps/ui/src/lib/components/about-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/about-surface-polish.layout.test.ts
@@ -44,6 +44,18 @@ describe('About surface polish', () => {
         expect(instanceSource).toContain('about.instance.window_now');
     });
 
+    it('keeps uptime and issue-report content inside the instance card on narrow screens', () => {
+        // A long model id used to establish the mobile grid's intrinsic width. That widened the
+        // whole card, carrying both the report row and the 24-hour strip past the viewport.
+        expect(instanceSource).toContain('class="grid min-w-0 gap-6');
+        expect(instanceSource).toContain('data-instance-uptime class="min-w-0"');
+        expect(instanceSource).toContain('class="mt-2 flex w-full min-w-0 max-w-full gap-[2px]"');
+        expect(instanceSource).toContain('class="min-w-0" data-instance-report');
+        expect(instanceSource).toContain('flex min-w-0 flex-col items-stretch gap-2');
+        expect(instanceSource).toContain('whitespace-normal break-all');
+        expect(instanceSource).toContain('w-full sm:w-auto');
+    });
+
     it('spends motion on the pipeline rather than decorative hover effects', () => {
         expect(instanceSource).not.toContain('hover:scale-y-125');
         expect(aboutSource).not.toContain('group-hover:-translate-y-px');


### PR DESCRIPTION
## What changed

- allow the instance summary grid and uptime strip to shrink within the phone viewport
- wrap long issue-report fingerprints on narrow screens and stack them above a full-width Copy action
- add a regression test for the mobile containment contract
- document the UI fix in the changelog

## Root cause

The long model identifier established an oversized intrinsic width for the single-column mobile grid. That widened the card and carried both the issue-report row and the 24-hour uptime strip beyond the viewport.

## Impact

The About page owner card now remains contained on narrow screens while retaining the full diagnostic fingerprint and a 44px minimum copy target.

## Validation

- `pnpm --dir apps/ui test -- --run src/lib/components/about-surface-polish.layout.test.ts`
- `pnpm --dir apps/ui check`
- `pnpm --dir apps/ui test -- --run`
- `pnpm --dir apps/ui build`
- `backend/.venv/bin/pytest -q` (1889 passed, 44 skipped)
- `ruff check .`
- `ruff format --check .`
- `git diff --check`