### PR TITLE
Polish the detection ID as a platform terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   list drew its own rules inside that again. One hairline separates them now.
 - **The species reference and nearby sightings are part of the record**, not folded behind a
   disclosure that had to be opened every time.
+- **The detection id opens as a little terminal.** The disclosure you click is the window chrome
+  itself, and the id is printed as command output with a blinking caret. The window furniture
+  follows the viewer's own platform: traffic lights on macOS, the minimise and maximise and close
+  set on Windows. The caret stops under `prefers-reduced-motion`.
 - **The species info button has padding.** It carried no padding class at all, so for a guest, whose
   sibling actions are hidden, it collapsed to the height of its own text.
 - **The Explorer loses two sets of horizontal rules.** The timeline was wrapped in a line above and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   disclosure that had to be opened every time.
 - **The detection id opens as a little terminal.** The disclosure you click is the window chrome
   itself, and the id is printed as command output with a blinking caret. The window furniture
-  follows the viewer's own platform: traffic lights on macOS, the minimise and maximise and close
-  set on Windows. The caret stops under `prefers-reduced-motion`.
+  follows the viewer's own platform, inside and out: traffic lights over a dark shell on macOS, a
+  bevelled Windows 95 title bar over a black DOS box on Windows, and a GNOME close button over
+  Ubuntu's aubergine with its green bash prompt on Linux. The caret stops under
+  `prefers-reduced-motion`.
 - **The species info button has padding.** It carried no padding class at all, so for a guest, whose
   sibling actions are hidden, it collapsed to the height of its own text.
 - **The Explorer loses two sets of horizontal rules.** The timeline was wrapped in a line above and

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -2548,7 +2548,7 @@
                 class="group order-last rounded-lg border border-slate-300 dark:border-slate-700/70 {terminalTheme.shell}"
             >
                 <summary
-                    class="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-[7px] px-3 py-1.5 marker:hidden group-open:rounded-b-none group-open:border-b group-open:border-slate-800 {windowChrome ===
+                    class="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-[7px] px-3 py-1.5 marker:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-400 group-open:rounded-b-none group-open:border-b group-open:border-slate-800 {windowChrome ===
                     'windows'
                         ? 'bg-[#000080]'
                         : 'bg-slate-900/80'}"
@@ -2557,11 +2557,11 @@
                         <span class="h-2 w-2 rounded-full bg-rose-500/70" aria-hidden="true"></span>
                         <span class="h-2 w-2 rounded-full bg-amber-500/70" aria-hidden="true"></span>
                         <span class="h-2 w-2 rounded-full bg-emerald-500/70" aria-hidden="true"></span>
-                        <span class="ml-1.5 font-mono text-[10px] text-slate-400">{$_('detection.id')}</span>
+                        <span class="ml-1.5 font-mono text-xs text-slate-400">{$_('detection.id')}</span>
                     {:else if windowChrome === 'windows'}
                         <!-- Deliberate Windows 95 pastiche, so the raised bevel and the period
                              greys are literal values rather than palette tokens. -->
