### PR TITLE
Separate the Explorer's timeline and pagination with space, not rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **The Explorer loses two sets of horizontal rules.** The timeline was wrapped in a line above and
+  below, putting one directly above the first row of detections, and the pagination was wrapped the
+  same way. Against a grid of cards that already carry strong edges, those read as lines drawn across
+  the page rather than as structure. Both are separated by space now.
+
 - **Mobile species tagging and notifications no longer hide controls.** The species picker follows
   the browser's visible viewport when an on-screen keyboard opens, keeps its results scrollable in
   short and landscape layouts, and exposes proper dialog and field semantics. Phone notifications

--- a/apps/ui/src/lib/components/Pagination.svelte
+++ b/apps/ui/src/lib/components/Pagination.svelte
@@ -70,7 +70,7 @@
 </script>
 
 {#if totalPages > 0}
-    <div data-pagination class="flex flex-col items-center justify-between gap-4 border-y border-slate-200 py-4 dark:border-slate-700 sm:flex-row">
+    <div data-pagination class="flex flex-col items-center justify-between gap-4 pt-5 pb-1 sm:flex-row">
         <!-- Items info and page size selector -->
         <div class="flex items-center gap-4 text-sm text-slate-600 dark:text-slate-400">
             <span class="font-medium text-slate-700 dark:text-slate-300">

--- a/apps/ui/src/lib/pages/Events.layout.test.ts
+++ b/apps/ui/src/lib/pages/Events.layout.test.ts
@@ -24,10 +24,13 @@ describe('Explorer page layout', () => {
         expect(eventsSource).not.toContain('species={availableSpecies}');
     });
 
-    it('presents the timeline as a quiet divided control instead of another card', () => {
+    it('separates the timeline and pagination with space, not rules', () => {
         expect(eventsSource).toContain('data-events-timeline');
-        expect(eventsSource).toMatch(/data-events-timeline[^>]+border-y/);
+        // Both used to be wrapped in a rule above and below. Against a grid of cards that
+        // already carry strong edges, those read as lines drawn across the page.
+        expect(eventsSource).not.toMatch(/data-events-timeline[^>]+border-y/);
         expect(paginationSource).toContain('data-pagination');
+        expect(paginationSource).not.toMatch(/data-pagination[^>]+border-y/);
         expect(paginationSource).not.toContain('card-base');
         expect(paginationSource).toContain("$_('pagination.showing'");
         expect(paginationSource).not.toContain('Showing <span');

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -1147,7 +1147,7 @@
         {/if}
 
         {#if !loading && timelineBuckets.length > 0}
-            <section data-events-timeline class="border-y border-slate-200 py-3 dark:border-slate-700">
+            <section data-events-timeline class="pb-4 pt-1">
                 <div class="flex flex-wrap items-center gap-2">
                     <button
                         type="button"


### PR DESCRIPTION
The timeline and the pagination were each wrapped in a `border-y`, a rule above and a rule below. That put one line directly above the first row of detections, and another pair boxing in the pagination.

Against a grid of cards that already carry strong edges, those read as lines drawn across the page rather than as structure. Both are now separated by space.

Not the pill outlines, which are unchanged.

## On the test

`Events.layout.test.ts` asserted the rule was present, under the name "presents the timeline as a quiet divided control instead of another card". That was a deliberate earlier decision, and the division is exactly what looks wrong, so the test moves with the intent: it now asserts the rules are absent, with a comment on why.

## Verification

- 733 tests pass, `npm run check` 0 errors, build clean
- Confirmed in the browser by computed style: `0px` top and bottom on both `[data-events-timeline]` and `[data-pagination]`, and visually on the pagination

## Worth a reviewer's eye

Two things in the same area were raised and **not** touched here, so they are still open:

- The timeline pills nest a `rounded-full` count badge inside a `rounded-full border` pill, so they are an outline wrapping an outline, and they do not match the explorer's own filter tokens, which use `bg-brand-50` with no border at all.
- In the pagination the active page is a solid filled block while inactive pages have no border or background, so they do not read as controls; the "Show" select adds a third outline style to the same row.