### PR TITLE
Keep mobile overlays clear of controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Mobile species tagging and notifications no longer hide controls.** The species picker follows
+  the browser's visible viewport when an on-screen keyboard opens, keeps its results scrollable in
+  short and landscape layouts, and exposes proper dialog and field semantics. Phone notifications
+  now use a safe-area-aware lane beneath the detection close control, which remains anchored while
+  detection content scrolls or the device rotates. Desktop notification placement stays unchanged.
+
 - **Update notifications now converge within minutes instead of potentially remaining stale for
   half a day.** The telemetry version endpoint reads CI's promoted D1 row without an isolate-local
   stale copy, the backend uses a bounded fifteen-minute success cache with a five-minute failure retry,

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -66,6 +66,7 @@
     import { isVideoPromotionGated } from '../video-promotion-gate';
     import { applyManualTagResult } from '../utils/manual-tag';
     import { findMatchingFullFrameCandidate } from '../utils/detection-evidence';
+    import { intersectVisibleViewport } from '../utils/visible-viewport';
 
     const FRIGATE_MISSING_DOCS_URL = 'https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/blob/dev/docs/troubleshooting/frigate-event-not-found.md';
 
@@ -155,6 +156,8 @@
 
     // State
     let modalElement = $state<HTMLElement | null>(null);
+    let manualTagViewportStyle = $state<string | undefined>(undefined);
+    let viewportAnimationFrame: number | undefined;
     let previousBodyPosition = '';
     let previousBodyTop = '';
     let previousBodyWidth = '';
@@ -231,6 +234,35 @@
         scrollLocked = false;
     }
 
+    function syncManualTagViewport(): void {
+        if (typeof window === 'undefined' || !modalElement || !window.visualViewport) {
+            manualTagViewportStyle = undefined;
+            return;
+        }
+
+        const modalBounds = modalElement.getBoundingClientRect();
+        const visibleBounds = intersectVisibleViewport(
+            { top: modalBounds.top, height: modalBounds.height },
+            {
+                offsetTop: window.visualViewport.offsetTop,
+                height: window.visualViewport.height
+            }
+        );
+        const isClipped = visibleBounds.top > 0.5 || visibleBounds.height < modalBounds.height - 0.5;
+
+        manualTagViewportStyle = isClipped && visibleBounds.height > 0
+            ? `top:${Math.round(visibleBounds.top)}px;height:${Math.round(visibleBounds.height)}px;`
+            : undefined;
+    }
+
+    function scheduleManualTagViewportSync(): void {
+        if (typeof window === 'undefined' || viewportAnimationFrame !== undefined) return;
+        viewportAnimationFrame = window.requestAnimationFrame(() => {
+            viewportAnimationFrame = undefined;
+            syncManualTagViewport();
+        });
+    }
+
     function withCacheBust(url: string, token: number): string {
         const separator = url.includes('?') ? '&' : '?';
         return `${url}${separator}v=${token}`;
@@ -287,6 +319,33 @@
         lockDocumentScroll();
         return () => {
             unlockDocumentScroll();
+        };
+    });
+
+    onMount(() => {
+        if (typeof window === 'undefined') return;
+        const visualViewport = window.visualViewport;
+        const modalResizeObserver = typeof ResizeObserver === 'undefined'
+            ? undefined
+            : new ResizeObserver(scheduleManualTagViewportSync);
+
+        syncManualTagViewport();
+        if (modalElement) {
+            modalResizeObserver?.observe(modalElement);
+        }
+        window.addEventListener('resize', scheduleManualTagViewportSync);
+        visualViewport?.addEventListener('resize', scheduleManualTagViewportSync);
+        visualViewport?.addEventListener('scroll', scheduleManualTagViewportSync);
+
+        return () => {
+            modalResizeObserver?.disconnect();
+            window.removeEventListener('resize', scheduleManualTagViewportSync);
+            visualViewport?.removeEventListener('resize', scheduleManualTagViewportSync);
+            visualViewport?.removeEventListener('scroll', scheduleManualTagViewportSync);
+            if (viewportAnimationFrame !== undefined) {
+                window.cancelAnimationFrame(viewportAnimationFrame);
+                viewportAnimationFrame = undefined;
+            }
         };
     });
 
@@ -2087,6 +2146,19 @@
             <ReclassificationOverlay progress={reclassifyProgress} />
         {/if}
 