-                        <span class="font-mono text-[10px] font-bold text-white">{$_('detection.id')}</span>
+                        <span class="font-mono text-xs font-bold text-white">{$_('detection.id')}</span>
                         <span class="ml-auto flex items-center gap-0.5" aria-hidden="true">
                             {#each ['minimise', 'maximise', 'close'] as control (control)}
                                 <span
@@ -2578,16 +2578,16 @@
                             {/each}
                         </span>
                     {:else}
-                        <span class="font-mono text-[10px] text-slate-400">{$_('detection.id')}</span>
+                        <span class="font-mono text-xs text-slate-400">{$_('detection.id')}</span>
                         <span class="ml-auto grid h-4 w-4 place-items-center rounded-full bg-slate-700/70 text-slate-300" aria-hidden="true">
                             <svg class="h-2 w-2" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1.4"><path d="m2 2 6 6M8 2l-6 6" /></svg>
                         </span>
                     {/if}
-                    <svg class="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180 {windowChrome === 'mac' ? 'ml-auto text-slate-500' : windowChrome === 'windows' ? 'ml-2.5 text-white/70' : 'ml-2.5 text-slate-500'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                    <svg class="h-3.5 w-3.5 shrink-0 motion-safe:transition-transform group-open:rotate-180 {windowChrome === 'mac' ? 'ml-auto text-slate-500' : windowChrome === 'windows' ? 'ml-2.5 text-white/70' : 'ml-2.5 text-slate-500'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
                     </svg>
                 </summary>
-                <div class="px-3 py-2.5 font-mono text-[11px] leading-relaxed">
+                <div class="px-3 py-2.5 font-mono text-xs leading-relaxed">
                     <p class={terminalTheme.prompt}>
                         {#if terminalTheme.host}<span class="font-bold text-[#8ae234]" aria-hidden="true">{terminalTheme.host}</span>{/if}<span
                             aria-hidden="true">{terminalTheme.sigil}</span>

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -688,16 +688,52 @@
     );
 
     /**
-     * A terminal borrows the viewer's own window furniture: traffic lights on macOS, and the
-     * minimise/maximise/close set on Windows. Purely cosmetic, so an unknown platform gets the
-     * macOS set rather than nothing.
+     * A terminal borrows the viewer's own window furniture: traffic lights on macOS, the
+     * bevelled Windows 95 set on Windows, and a single round close button in the GNOME manner
+     * on Linux. Purely cosmetic, so an unknown platform gets the macOS set rather than nothing.
      */
-    const windowChrome = $derived.by((): 'mac' | 'windows' => {
+    const windowChrome = $derived.by((): 'mac' | 'windows' | 'linux' => {
         if (typeof navigator === 'undefined') return 'mac';
         const agent = navigator as Navigator & { userAgentData?: { platform?: string } };
         const platform = (agent.userAgentData?.platform ?? navigator.platform ?? navigator.userAgent ?? '')
             .toLowerCase();
-        return platform.includes('win') ? 'windows' : 'mac';
+        if (platform.includes('win')) return 'windows';
+        // Android reports Linux in its user agent, and is not a desktop window manager.
+        if (platform.includes('linux') && !platform.includes('android')) return 'linux';
+        return 'mac';
+    });
+
+    /**
+     * The window's insides follow its furniture: a plain dark shell on macOS, the black and grey
+     * of a DOS box on Windows, and the aubergine GNOME Terminal ships with on Linux.
+     */
+    const terminalTheme = $derived.by(() => {
+        if (windowChrome === 'windows') {
+            return {
+                shell: 'bg-black',
+                prompt: 'text-[#c0c0c0]',
+                host: null,
+                sigil: 'C:\\>',
+                output: 'text-[#c0c0c0]'
+            };
+        }
+        if (windowChrome === 'linux') {
+            // Ubuntu: the aubergine terminal and its bash prompt, green user@host then blue path.
+            return {
+                shell: 'bg-[#300a24]',
+                prompt: 'text-[#d3d7cf]',
+                host: 'yawamf@feeder',
+                sigil: ':~$',
+                output: 'text-[#eeeeec]'
+            };
+        }
+        return {
+            shell: 'bg-slate-950',
+            prompt: 'text-slate-500',
+            host: null,
+            sigil: '$',
+            output: 'text-emerald-300'
+        };
     });
 
     /**
@@ -2509,32 +2545,55 @@
                  Dark in both themes on purpose, because that is what a terminal is. -->
             <details
                 data-detection-technical-identity
-                class="group order-last rounded-lg border border-slate-300 bg-slate-950 dark:border-slate-700/70"
+                class="group order-last rounded-lg border border-slate-300 dark:border-slate-700/70 {terminalTheme.shell}"
             >
-                <summary class="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-[7px] bg-slate-900/80 px-3 py-1.5 marker:hidden group-open:rounded-b-none group-open:border-b group-open:border-slate-800">
+                <summary
+                    class="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-[7px] px-3 py-1.5 marker:hidden group-open:rounded-b-none group-open:border-b group-open:border-slate-800 {windowChrome ===
+                    'windows'
+                        ? 'bg-[#000080]'
+                        : 'bg-slate-900/80'}"
+                >
                     {#if windowChrome === 'mac'}
                         <span class="h-2 w-2 rounded-full bg-rose-500/70" aria-hidden="true"></span>
                         <span class="h-2 w-2 rounded-full bg-amber-500/70" aria-hidden="true"></span>
                         <span class="h-2 w-2 rounded-full bg-emerald-500/70" aria-hidden="true"></span>
                         <span class="ml-1.5 font-mono text-[10px] text-slate-400">{$_('detection.id')}</span>
+                    {:else if windowChrome === 'windows'}
+                        <!-- Deliberate Windows 95 pastiche, so the raised bevel and the period
+                             greys are literal values rather than palette tokens. -->
+                        <span class="font-mono text-[10px] font-bold text-white">{$_('detection.id')}</span>
+                        <span class="ml-auto flex items-center gap-0.5" aria-hidden="true">
+                            {#each ['minimise', 'maximise', 'close'] as control (control)}
+                                <span
+                                    class="grid h-3.5 w-4 place-items-center border border-l-white border-t-white border-r-[#404040] border-b-[#404040] bg-[#c0c0c0] text-black"
+                                >
+                                    {#if control === 'minimise'}
+                                        <svg class="h-2 w-2" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1.4"><path d="M2 8h6" /></svg>
+                                    {:else if control === 'maximise'}
+                                        <svg class="h-2 w-2" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.2"><rect x="1.6" y="1.6" width="6.8" height="6.8" /><path d="M1.6 3.2h6.8" /></svg>
+                                    {:else}
+                                        <svg class="h-2 w-2" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1.4"><path d="m2 2 6 6M8 2l-6 6" /></svg>
+                                    {/if}
+                                </span>
+                            {/each}
+                        </span>
                     {:else}
                         <span class="font-mono text-[10px] text-slate-400">{$_('detection.id')}</span>
-                        <span class="ml-auto flex items-center gap-2.5 text-slate-500" aria-hidden="true">
-                            <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1"><path d="M1 5h8" /></svg>
-                            <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1"><rect x="1.5" y="1.5" width="7" height="7" /></svg>
-                            <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1"><path d="m1.5 1.5 7 7M8.5 1.5l-7 7" /></svg>
+                        <span class="ml-auto grid h-4 w-4 place-items-center rounded-full bg-slate-700/70 text-slate-300" aria-hidden="true">
+                            <svg class="h-2 w-2" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1.4"><path d="m2 2 6 6M8 2l-6 6" /></svg>
                         </span>
                     {/if}
-                    <svg class="h-3.5 w-3.5 shrink-0 text-slate-500 transition-transform group-open:rotate-180 {windowChrome === 'mac' ? 'ml-auto' : 'ml-2.5'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                    <svg class="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180 {windowChrome === 'mac' ? 'ml-auto text-slate-500' : windowChrome === 'windows' ? 'ml-2.5 text-white/70' : 'ml-2.5 text-slate-500'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
                     </svg>
                 </summary>
                 <div class="px-3 py-2.5 font-mono text-[11px] leading-relaxed">
-                    <p class="text-slate-500">
-                        <span class="text-emerald-400" aria-hidden="true">$</span>
+                    <p class={terminalTheme.prompt}>
+                        {#if terminalTheme.host}<span class="font-bold text-[#8ae234]" aria-hidden="true">{terminalTheme.host}</span>{/if}<span
+                            aria-hidden="true">{terminalTheme.sigil}</span>
                         yawamf event show
                     </p>
-                    <p class="mt-1 break-all text-emerald-300">
+                    <p class="mt-1 break-all {terminalTheme.output}">
                         {detection.frigate_event}<span class="terminal-caret" aria-hidden="true">&#9608;</span>
                     </p>
                 </div>

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -688,6 +688,19 @@
     );
 
     /**
+     * A terminal borrows the viewer's own window furniture: traffic lights on macOS, and the
+     * minimise/maximise/close set on Windows. Purely cosmetic, so an unknown platform gets the
+     * macOS set rather than nothing.
+     */
+    const windowChrome = $derived.by((): 'mac' | 'windows' => {
+        if (typeof navigator === 'undefined') return 'mac';
+        const agent = navigator as Navigator & { userAgentData?: { platform?: string } };
+        const platform = (agent.userAgentData?.platform ?? navigator.platform ?? navigator.userAgent ?? '')
+            .toLowerCase();
+        return platform.includes('win') ? 'windows' : 'mac';
+    });
+
+    /**
      * Fades the strip's trailing edge only while it actually overflows, so a strip that fits is not
      * clipped for decoration. Thumbnails load lazily, so image loads are watched as well as resizes.
      */
@@ -697,13 +710,18 @@
             node.style.setProperty('--strip-fade', hasMoreToRight ? '2rem' : '0px');
         };
         update();
-        const observer = new ResizeObserver(update);
-        observer.observe(node);
+        const resize = new ResizeObserver(update);
+        resize.observe(node);
+        // The container keeps its size when the candidate list changes, so a resize alone would
+        // leave the fade describing a strip that is no longer there.
+        const mutation = new MutationObserver(update);
+        mutation.observe(node, { childList: true });
         node.addEventListener('load', update, true);
         node.addEventListener('scroll', update, { passive: true });
         return {
             destroy() {
-                observer.disconnect();
+                resize.disconnect();
+                mutation.disconnect();
                 node.removeEventListener('load', update, true);
                 node.removeEventListener('scroll', update);
             }
@@ -1636,6 +1654,22 @@
 </script>
 
 <style>
+    /* Svelte scopes @keyframes, so a name referenced from a class resolves to nothing without
+       the -global- prefix. */
+    @keyframes -global-terminal-blink {
+        0%, 49% { opacity: 1; }
+        50%, 100% { opacity: 0; }
+    }
+
+    .terminal-caret {
+        margin-left: 0.15em;
+        animation: terminal-blink 1.1s steps(1) infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .terminal-caret { animation: none; opacity: 1; }
+    }
+
     /*
      * The options strip sits over a dark gradient on the image, where a native scrollbar is both
      * ugly and low contrast. The bar is hidden and the right edge fades instead, so there is still
@@ -2471,14 +2505,39 @@
 
             <div class="flex flex-1 flex-col gap-5 overflow-y-auto p-5 sm:p-6 {showTagDropdown ? 'blur-sm pointer-events-none select-none' : ''}">
             <!-- Detection ID -->
-            <details data-detection-technical-identity class="group order-last border-t border-slate-200 pt-3 dark:border-slate-700">
-                <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 text-xs font-semibold text-slate-500 marker:hidden dark:text-slate-400">
-                    <span>{$_('detection.id')}</span>
-                    <svg class="h-4 w-4 transition-transform group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <!-- The disclosure is the window chrome: clicking the title bar opens the terminal.
+                 Dark in both themes on purpose, because that is what a terminal is. -->
+            <details
+                data-detection-technical-identity
+                class="group order-last rounded-lg border border-slate-300 bg-slate-950 dark:border-slate-700/70"
+            >
+                <summary class="flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-[7px] bg-slate-900/80 px-3 py-1.5 marker:hidden group-open:rounded-b-none group-open:border-b group-open:border-slate-800">
+                    {#if windowChrome === 'mac'}
+                        <span class="h-2 w-2 rounded-full bg-rose-500/70" aria-hidden="true"></span>
+                        <span class="h-2 w-2 rounded-full bg-amber-500/70" aria-hidden="true"></span>
+                        <span class="h-2 w-2 rounded-full bg-emerald-500/70" aria-hidden="true"></span>
+                        <span class="ml-1.5 font-mono text-[10px] text-slate-400">{$_('detection.id')}</span>
+                    {:else}
+                        <span class="font-mono text-[10px] text-slate-400">{$_('detection.id')}</span>
+                        <span class="ml-auto flex items-center gap-2.5 text-slate-500" aria-hidden="true">
+                            <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1"><path d="M1 5h8" /></svg>
+                            <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1"><rect x="1.5" y="1.5" width="7" height="7" /></svg>
+                            <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" stroke="currentColor" stroke-width="1"><path d="m1.5 1.5 7 7M8.5 1.5l-7 7" /></svg>
+                        </span>
+                    {/if}
+                    <svg class="h-3.5 w-3.5 shrink-0 text-slate-500 transition-transform group-open:rotate-180 {windowChrome === 'mac' ? 'ml-auto' : 'ml-2.5'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
                     </svg>
                 </summary>
-                <p class="break-all font-mono text-xs text-slate-700 dark:text-slate-300">{detection.frigate_event}</p>
+                <div class="px-3 py-2.5 font-mono text-[11px] leading-relaxed">
+                    <p class="text-slate-500">
+                        <span class="text-emerald-400" aria-hidden="true">$</span>
+                        yawamf event show
+                    </p>
+                    <p class="mt-1 break-all text-emerald-300">
+                        {detection.frigate_event}<span class="terminal-caret" aria-hidden="true">&#9608;</span>
+                    </p>
+                </div>
                 <!-- The "Frigate event missing" indicator that used to live here as a
                      standalone pill has been folded into the consolidated snapshot/
                      video-status notice below.  The same information is now shown

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -29,7 +29,7 @@ describe('detection surface polish', () => {
     it('keeps implementation identity collapsed until it is requested', () => {
         expect(detectionModalSource).toContain('data-detection-technical-identity');
         expect(detectionModalSource).toContain('<details');
-        expect(detectionModalSource).toContain('group order-last border-t');
+        expect(detectionModalSource).toContain('group order-last');
         expect(detectionModalSource).toContain('{detection.frigate_event}');
     });
 
@@ -104,6 +104,34 @@ describe('detection surface polish', () => {
         // background made a card within a card.
         expect(detectionModalSource).not.toContain("bg-white/75 dark:bg-slate-900/40'");
         expect(detectionModalSource).toContain('border-t pt-2 {videoStatusNoticeTone.detailsContainer}');
+    });
+
+    it('makes the detection id disclosure the terminal chrome itself', () => {
+        // The summary is the title bar: clicking the window opens it.
+        expect(detectionModalSource).toContain('@keyframes -global-terminal-blink');
+        expect(detectionModalSource).toContain('yawamf event show');
+        expect(detectionModalSource).toContain('terminal-caret');
+        expect(detectionModalSource).toContain('prefers-reduced-motion');
+        // overflow-hidden on a <details> collapses it to its own borders in Chrome, so the
+        // corners are rounded on the summary rather than clipped by the parent.
+        expect(detectionModalSource).not.toMatch(
+            /data-detection-technical-identity[\s\S]{0,240}?overflow-hidden/
+        );
+        expect(detectionModalSource).toContain('group-open:rounded-b-none');
+    });
+
+    it('borrows the window furniture of the viewer os', () => {
+        expect(detectionModalSource).toContain("): 'mac' | 'windows'");
+        expect(detectionModalSource).toContain("platform.includes('win') ? 'windows' : 'mac'");
+        // Cosmetic only, so an unrecognised platform still gets a complete window.
+        expect(detectionModalSource).toContain("if (typeof navigator === 'undefined') return 'mac'");
+    });
+
+    it('re-measures the options strip when the candidate list changes', () => {
+        // The container keeps its size when children change, so a resize observer alone would
+        // leave the fade describing a strip that is no longer there.
+        expect(detectionModalSource).toContain('new MutationObserver(update)');
+        expect(detectionModalSource).toContain('{ childList: true }');
     });
 
     it('gives the species info button real padding', () => {

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -118,6 +118,9 @@ describe('detection surface polish', () => {
             /data-detection-technical-identity[\s\S]{0,240}?overflow-hidden/
         );
         expect(detectionModalSource).toContain('group-open:rounded-b-none');
+        expect(detectionModalSource).toContain('focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-400');
+        expect(detectionModalSource).toContain('font-mono text-xs');
+        expect(detectionModalSource).toContain('motion-safe:transition-transform group-open:rotate-180');
     });
 
     it('borrows the window furniture of the viewer os', () => {

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -121,10 +121,16 @@ describe('detection surface polish', () => {
     });
 
     it('borrows the window furniture of the viewer os', () => {
-        expect(detectionModalSource).toContain("): 'mac' | 'windows'");
-        expect(detectionModalSource).toContain("platform.includes('win') ? 'windows' : 'mac'");
+        expect(detectionModalSource).toContain("): 'mac' | 'windows' | 'linux'");
+        expect(detectionModalSource).toContain("if (platform.includes('win')) return 'windows'");
+        // Android reports Linux in its user agent and is not a desktop window manager.
+        expect(detectionModalSource).toContain("!platform.includes('android')");
         // Cosmetic only, so an unrecognised platform still gets a complete window.
         expect(detectionModalSource).toContain("if (typeof navigator === 'undefined') return 'mac'");
+        // The insides follow the furniture: DOS black, Ubuntu aubergine, plain dark elsewhere.
+        expect(detectionModalSource).toContain("shell: 'bg-[#300a24]'");
+        expect(detectionModalSource).toContain("host: 'yawamf@feeder'");
+        expect(detectionModalSource).toContain("bg-[#000080]");
     });
 
     it('re-measures the options strip when the candidate list changes', () => {


### PR DESCRIPTION
## Outcome

The collapsed detection ID opens as a small terminal whose chrome follows macOS, Windows, or Linux. The terminal remains a little bit of fun without changing detection behaviour or exposing additional data.

## Included

- Platform-aware window chrome and matching terminal palette
- A measured snapshot-strip overflow update when candidate children change
- A 44px disclosure target with a visible keyboard focus ring
- Readable 12px terminal labels and output
- Reduced-motion-safe caret and disclosure movement
- Layout regression coverage for the terminal, platform variants, and mutation observer cleanup

## Excluded

- No API, database, detection, or authentication changes
- No new user-facing configuration

## Verification

- Frontend: 763 tests passed
- Svelte check: 0 errors and 0 warnings
- Production frontend build passed
- Backend: 1,892 passed, 45 hardware-dependent tests skipped
- Repo-wide Ruff lint and format checks passed

## Risk

Low. The platform treatment is cosmetic and falls back to the macOS presentation when platform information is unavailable. The event ID remains collapsed and unchanged.
