### PR TITLE
Polish the detection frame overflow cue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   view switch keeps its recovery path for tightly cropped detections, while a dedicated action lane
   gives both controls full-size touch targets without overlap.
 - **The options strip no longer shows a native scrollbar** across the image gradient. The bar is
-  hidden and the trailing edge fades, but only while the strip actually overflows, so a strip that
-  fits is not clipped for decoration.
+  hidden and a generous trailing-edge fade makes additional frames clear, but only while the strip
+  actually overflows, so a strip that fits is not clipped for decoration.
 - **The video notice stops nesting a card inside a card.** The notice is already tinted and
   bordered; its technical details added another border and background inside that, and the evidence
   list drew its own rules inside that again. One hairline separates them now.

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -743,7 +743,7 @@
     function watchOverflow(node: HTMLElement) {
         const update = () => {
             const hasMoreToRight = node.scrollLeft + node.clientWidth < node.scrollWidth - 1;
-            node.style.setProperty('--strip-fade', hasMoreToRight ? '2rem' : '0px');
+            node.style.setProperty('--strip-fade', hasMoreToRight ? '3.5rem' : '0px');
         };
         update();
         const resize = new ResizeObserver(update);

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -82,6 +82,7 @@ describe('detection surface polish', () => {
         expect(detectionModalSource).toContain('scrollbar-width: none');
         expect(detectionModalSource).toContain('node.scrollLeft + node.clientWidth < node.scrollWidth - 1');
         expect(detectionModalSource).toContain("node.addEventListener('scroll', update, { passive: true })");
+        expect(detectionModalSource).toContain("hasMoreToRight ? '3.5rem' : '0px'");
         expect(detectionModalSource).toContain("'--strip-fade'");
     });
 


### PR DESCRIPTION
## Outcome

The detection details snapshot strip now uses a wider trailing fade when more real frames are available, making the horizontal continuation clearer on phones without clipping a strip that already fits.

## Included

- Increase the measured overflow fade from `2rem` to `3.5rem`.
- Preserve owner-only access and real snapshot candidate data.
- Add a regression assertion for the intended fade width.
- Update the Unreleased changelog entry.

## Excluded

- No API, database, authentication, candidate-ranking, or snapshot-selection changes.
- No temporary or synthetic candidate frames are included.

## Verification

- `npm run check`: 0 errors, 0 warnings
- `npm test`: 763 passed
- `npm run build`: passed
- `.venv/bin/ruff check .`: passed
- `.venv/bin/ruff format --check .`: 405 files already formatted
- `backend/.venv/bin/pytest`: 1,899 passed, 44 skipped
- `git diff --check`: passed

## Risk

Low. This changes only the visual mask width used after the strip has measured real horizontal overflow. The existing owner gate, resize and mutation observers, scroll handling, touch targets, and candidate selection behavior are unchanged.