+        {#if !snapshotRepairOpen}
+            <button
+                data-detection-modal-close
+                onclick={onClose}
+                class="absolute top-4 right-4 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/25 bg-black/45 text-white shadow-lg backdrop-blur-sm transition-colors hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                aria-label={$_('common.close')}
+            >
+                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        {/if}
+
         <div class="flex-1 overflow-hidden flex flex-col lg:grid lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
 	            <div class="relative aspect-[4/3] shrink-0 overflow-hidden lg:aspect-auto lg:h-full lg:min-h-[26rem] bg-gradient-to-br from-slate-900 via-slate-950 to-brand-950 sm:aspect-video lg:aspect-auto lg:h-full lg:border-r lg:border-slate-200/70 dark:lg:border-slate-700/60">
                     {#if showMediaSlotVideoAnalysis}
@@ -2286,17 +2358,6 @@
                         </div>
                     {/if}
 
-        {#if !snapshotRepairOpen}
-            <button
-                onclick={onClose}
-                class="absolute top-4 right-4 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/25 bg-black/45 text-white shadow-lg backdrop-blur-sm transition-colors hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-                aria-label={$_('common.close')}
-            >
-                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
-        {/if}
                 {#if canShowFullFrame}
                     <div class="absolute left-3 top-3 z-20 flex gap-1 rounded-lg bg-slate-950/55 p-1 backdrop-blur-sm" data-detection-media-toggle>
                         <button
@@ -3908,48 +3969,59 @@
 
         {#if hasOwnerDetectionActions && showTagDropdown}
             <div
-                class="absolute inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4 overscroll-contain touch-none"
+                data-manual-tag-dialog
+                class="absolute left-0 right-0 top-0 z-50 flex h-full items-center justify-center overscroll-contain bg-black/40 p-4 backdrop-blur-sm"
+                style={manualTagViewportStyle}
                 onclick={(e) => {
                     if (e.target === e.currentTarget && !updatingTag) {
                         showTagDropdown = false;
                     }
                 }}
                 onkeydown={(e) => {
-                    if ((e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') && e.target === e.currentTarget && !updatingTag) {
+                    if (e.key === 'Escape' && !updatingTag) {
                         e.preventDefault();
+                        e.stopPropagation();
                         showTagDropdown = false;
                     }
                 }}
-                role="button"
-                tabindex="0"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="manual-tag-dialog-title"
+                tabindex="-1"
             >
                 <div
-                    class="w-full max-w-md mx-2 bg-white dark:bg-slate-800 rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700 overflow-hidden animate-in fade-in zoom-in-95 touch-pan-y"
+                    class="mx-2 flex max-h-full w-full max-w-md flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl animate-in fade-in zoom-in-95 touch-pan-y dark:border-slate-700 dark:bg-slate-800"
                     aria-busy={updatingTag}
                 >
-                    <div class="px-5 py-4 border-b border-slate-100 dark:border-slate-700 flex items-center justify-between">
-                        <h4 class="text-sm font-bold text-slate-800 dark:text-slate-100">
+                    <div class="flex shrink-0 items-center justify-between border-b border-slate-100 px-5 py-2 dark:border-slate-700">
+                        <h4 id="manual-tag-dialog-title" class="text-sm font-bold text-slate-800 dark:text-slate-100">
                             {$_('actions.manual_tag')}
                         </h4>
                         <button
                             type="button"
                             onclick={() => showTagDropdown = false}
                             disabled={updatingTag}
-                            class="text-xs font-bold text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+                            class="btn btn-ghost min-h-11 px-3 text-xs"
                         >
                             {$_('common.cancel')}
                         </button>
                     </div>
-                    <div class="p-4 border-b border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50">
+                    <div class="shrink-0 border-b border-slate-100 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/50">
+                        <label for="manual-tag-species-search" class="sr-only">
+                            {$_('detection.tagging.search_placeholder')}
+                        </label>
                         <input
+                            id="manual-tag-species-search"
                             type="text"
                             bind:value={tagSearchQuery}
                             disabled={updatingTag}
+                            autocomplete="off"
+                            enterkeyhint="search"
                             placeholder={$_('detection.tagging.search_placeholder')}
-                            class="w-full px-4 py-2 text-sm rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-brand-500 focus:border-transparent outline-none"
+                            class="input-base min-h-11 text-base sm:text-sm"
                         />
                     </div>
-                    <div class="max-h-72 overflow-y-auto overscroll-contain p-1">
+                    <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-1">
                         {#each searchResults as result}
                             {@const names = getResultNames(result)}
                             {@const isPending = updatingTag && pendingManualTagId === result.id}
@@ -3957,7 +4029,7 @@
                                 type="button"
                                 onclick={() => handleManualTag(result)}
                                 disabled={updatingTag}
-                                class="w-full px-4 py-2.5 text-left text-sm font-medium rounded-lg transition-all touch-manipulation hover:bg-brand-50 dark:hover:bg-brand-900/20 hover:text-brand-600 dark:hover:text-brand-400 disabled:opacity-60 disabled:cursor-wait {result.id === detection.display_name ? 'bg-brand-500/10 text-brand-600 font-bold' : 'text-slate-600 dark:text-slate-300'}"
+                                class="min-h-11 w-full rounded-lg px-4 py-2.5 text-left text-sm font-medium transition-all touch-manipulation hover:bg-brand-50 hover:text-brand-600 disabled:cursor-wait disabled:opacity-60 dark:hover:bg-brand-900/20 dark:hover:text-brand-400 {result.id === detection.display_name ? 'bg-brand-500/10 text-brand-600 font-bold' : 'text-slate-600 dark:text-slate-300'}"
                             >
                                 <span class="block text-sm leading-tight">
                                     {names.primary}

--- a/apps/ui/src/lib/components/Toast.svelte
+++ b/apps/ui/src/lib/components/Toast.svelte
@@ -23,24 +23,30 @@
     function getColorClasses(type: Toast['type']) {
         switch (type) {
             case 'success':
-                return 'bg-accent-500 border-accent-600';
+                return 'bg-accent-700 border-accent-800';
             case 'error':
-                return 'bg-red-500 border-red-600';
+                return 'bg-red-700 border-red-800';
             case 'warning':
-                return 'bg-amber-500 border-amber-600';
+                return 'bg-amber-700 border-amber-800';
             case 'info':
             default:
-                return 'bg-brand-500 border-brand-600';
+                return 'bg-brand-700 border-brand-800';
         }
     }
 </script>
 
 <!-- Toast Container -->
-<div class="fixed top-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none">
+<div
+    data-toast-container
+    class="toast-container z-[100] flex flex-col items-end gap-2 pointer-events-none"
+    aria-live="polite"
+    aria-relevant="additions"
+>
     {#each toasts as toast (toast.id)}
         <div
-            class="pointer-events-auto max-w-md {getColorClasses(toast.type)} text-white rounded-xl shadow-lg border-2 backdrop-blur-sm"
+            class="pointer-events-auto w-full max-w-md {getColorClasses(toast.type)} text-white rounded-xl shadow-lg border-2 backdrop-blur-sm"
             transition:fly={{ x: 300, duration: 300 }}
+            aria-atomic="true"
         >
             <div class="flex items-center gap-3 p-4">
                 <!-- Icon -->
@@ -56,7 +62,7 @@
                 <!-- Close Button -->
                 <button
                     onclick={() => toastStore.remove(toast.id)}
-                    class="flex-shrink-0 w-6 h-6 rounded-full hover:bg-white/20 flex items-center justify-center transition-colors"
+                    class="-mr-2 inline-flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
                     aria-label={$_('notifications.close_toast', { default: 'Close notification' })}
                 >
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -69,5 +75,17 @@
 </div>
 
 <style>
-    /* Additional styles if needed */
+    .toast-container {
+        position: fixed;
+        top: calc(env(safe-area-inset-top, 0px) + 5rem);
+        right: 1rem;
+        left: 1rem;
+    }
+
+    @media (min-width: 640px) {
+        .toast-container {
+            top: 1rem;
+            left: auto;
+        }
+    }
 </style>

--- a/apps/ui/src/lib/components/mobile-overlay-clearance.layout.test.ts
+++ b/apps/ui/src/lib/components/mobile-overlay-clearance.layout.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import detectionModalSource from './DetectionModal.svelte?raw';
+import toastSource from './Toast.svelte?raw';
+
+describe('mobile overlay clearance', () => {
+    it('keeps the manual species picker inside the visible viewport', () => {
+        expect(detectionModalSource).toContain("import { intersectVisibleViewport }");
+        expect(detectionModalSource).toContain("visualViewport?.addEventListener('resize'");
+        expect(detectionModalSource).toContain("visualViewport?.addEventListener('scroll'");
+        expect(detectionModalSource).toContain('style={manualTagViewportStyle}');
+        expect(detectionModalSource).toContain('data-manual-tag-dialog');
+        expect(detectionModalSource).toContain('aria-modal="true"');
+        expect(detectionModalSource).toContain('max-h-full');
+        expect(detectionModalSource).toContain('text-base sm:text-sm');
+    });
+
+    it('anchors the detection close action outside the scrollable content region', () => {
+        const closeActionIndex = detectionModalSource.indexOf('data-detection-modal-close');
+        const scrollableContentIndex = detectionModalSource.indexOf('class="flex-1 overflow-hidden flex flex-col');
+
+        expect(closeActionIndex).toBeGreaterThan(-1);
+        expect(scrollableContentIndex).toBeGreaterThan(-1);
+        expect(closeActionIndex).toBeLessThan(scrollableContentIndex);
+    });
+
+    it('places phone toasts below the modal controls and within safe-area gutters', () => {
+        expect(toastSource).toContain('data-toast-container');
+        expect(toastSource).toContain('class="toast-container');
+        expect(toastSource).toContain('env(safe-area-inset-top, 0px)');
+        expect(toastSource).toContain('top: 1rem;');
+        expect(toastSource).toContain('aria-live="polite"');
+        expect(toastSource).toContain('aria-atomic="true"');
+        expect(toastSource).toContain('bg-accent-700 border-accent-800');
+        expect(toastSource).not.toContain('bg-accent-500 border-accent-600');
+    });
+});

--- a/apps/ui/src/lib/utils/visible-viewport.test.ts
+++ b/apps/ui/src/lib/utils/visible-viewport.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { intersectVisibleViewport } from './visible-viewport';
+
+describe('intersectVisibleViewport', () => {
+    it('limits a full-height modal to the space above a mobile keyboard', () => {
+        expect(
+            intersectVisibleViewport(
+                { top: 0, height: 800 },
+                { offsetTop: 0, height: 476 }
+            )
+        ).toEqual({ top: 0, height: 476 });
+    });
+
+    it('accounts for browser chrome shifting the visible viewport', () => {
+        expect(
+            intersectVisibleViewport(
+                { top: 0, height: 800 },
+                { offsetTop: 64, height: 412 }
+            )
+        ).toEqual({ top: 64, height: 412 });
+    });
+
+    it('keeps the modal bounds when the visual viewport fully contains it', () => {
+        expect(
+            intersectVisibleViewport(
+                { top: 40, height: 720 },
+                { offsetTop: 0, height: 800 }
+            )
+        ).toEqual({ top: 0, height: 720 });
+    });
+
+    it('returns an empty intersection when the modal is outside the visible viewport', () => {
+        expect(
+            intersectVisibleViewport(
+                { top: 700, height: 100 },
+                { offsetTop: 0, height: 600 }
+            )
+        ).toEqual({ top: 0, height: 0 });
+    });
+});

--- a/apps/ui/src/lib/utils/visible-viewport.ts
+++ b/apps/ui/src/lib/utils/visible-viewport.ts
@@ -1,0 +1,24 @@
+export interface VerticalBounds {
+    top: number;
+    height: number;
+}
+
+export interface VisualViewportBounds {
+    offsetTop: number;
+    height: number;
+}
+
+export function intersectVisibleViewport(
+    container: VerticalBounds,
+    viewport: VisualViewportBounds
+): VerticalBounds {
+    const containerBottom = container.top + container.height;
+    const viewportBottom = viewport.offsetTop + viewport.height;
+    const visibleTop = Math.max(container.top, viewport.offsetTop);
+    const visibleBottom = Math.min(containerBottom, viewportBottom);
+
+    return {
+        top: Math.max(0, visibleTop - container.top),
+        height: Math.max(0, visibleBottom - visibleTop)
+    };
+}


### PR DESCRIPTION
## Outcome

Mobile species tagging and transient notifications no longer hide the controls needed to finish the interaction.

## Included

- Fit the manual species picker to `window.visualViewport` without opting the whole app into keyboard overlay handling.
- Keep filtered species results scrollable in short portrait and landscape viewports.
- Anchor the detection close action to the modal shell so internal scrolling and rotation cannot move it off-screen.
- Place phone toasts in a safe-area-aware lane beneath the close control while retaining the desktop position.
- Improve picker dialog semantics, field labelling, touch targets, toast announcement behaviour, and theme contrast.
- Add pure viewport-intersection and source-level layout regression tests.

## Excluded

- No backend, API, database, migration, or global viewport-meta changes.
- No use of the Chromium-only VirtualKeyboard API.

## Root cause

The picker was centred against the layout viewport, which can remain taller than the area visible above a mobile keyboard. Filtering shortened and re-centred the picker, placing its result row beneath the keyboard. Toasts and the modal close control also shared the same top-right coordinates, with the toast in the higher stacking context. The close action additionally lived inside an internally scrolled media region.

## Verification

- `npm test` — 141 files, 733 tests passed
- `npm run check` — zero errors and warnings
- `npm run build` — production build and JavaScript budget passed
- `pytest` — 1,894 passed, 44 skipped
- `ruff check .` — passed
- `ruff format --check .` — 506 files formatted
- Browser QA at 390×844 and 844×390 in light and dark themes; no horizontal overflow, 19px phone toast/close clearance, and close remained fully visible after rotation

## Risk

UI-only and reversible. No data, migration, security, or deployment contract changes.

Addresses #189.
