### PR TITLE
Polish snapshot strip interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Desktop snapshot choices remain selectable at the edge of the filmstrip.** The overflow fade
+  is now a separate pointer-transparent layer instead of a mask on the interactive scroller. The
+  selected frame uses a subtle lift, scale and shadow rather than a persistent blue outline.
 - **Detection media controls no longer cover the bird name or snapshot choices on phones.** The
   title, favourite, playback and full-visit actions, and snapshot rail now form one ordered footer
   that wraps upward as a unit. Full-visit readiness is part of the play action instead of looking

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -706,13 +706,15 @@
     });
 
     /**
-     * Fades the strip's trailing edge only while it actually overflows, so a strip that fits is not
-     * clipped for decoration. Thumbnails load lazily, so image loads are watched as well as resizes.
+     * Shows the strip's trailing hint only while it actually overflows. The hint is a separate,
+     * pointer-transparent layer so desktop browsers never hit-test through a CSS mask.
+     * Thumbnails load lazily, so image loads are watched as well as resizes.
      */
     function watchOverflow(node: HTMLElement) {
+        const shell = node.closest<HTMLElement>('[data-snapshot-strip-shell]');
         const update = () => {
             const hasMoreToRight = node.scrollLeft + node.clientWidth < node.scrollWidth - 1;
-            node.style.setProperty('--strip-fade', hasMoreToRight ? '3.5rem' : '0px');
+            shell?.style.setProperty('--strip-fade-opacity', hasMoreToRight ? '1' : '0');
         };
         update();
         const resize = new ResizeObserver(update);
@@ -727,6 +729,7 @@
             destroy() {
                 resize.disconnect();
                 mutation.disconnect();
+                shell?.style.removeProperty('--strip-fade-opacity');
                 node.removeEventListener('load', update, true);
                 node.removeEventListener('scroll', update);
             }
@@ -1628,20 +1631,21 @@
 
     /*
      * The options strip sits over a dark gradient on the image, where a native scrollbar is both
-     * ugly and low contrast. The bar is hidden and the right edge fades instead, so there is still
-     * a signal that more frames exist. Scrolling by wheel, trackpad and keyboard is unaffected.
+     * ugly and low contrast. The bar is hidden and a pointer-transparent sibling darkens the right
+     * edge instead, so there is still a signal that more frames exist without blocking selection.
+     * Scrolling by wheel, trackpad and keyboard is unaffected.
      */
     .snapshot-strip {
         scrollbar-width: none;
         -ms-overflow-style: none;
-        /* Zero width until the action measures a real overflow, so a strip that fits is not
-           clipped for decoration. */
-        -webkit-mask-image: linear-gradient(to right, #000 calc(100% - var(--strip-fade, 0px)), transparent 100%);
-        mask-image: linear-gradient(to right, #000 calc(100% - var(--strip-fade, 0px)), transparent 100%);
     }
 
     .snapshot-strip::-webkit-scrollbar {
         display: none;
+    }
+
+    .snapshot-strip-fade {
+        opacity: var(--strip-fade-opacity, 0);
     }
 
     .ai-surface {
@@ -2419,41 +2423,48 @@
                             {/if}
                         </div>
                         <div class="flex min-w-0 items-center gap-1.5">
-                            <div class="snapshot-strip flex min-w-0 flex-1 gap-1.5 overflow-x-auto" use:watchOverflow>
-                                {#if originalFrigateSnapshotAvailable}
-                                    {@const originalIsSelected = pendingSnapshotMode === 'revert_original' || (!pendingSnapshotMode && currentSnapshotSource === 'frigate_snapshot')}
-                                    <button
-                                        type="button"
-                                        class="min-h-11 min-w-11 shrink-0 rounded-md p-1 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 {originalIsSelected ? 'ring-2 ring-brand-400' : 'opacity-70 hover:opacity-100'}"
-                                        title={$_('detection.snapshot_source_original', { default: 'Original Frigate crop' })}
-                                        aria-label={$_('detection.snapshot_preview_original_aria', { default: 'Preview original Frigate snapshot' })}
-                                        aria-pressed={originalIsSelected}
-                                        onclick={(event) => { event.stopPropagation(); stageOriginalFrigateSnapshot(); }}
-                                    >
-                                        <img src={originalFrigateSnapshotUrl} alt="" loading="lazy" class="h-9 w-12 rounded-md object-cover" />
-                                    </button>
-                                {/if}
-                                {#each snapshotOptionStrip as candidate (candidate.candidate_id)}
-                                    {@const candidateIsSelected = pendingSnapshotCandidateId === candidate.candidate_id || (!pendingSnapshotMode && currentSnapshotCandidateId === candidate.candidate_id)}
-                                    <button
-                                        type="button"
-                                        class="min-h-11 min-w-11 shrink-0 rounded-md p-1 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 {candidateIsSelected ? 'ring-2 ring-brand-400' : 'opacity-70 hover:opacity-100'}"
-                                        title={candidate.classifier_label ?? snapshotSourceLabel(candidate.source_mode)}
-                                        aria-label={$_('detection.snapshot_option_aria', {
-                                            values: { source: snapshotSourceLabel(candidate.source_mode) },
-                                            default: 'Preview {source} snapshot option'
-                                        })}
-                                        aria-pressed={candidateIsSelected}
-                                        onclick={(event) => { event.stopPropagation(); previewSnapshotCandidate(candidate); }}
-                                    >
-                                        <img
-                                            src={candidate.thumbnail_url ?? undefined}
-                                            alt=""
-                                            loading="lazy"
-                                            class="h-9 w-12 rounded-md object-cover"
-                                        />
-                                    </button>
-                                {/each}
+                            <div class="snapshot-strip-shell relative min-w-0 flex-1" data-snapshot-strip-shell>
+                                <div class="snapshot-strip -my-2 flex min-w-0 gap-1.5 overflow-x-auto px-1 py-3" use:watchOverflow>
+                                    {#if originalFrigateSnapshotAvailable}
+                                        {@const originalIsSelected = pendingSnapshotMode === 'revert_original' || (!pendingSnapshotMode && currentSnapshotSource === 'frigate_snapshot')}
+                                        <button
+                                            type="button"
+                                            class="relative min-h-11 min-w-11 shrink-0 rounded-md p-1 transition duration-200 ease-out motion-reduce:transform-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 {originalIsSelected ? 'z-10 -translate-y-1 scale-105 bg-white/15 opacity-100 shadow-lg shadow-black/50' : 'opacity-70 hover:z-10 hover:-translate-y-0.5 hover:scale-105 hover:opacity-100 hover:shadow-md active:translate-y-0 active:scale-95'}"
+                                            title={$_('detection.snapshot_source_original', { default: 'Original Frigate crop' })}
+                                            aria-label={$_('detection.snapshot_preview_original_aria', { default: 'Preview original Frigate snapshot' })}
+                                            aria-pressed={originalIsSelected}
+                                            onclick={(event) => { event.stopPropagation(); stageOriginalFrigateSnapshot(); }}
+                                        >
+                                            <img src={originalFrigateSnapshotUrl} alt="" loading="lazy" class="h-9 w-12 rounded-md object-cover" />
+                                        </button>
+                                    {/if}
+                                    {#each snapshotOptionStrip as candidate (candidate.candidate_id)}
+                                        {@const candidateIsSelected = pendingSnapshotCandidateId === candidate.candidate_id || (!pendingSnapshotMode && currentSnapshotCandidateId === candidate.candidate_id)}
+                                        <button
+                                            type="button"
+                                            class="relative min-h-11 min-w-11 shrink-0 rounded-md p-1 transition duration-200 ease-out motion-reduce:transform-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 {candidateIsSelected ? 'z-10 -translate-y-1 scale-105 bg-white/15 opacity-100 shadow-lg shadow-black/50' : 'opacity-70 hover:z-10 hover:-translate-y-0.5 hover:scale-105 hover:opacity-100 hover:shadow-md active:translate-y-0 active:scale-95'}"
+                                            title={candidate.classifier_label ?? snapshotSourceLabel(candidate.source_mode)}
+                                            aria-label={$_('detection.snapshot_option_aria', {
+                                                values: { source: snapshotSourceLabel(candidate.source_mode) },
+                                                default: 'Preview {source} snapshot option'
+                                            })}
+                                            aria-pressed={candidateIsSelected}
+                                            onclick={(event) => { event.stopPropagation(); previewSnapshotCandidate(candidate); }}
+                                        >
+                                            <img
+                                                src={candidate.thumbnail_url ?? undefined}
+                                                alt=""
+                                                loading="lazy"
+                                                class="h-9 w-12 rounded-md object-cover"
+                                            />
+                                        </button>
+                                    {/each}
+                                </div>
+                                <div
+                                    class="snapshot-strip-fade pointer-events-none absolute inset-y-2 right-0 w-14 bg-gradient-to-r from-transparent to-slate-950/80 transition-opacity duration-150 motion-reduce:transition-none"
+                                    data-snapshot-strip-fade
+                                    aria-hidden="true"
+                                ></div>
                             </div>
                             {#if pendingSnapshotMode}
                                 <button

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -98,15 +98,26 @@ describe('detection surface polish', () => {
         expect(detectionModalSource).not.toContain("canShowFullFrame ? 'top-16 left-3' : 'top-4 left-4'");
     });
 
-    it('hides the options strip scrollbar and fades only a real overflow', () => {
-        // A native bar over the image gradient is ugly and low contrast; masking unconditionally
-        // would clip the last thumbnail on a strip that fits.
+    it('keeps overflowing snapshot choices clickable beneath a non-interactive fade', () => {
+        // Masking the interactive scroller makes hit testing unreliable at the transparent edge
+        // in desktop browsers. The visual hint belongs in a pointer-transparent sibling layer.
         expect(detectionModalSource).toContain('.snapshot-strip');
         expect(detectionModalSource).toContain('scrollbar-width: none');
         expect(detectionModalSource).toContain('node.scrollLeft + node.clientWidth < node.scrollWidth - 1');
         expect(detectionModalSource).toContain("node.addEventListener('scroll', update, { passive: true })");
-        expect(detectionModalSource).toContain("hasMoreToRight ? '3.5rem' : '0px'");
-        expect(detectionModalSource).toContain("'--strip-fade'");
+        expect(detectionModalSource).toContain("style.setProperty('--strip-fade-opacity', hasMoreToRight ? '1' : '0')");
+        expect(detectionModalSource).toContain('data-snapshot-strip-fade');
+        expect(detectionModalSource).toContain('pointer-events-none');
+        expect(detectionModalSource).not.toContain('mask-image:');
+    });
+
+    it('lifts the selected snapshot like a dock item without using an active outline', () => {
+        expect(detectionModalSource).toContain("'z-10 -translate-y-1 scale-105 bg-white/15 opacity-100 shadow-lg shadow-black/50'");
+        expect(detectionModalSource).toContain('motion-reduce:transform-none');
+        expect(detectionModalSource).toContain('aria-pressed={candidateIsSelected}');
+        expect(detectionModalSource).toContain('aria-pressed={originalIsSelected}');
+        expect(detectionModalSource).not.toContain("originalIsSelected ? 'ring-2 ring-brand-400'");
+        expect(detectionModalSource).not.toContain("candidateIsSelected ? 'ring-2 ring-brand-400'");
     });
 
     it('labels the name rather than the reference photograph beside it', () => {


### PR DESCRIPTION
## Outcome

Snapshot choices at the desktop filmstrip edge remain clickable, and the selected frame now uses a subtle dock-style lift and shadow instead of a persistent outline.

## Root cause

The overflow cue was implemented as a CSS mask on the interactive scrolling element. Masked hit testing is inconsistent at transparent pixels in desktop browsers, so frames entering that edge could become difficult or impossible to select.

## Changes

- move the overflow cue to a separate pointer-transparent fade layer
- keep the fade conditional on actual remaining overflow
- lift and shadow the selected snapshot without changing layout bounds
- preserve `aria-pressed`, keyboard focus, reduced-motion behaviour, and 44px targets
- add structural regression coverage and an Unreleased changelog entry

## Scope

This changes only the detection modal snapshot filmstrip. It does not change snapshot generation, persistence, classification, APIs, or database state.

## Verification

- `npm run check` (0 errors, 0 warnings)
- `npm test` (144 files, 771 tests)
- `npm run build`
- `backend/.venv/bin/pytest` from `backend/` (1,899 passed, 44 skipped)
- `backend/.venv/bin/ruff check .`
- `backend/.venv/bin/ruff format --check .`
- `git diff --check`