### PR TITLE
Fix stale update notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Update notifications now converge within minutes instead of potentially remaining stale for
+  half a day.** The telemetry version endpoint reads CI's promoted D1 row without an isolate-local
+  stale copy, the backend uses a bounded fifteen-minute success cache with a five-minute failure retry,
+  and browser/proxy caching is disabled for the instance status response. The shared UI store now
+  retries failed checks and refreshes while visible, on navigation, and after returning to the tab;
+  version-keyed dismissals remain honoured.
+
 - **Anonymous telemetry now has an explicit Free-tier and privacy boundary.** D1 schema updates use
   ordered, non-destructive migrations; new heartbeats retain only a hashed installation identity;
   exact health replays no longer spend the daily write budget; scheduled bounded retention removes

--- a/apps/telemetry-worker/src/index.ts
+++ b/apps/telemetry-worker/src/index.ts
@@ -833,9 +833,6 @@ type VersionChannels = {
   dev: { version: string | null; commit: string | null; url: string | null };
   branches: Record<string, { version: string | null; commit: string | null; url: string | null }>;
 };
-const VERSION_CACHE: { data: VersionChannels | null; expires: number } = { data: null, expires: 0 };
-const VERSION_CACHE_TTL_MS = 30 * 60 * 1000;
-
 // Versions published by CI. D1 is authoritative for update checks; if the table or a branch row
 // is missing, the corresponding channel stays null instead of being guessed from GitHub.
 async function readVersionsFromD1(db: D1Database): Promise<Partial<VersionChannels>> {
@@ -860,10 +857,6 @@ async function readVersionsFromD1(db: D1Database): Promise<Partial<VersionChanne
 }
 
 app.get('/version', async (c) => {
-  const now = Date.now();
-  if (VERSION_CACHE.data && VERSION_CACHE.expires > now) {
-    return c.json(VERSION_CACHE.data, 200, { 'Cache-Control': 'public, max-age=1800' });
-  }
   try {
     const stored = await readVersionsFromD1(c.env.DB);
     const payload: VersionChannels = {
@@ -871,12 +864,13 @@ app.get('/version', async (c) => {
       dev: stored.dev ?? { version: null, commit: null, url: null },
       branches: stored.branches ?? {},
     };
-    VERSION_CACHE.data = payload;
-    VERSION_CACHE.expires = now + VERSION_CACHE_TTL_MS;
-    return c.json(payload, 200, { 'Cache-Control': 'public, max-age=1800' });
-  } catch (e: any) {
-    if (VERSION_CACHE.data) return c.json(VERSION_CACHE.data, 200);
-    return c.json({ error: e?.message ?? 'fetch_failed' }, 502);
+    // CI writes D1 only after the corresponding image family has passed and been promoted.
+    // Do not retain an isolate-local copy: it could hide the publication for 30 minutes and
+    // then seed each installation's own cache with stale data. Backend callers already
+    // coalesce this read for fifteen minutes per installation.
+    return c.json(payload, 200, { 'Cache-Control': 'no-store, max-age=0' });
+  } catch {
+    return c.json({ error: 'fetch_failed' }, 502, { 'Cache-Control': 'no-store, max-age=0' });
   }
 });
 

--- a/apps/telemetry-worker/test/worker.integration.test.mjs
+++ b/apps/telemetry-worker/test/worker.integration.test.mjs
@@ -65,6 +65,31 @@ after(async () => {
   await mf?.dispose();
 });
 
+test("version publication is visible immediately without a stale isolate cache", async (t) => {
+  await usageDb.prepare(`
+    INSERT OR REPLACE INTO app_versions (channel, version, commit_sha, url, updated_at)
+    VALUES ('dev', '2.17.0', 'old0000000000000000000000000000000000000',
+            'https://example.test/tree/dev', datetime('now'))
+  `).run();
+  t.after(async () => {
+    await usageDb.prepare("DELETE FROM app_versions WHERE channel = 'dev'").run();
+  });
+
+  const before = await mf.dispatchFetch("http://worker.test/version");
+  assert.equal(before.status, 200);
+  assert.equal((await before.json()).dev.commit, "old0000000000000000000000000000000000000");
+
+  await usageDb.prepare(`
+    UPDATE app_versions
+    SET commit_sha = 'new1111111111111111111111111111111111111', updated_at = datetime('now')
+    WHERE channel = 'dev'
+  `).run();
+
+  const afterPublish = await mf.dispatchFetch("http://worker.test/version");
+  assert.equal(afterPublish.status, 200);
+  assert.equal((await afterPublish.json()).dev.commit, "new1111111111111111111111111111111111111");
+});
+
 test("user metrics dashboard renders a bounded daily trend and distinct mode", async (t) => {
   await usageDb.prepare(`
     INSERT INTO heartbeats (

--- a/apps/ui/src/lib/api/system.ts
+++ b/apps/ui/src/lib/api/system.ts
@@ -145,7 +145,7 @@ export interface UpdateStatus {
 }
 
 export async function fetchUpdateStatus(): Promise<UpdateStatus> {
-    const response = await apiFetch(`${API_BASE}/update-status`);
+    const response = await apiFetch(`${API_BASE}/update-status`, { cache: 'no-store' });
     return handleResponse<UpdateStatus>(response);
 }
 

--- a/apps/ui/src/lib/api/system.update-banner.test.ts
+++ b/apps/ui/src/lib/api/system.update-banner.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { shouldShowUpdateBanner, type UpdateStatus } from './system';
+import { fetchUpdateStatus, shouldShowUpdateBanner, type UpdateStatus } from './system';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 const status = (overrides: Partial<UpdateStatus>): UpdateStatus => ({
     current_version: '2.10.0',
@@ -33,5 +37,20 @@ describe('shouldShowUpdateBanner', () => {
 
     it('is safe with null status', () => {
         expect(shouldShowUpdateBanner(null, null)).toBe(false);
+    });
+
+    it('bypasses browser caches when checking update status', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(status({})), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await fetchUpdateStatus();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/update-status'),
+            expect.objectContaining({ cache: 'no-store' })
+        );
     });
 });

--- a/apps/ui/src/lib/stores/update_status.svelte.ts
+++ b/apps/ui/src/lib/stores/update_status.svelte.ts
@@ -1,29 +1,63 @@
 import { fetchUpdateStatus, shouldShowUpdateBanner, type UpdateStatus } from '../api';
+import { StaleTracker } from '../utils/stale_tracker';
+import { refreshCoordinator } from './refresh_coordinator.svelte';
 
 // Dismissal is keyed on the version, so dismissing one update doesn't hide a later, newer one.
 const DISMISSED_KEY = 'update-banner-dismissed-version';
+export const UPDATE_STATUS_MAX_AGE_MS = 15 * 60 * 1000;
 
 /**
  * Shared update-availability state so the update banner and the sidebar indicator stay in
  * sync from a single check, and a dismiss is honoured everywhere. An update prompt is never
  * critical, so a failed fetch just leaves the status null (nothing shown).
  */
-class UpdateStatusStore {
+export class UpdateStatusStore {
     status = $state<UpdateStatus | null>(null);
     dismissedVersion = $state<string | null>(null);
-    private loaded = false;
+    private initialized = false;
+    private loadPromise: Promise<void> | null = null;
+    private pollTimer: ReturnType<typeof setInterval> | null = null;
+    private readonly staleTracker = new StaleTracker(UPDATE_STATUS_MAX_AGE_MS);
+
+    constructor() {
+        refreshCoordinator.register(() => this.refreshIfStale());
+    }
 
     async load(): Promise<void> {
-        if (this.loaded) return;
-        this.loaded = true;
-        if (typeof localStorage !== 'undefined') {
-            this.dismissedVersion = localStorage.getItem(DISMISSED_KEY);
+        if (!this.initialized) {
+            this.initialized = true;
+            if (typeof localStorage !== 'undefined') {
+                this.dismissedVersion = localStorage.getItem(DISMISSED_KEY);
+            }
+            this.startPolling();
         }
-        try {
-            this.status = await fetchUpdateStatus();
-        } catch {
-            this.status = null;
-        }
+        await this.refreshIfStale();
+    }
+
+    async refreshIfStale(): Promise<void> {
+        if (this.loadPromise) return this.loadPromise;
+        if (!this.staleTracker.isStale()) return;
+
+        this.loadPromise = (async () => {
+            try {
+                this.status = await fetchUpdateStatus();
+                this.staleTracker.touch();
+            } catch {
+                // Keep a last-known status if one exists. A failed first check remains stale,
+                // so navigation, visibility recovery, or the poll will retry automatically.
+            } finally {
+                this.loadPromise = null;
+            }
+        })();
+        return this.loadPromise;
+    }
+
+    private startPolling(): void {
+        if (this.pollTimer !== null || typeof window === 'undefined') return;
+        this.pollTimer = window.setInterval(() => {
+            if (document.hidden) return;
+            void this.refreshIfStale();
+        }, UPDATE_STATUS_MAX_AGE_MS);
     }
 
     dismiss(): void {

--- a/apps/ui/src/lib/stores/update_status.test.ts
+++ b/apps/ui/src/lib/stores/update_status.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    fetchUpdateStatus: vi.fn(),
+}));
+
+vi.mock('../api', () => ({
+    fetchUpdateStatus: mocks.fetchUpdateStatus,
+    shouldShowUpdateBanner: (status: { update_available?: boolean; latest_version?: string | null } | null, dismissed: string | null) =>
+        Boolean(status?.update_available && status.latest_version && status.latest_version !== dismissed),
+}));
+
+const status = (commit: string) => ({
+    current_version: '2.17.0-dev+old0000',
+    channel: 'dev',
+    latest_version: `2.17.0-dev+${commit}`,
+    update_available: commit !== 'old0000',
+    release_url: 'https://example.test/tree/dev',
+    checked_at: '2026-08-13T00:00:00Z',
+    enabled: true,
+    error: null,
+});
+
+describe('UpdateStatusStore', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-13T00:00:00Z'));
+        vi.resetModules();
+        mocks.fetchUpdateStatus.mockReset();
+        Object.defineProperty(globalThis, 'localStorage', {
+            configurable: true,
+            value: {
+                getItem: vi.fn().mockReturnValue(null),
+                setItem: vi.fn(),
+            },
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it('deduplicates the initial check and refreshes a stale result', async () => {
+        mocks.fetchUpdateStatus
+            .mockResolvedValueOnce(status('old0000'))
+            .mockResolvedValueOnce(status('new1111'));
+        const { UPDATE_STATUS_MAX_AGE_MS, UpdateStatusStore } = await import('./update_status.svelte');
+        const store = new UpdateStatusStore();
+
+        await Promise.all([store.load(), store.load(), store.load()]);
+        expect(mocks.fetchUpdateStatus).toHaveBeenCalledTimes(1);
+        expect(store.updateAvailable).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(UPDATE_STATUS_MAX_AGE_MS);
+        await store.refreshIfStale();
+
+        expect(mocks.fetchUpdateStatus).toHaveBeenCalledTimes(2);
+        expect(store.latestVersion).toBe('2.17.0-dev+new1111');
+        expect(store.updateAvailable).toBe(true);
+    });
+
+    it('retries after an initial transient failure instead of staying null forever', async () => {
+        mocks.fetchUpdateStatus
+            .mockRejectedValueOnce(new Error('offline'))
+            .mockResolvedValueOnce(status('new2222'));
+        const { UPDATE_STATUS_MAX_AGE_MS, UpdateStatusStore } = await import('./update_status.svelte');
+        const store = new UpdateStatusStore();
+
+        await store.load();
+        expect(store.status).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(UPDATE_STATUS_MAX_AGE_MS);
+        await store.refreshIfStale();
+
+        expect(mocks.fetchUpdateStatus).toHaveBeenCalledTimes(2);
+        expect(store.updateAvailable).toBe(true);
+    });
+});

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -68,7 +68,7 @@ class UpdateStatusResponse(APIModel):
 
 
 @router.get("/update-status", response_model=UpdateStatusResponse)
-async def get_update_status() -> UpdateStatusResponse:
+async def get_update_status(response: Response) -> UpdateStatusResponse:
     """Report whether a newer YA-WAMF release is available (in-app update prompt).
 
     A notification only — YA-WAMF never updates itself; pulling a new image is left to the
@@ -76,6 +76,9 @@ async def get_update_status() -> UpdateStatusResponse:
     """
     from app.services.update_service import update_service
 
+    # The shared UI store owns freshness and the backend owns its short Worker/D1 cache.
+    # Intermediate browser/proxy caching would make both controls ineffective.
+    response.headers["Cache-Control"] = "no-store, max-age=0"
     current_version = os.environ.get("APP_VERSION", "unknown")
     # APP_VERSION is "<base>-<branch>+<hash>" (branch image) or "<base>+<hash>" (release).
     # Prefer APP_BRANCH from the image build because stable releases intentionally omit the

--- a/backend/app/services/update_service.py
+++ b/backend/app/services/update_service.py
@@ -1,11 +1,10 @@
 """Checks for a newer YA-WAMF release to power the in-app update prompt.
 
-The latest version comes from the telemetry worker's ``/version`` endpoint (a plain GET
-with no telemetry payload), which fetches and edge-caches it from GitHub — so GitHub is
-hit once per cache window globally rather than once per install, and the check works even
-when telemetry is disabled. The local lookup is itself cached and lazy (refreshed on
-request when stale), never blocks, and degrades to the last known result — or to "no
-update" — on any failure. Honours the ``system.update_check_enabled`` privacy opt-out.
+The latest version comes from the telemetry worker's D1-backed ``/version`` endpoint (a
+plain GET with no telemetry payload), so the check works even when telemetry is disabled.
+The local lookup is cached briefly and refreshed lazily on request, never blocks, and
+degrades to the last known result — or to "no update" — on any failure. Honours the
+``system.update_check_enabled`` privacy opt-out.
 """
 
 import asyncio
@@ -21,8 +20,11 @@ from app.utils.version import is_update_available
 log = structlog.get_logger()
 
 RELEASES_PAGE_URL = "https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/releases/latest"
-SUCCESS_TTL_SECONDS = 12 * 3600
-FAILURE_RETRY_SECONDS = 3600
+# Keep update prompts useful without turning every browser poll into a Worker/D1 read.
+# At the current fleet size a fifteen-minute successful TTL is roughly 2,400 requests/day,
+# while avoiding the old twelve-hour stale "no update" window and retaining Free-tier headroom.
+SUCCESS_TTL_SECONDS = 15 * 60
+FAILURE_RETRY_SECONDS = 5 * 60
 FETCH_TIMEOUT_SECONDS = 8.0
 
 

--- a/backend/tests/test_system_telemetry.py
+++ b/backend/tests/test_system_telemetry.py
@@ -6,6 +6,7 @@ import pytest
 from app.main import app
 from app.routers import stats as stats_router
 from app.services.system_telemetry import SystemTelemetrySample, SystemTelemetrySampler
+from app.services.update_service import update_service
 
 
 def _write_cpu_stat(path: Path, *, user: int, system: int, idle: int) -> None:
@@ -64,3 +65,29 @@ async def test_system_telemetry_endpoint_returns_live_sample_without_caching(mon
         "cpu_percent": 37.5,
         "accelerator": {"kind": "npu", "label": "NPU", "utilization_percent": 18.2},
     }
+
+
+@pytest.mark.asyncio
+async def test_update_status_endpoint_is_never_browser_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def stub_status(current_version: str, branch: str, git_hash: str) -> dict:
+        return {
+            "current_version": current_version,
+            "channel": branch,
+            "latest_version": f"2.17.0-{branch}+abcdef0",
+            "update_available": True,
+            "release_url": "https://example.test/tree/dev",
+            "checked_at": "2026-08-13T00:00:00+00:00",
+            "enabled": True,
+            "error": None,
+        }
+
+    monkeypatch.setattr(update_service, "get_status", stub_status)
+    monkeypatch.setenv("APP_VERSION", "2.17.0-dev+1234567")
+    monkeypatch.setenv("APP_BRANCH", "dev")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/update-status")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store, max-age=0"
+    assert response.json()["update_available"] is True

--- a/backend/tests/test_update_service.py
+++ b/backend/tests/test_update_service.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from app.config import settings
-from app.services.update_service import UpdateService
+from app.services.update_service import FAILURE_RETRY_SECONDS, SUCCESS_TTL_SECONDS, UpdateService
 
 CHANNELS = {
     "stable": {"version": "v2.12.0", "url": "https://example/releases/tag/v2.12.0"},
@@ -98,6 +98,35 @@ async def test_result_is_cached_within_ttl():
         await svc.get_status("2.10.0", branch="main", git_hash="x")
         await svc.get_status("2.10.0", branch="main", git_hash="x")
     svc._fetch_channels.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_successful_result_refreshes_after_bounded_ttl():
+    svc = UpdateService()
+    svc._fetch_channels = AsyncMock(return_value=CHANNELS)
+    with patch.object(settings.system, "update_check_enabled", True):
+        await svc.get_status("2.10.0", branch="main", git_hash="x")
+        svc._fetched_at -= SUCCESS_TTL_SECONDS + 1
+        await svc.get_status("2.10.0", branch="main", git_hash="x")
+
+    assert svc._fetch_channels.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_result_retries_after_short_bounded_ttl():
+    svc = UpdateService()
+    svc._fetch_channels = AsyncMock(
+        side_effect=[RuntimeError("temporary"), CHANNELS],
+    )
+    with patch.object(settings.system, "update_check_enabled", True):
+        first = await svc.get_status("2.10.0", branch="main", git_hash="x")
+        svc._fetched_at -= FAILURE_RETRY_SECONDS + 1
+        recovered = await svc.get_status("2.10.0", branch="main", git_hash="x")
+
+    assert first["error"] == "fetch_failed"
+    assert recovered["error"] is None
+    assert recovered["update_available"] is True
+    assert svc._fetch_channels.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- refresh the D1-backed version source immediately after CI publishes a promoted image
- bound the backend cache to 15 minutes, retry failures after 5 minutes, and prevent browser/proxy caching
- retry and periodically refresh the shared UI update state while visible, on navigation, and after tab return
- preserve version-keyed dismissals and the last known status across transient failures

## Root cause

The Worker retained an isolate-local version response for 30 minutes, the backend retained a successful result for 12 hours, and the browser store attempted its check only once per page lifetime. A check just before CI publication could therefore hide a real update for most of a day, while an initial transient UI failure was never retried.

## Free-tier impact

At the current 25-active-install fleet, the 15-minute backend cache bounds version checks to roughly 2,400 Worker requests per day with only a few D1 rows read per request. This remains well inside Cloudflare's Free-tier allowances.

## Validation

- `pytest backend/tests -q` — 1,888 passed, 49 skipped
- `npm test` — UI 726 passed
- `npm run check` — zero Svelte errors or warnings
- `npm run build` — production UI build passed
- telemetry Worker `npm test` — 17 passed
- `ruff check backend custom_components scripts tests` — passed
- `git diff --check` — passed
