### PR TITLE
Stabilise live jobs and notification progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Live work now stays put while it progresses.** Full-visit and best-frame jobs retain one
+  timestamp from queue admission through execution, queued video work keeps that timestamp when a
+  worker starts, and the browser reconciles polling with fresher live progress without moving a row
+  or running a bar backwards. Work lanes, including taxonomy enrichment, use a fixed operational
+  order; the job manager, combined notification timeline and global progress bar use short,
+  reduced-motion-safe transform animations instead of long layout-driven width transitions.
+
 - **Desktop snapshot choices remain selectable at the edge of the filmstrip.** The overflow fade
   is now a separate pointer-transparent layer instead of a mask on the interactive scroller. The
   selected frame uses a subtle lift, scale and shadow rather than a persistent blue outline.

--- a/apps/ui/src/lib/components/GlobalProgress.svelte
+++ b/apps/ui/src/lib/components/GlobalProgress.svelte
@@ -152,8 +152,8 @@
                 >
                     {#if aggregate.determinate && aggregate.percent !== null}
                         <div
-                            class="h-full bg-gradient-to-r from-accent-500 via-brand-500 to-sky-500 transition-all duration-500"
-                            style="width: {aggregate.percent}%"
+                            class="h-full w-full origin-left bg-gradient-to-r from-accent-500 via-brand-500 to-sky-500 transition-transform duration-200 ease-out motion-reduce:transition-none"
+                            style="transform: scaleX({aggregate.percent / 100})"
                         ></div>
                     {:else}
                         <div class="h-full w-2/5 bg-gradient-to-r from-accent-500/70 via-brand-500/70 to-sky-500/70 motion-safe:animate-pulse"></div>

--- a/apps/ui/src/lib/jobs/pipeline.test.ts
+++ b/apps/ui/src/lib/jobs/pipeline.test.ts
@@ -193,5 +193,23 @@ describe('buildJobsPipelineModel', () => {
         });
     });
 
+    it('keeps work and enrichment lanes in a fixed order as live counts change', () => {
+        const first = buildJobsPipelineModel([
+            runningJob('taxonomy:1', 'taxonomy_sync'),
+            runningJob('video:1', 'auto_video')
+        ], [], {
+            reclassify: { queued: 10, running: 0, queueDepthKnown: true, updatedAt: 1 }
+        });
+        const second = buildJobsPipelineModel([
+            runningJob('taxonomy:1', 'taxonomy_sync'),
+            runningJob('video:1', 'auto_video')
+        ], [], {
+            reclassify: { queued: 1, running: 20, queueDepthKnown: true, updatedAt: 2 }
+        });
+
+        expect(first.kinds.map((row) => row.kind)).toEqual(['reclassify', 'auto_video', 'taxonomy_sync']);
+        expect(second.kinds.map((row) => row.kind)).toEqual(first.kinds.map((row) => row.kind));
+    });
+
 
 });

--- a/apps/ui/src/lib/jobs/pipeline.ts
+++ b/apps/ui/src/lib/jobs/pipeline.ts
@@ -74,13 +74,19 @@ function normalizeKind(value: unknown): string {
     return trimmed.length > 0 ? trimmed : 'job';
 }
 
-function rankKind(row: JobPipelineKindRow): number {
-    // Prioritize active/running work, then known queued pressure, then terminal backlog.
-    return (row.running * 1000)
-        + ((row.queued ?? 0) * 100)
-        + (row.failed * 10)
-        + row.completed;
-}
+const KIND_DISPLAY_ORDER = [
+    'reclassify_batch',
+    'reclassify',
+    'auto_video',
+    'video_analysis',
+    'high_quality_snapshot',
+    'full_visit',
+    'backfill',
+    'weather_backfill',
+    'taxonomy_sync'
+] as const;
+
+const KIND_DISPLAY_RANK = new Map<string, number>(KIND_DISPLAY_ORDER.map((kind, index) => [kind, index]));
 
 export function buildJobsPipelineModel(
     activeJobs: JobProgressItem[],
@@ -191,7 +197,10 @@ export function buildJobsPipelineModel(
     }
 
     kinds.sort((a, b) => {
-        const diff = rankKind(b) - rankKind(a);
+        // Counts change on every live update. A fixed operational order keeps lanes
+        // (including taxonomy/enrichment work) in one place while those counts change.
+        const diff = (KIND_DISPLAY_RANK.get(a.kind) ?? KIND_DISPLAY_ORDER.length)
+            - (KIND_DISPLAY_RANK.get(b.kind) ?? KIND_DISPLAY_ORDER.length);
         if (diff !== 0) return diff;
         return a.kind.localeCompare(b.kind);
     });

--- a/apps/ui/src/lib/pages/Jobs.layout.test.ts
+++ b/apps/ui/src/lib/pages/Jobs.layout.test.ts
@@ -17,7 +17,7 @@ describe('jobs page active work semantics', () => {
     it('renders actual active jobs instead of fake thread slots', () => {
         expect(jobsPageSource).toContain("from '../stores/backfill_status.svelte'");
         expect(jobsPageSource).toContain('let presentedActiveJobs = $derived.by(() =>');
-        expect(jobsPageSource).toContain('{#each presentedActiveJobs as job (job.id)}');
+        expect(jobsPageSource).toContain('{#each presentedActiveJobs as job (stableJobIdentity(job))}');
         expect(jobsPageSource).toContain("jobs.coordinator_job', { default: 'Coordinator Job' }");
         expect(jobsPageSource).toContain("jobs.active_job', { default: 'Active Job' }");
         expect(jobsPageSource).not.toContain("from '../jobs/active-slots'");
@@ -43,7 +43,7 @@ describe('jobs page active work semantics', () => {
         expect(jobsPageSource).toContain("import Pagination from '../components/Pagination.svelte'");
         expect(jobsPageSource).toContain('paginateItems(recentJobs, requestedRecentPage, recentPageSize)');
         expect(jobsPageSource).toContain('data-jobs-history-pagination');
-        expect(jobsPageSource).toContain('{#each presentedActiveJobs as job (job.id)}');
+        expect(jobsPageSource).toContain('{#each presentedActiveJobs as job (stableJobIdentity(job))}');
     });
 
     it('explains that backfill cards represent coordinator work', () => {

--- a/apps/ui/src/lib/pages/Jobs.svelte
+++ b/apps/ui/src/lib/pages/Jobs.svelte
@@ -10,7 +10,7 @@
     import { pageRefreshAction } from '../stores/page_refresh_action.svelte';
     import { resetVideoCircuit } from '../api/maintenance';
     import { toAppPath } from '../app/url-base';
-    import { serverJobsStore } from '../stores/server_jobs.svelte';
+    import { serverJobsStore, stableJobIdentity } from '../stores/server_jobs.svelte';
     import Pagination from '../components/Pagination.svelte';
     import { paginateItems } from '../utils/pagination';
     let { onNavigate, embedded = false } = $props<{ onNavigate?: (path: string) => void; embedded?: boolean }>();
@@ -285,7 +285,7 @@
             <p class="text-xs text-slate-500">{$_('jobs.active_empty', { default: 'No active jobs.' })}</p>
         {:else}
             <div class="divide-y divide-slate-200/80 dark:divide-slate-800/80">
-                {#each presentedActiveJobs as job (job.id)}
+                {#each presentedActiveJobs as job (stableJobIdentity(job))}
                     {@const presentation = presentActiveJob(job, pipelineByKind.get(job.kind) ?? null, analysisStatus, nowTs, t)}
                     {@const jobKindIcon = presentJobKindIcon(job.kind)}
                     <div class="py-4 first:pt-0 last:pb-0">
@@ -351,9 +351,9 @@
                                 aria-valuenow={presentation.determinate && presentation.percent !== null ? presentation.percent : undefined}
                             >
                                 {#if presentation.determinate && presentation.percent !== null}
-                                    <div class="h-full bg-gradient-to-r from-accent-500 via-brand-500 to-sky-500 transition-all duration-500" style={`width: ${presentation.percent}%`}></div>
+                                    <div class="h-full w-full origin-left bg-gradient-to-r from-accent-500 via-brand-500 to-sky-500 transition-transform duration-200 ease-out motion-reduce:transition-none" style={`transform: scaleX(${presentation.percent / 100})`}></div>
                                 {:else}
-                                    <div class="h-full w-2/5 bg-gradient-to-r from-accent-500/70 via-brand-500/70 to-sky-500/70 animate-pulse"></div>
+                                    <div class="h-full w-2/5 bg-gradient-to-r from-accent-500/70 via-brand-500/70 to-sky-500/70 motion-safe:animate-pulse"></div>
                                 {/if}
                             </div>
                             {#if isBackfillKind(job.kind)}

--- a/apps/ui/src/lib/pages/Notifications.svelte
+++ b/apps/ui/src/lib/pages/Notifications.svelte
@@ -307,7 +307,7 @@
                                     {#if progress}
                                         <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
                                             <!-- Brand, not the amber gradient this used to run: a job in flight needs nobody. -->
-                                            <div class="h-full rounded-full bg-brand-500 transition-[width] duration-500" style={`width: ${progress.percent}%`}></div>
+                                            <div class="h-full w-full origin-left rounded-full bg-brand-500 transition-transform duration-200 ease-out motion-reduce:transition-none" style={`transform: scaleX(${progress.percent / 100})`}></div>
                                         </div>
                                         <p class="mt-1 flex justify-between font-mono text-[10px] text-slate-400 dark:text-slate-500">
                                             <span>{progress.current.toLocaleString()} / {progress.total.toLocaleString()}</span>

--- a/apps/ui/src/lib/stores/server_jobs.svelte.ts
+++ b/apps/ui/src/lib/stores/server_jobs.svelte.ts
@@ -16,10 +16,20 @@ function titleForJob(job: ServerJob): string {
     return job.event_id ?? job.kind.replace(/_/g, ' ');
 }
 
-function toProgressItem(job: ServerJob, capturedAt: number): JobProgressItem {
-    const startedAt = parseTimestamp(job.created_at, capturedAt);
-    const updatedAt = parseTimestamp(job.updated_at, startedAt);
+function toProgressItem(
+    job: ServerJob,
+    capturedAt: number,
+    previous?: JobProgressItem
+): JobProgressItem {
+    const reportedStartedAt = parseTimestamp(job.created_at, capturedAt);
+    const startedAt = previous ? Math.min(previous.startedAt, reportedStartedAt) : reportedStartedAt;
+    const reportedUpdatedAt = parseTimestamp(job.updated_at, startedAt);
+    const updatedAt = previous ? Math.max(previous.updatedAt, reportedUpdatedAt) : reportedUpdatedAt;
     const terminal = job.status === 'completed' || job.status === 'failed';
+    const reportedCurrent = Math.max(0, Math.floor(job.current ?? 0));
+    const reportedTotal = Math.max(0, Math.floor(job.total ?? 0));
+    const current = previous ? Math.max(previous.current, reportedCurrent) : reportedCurrent;
+    const total = previous ? Math.max(previous.total, reportedTotal, current) : Math.max(reportedTotal, current);
     return {
         id: job.id,
         kind: job.kind,
@@ -35,8 +45,8 @@ function toProgressItem(job: ServerJob, capturedAt: number): JobProgressItem {
                     : job.status === 'queued' || job.status === 'retrying'
                         ? 'queued'
                         : 'running',
-        current: Math.max(0, Math.floor(job.current ?? 0)),
-        total: Math.max(0, Math.floor(job.total ?? 0)),
+        current,
+        total,
         startedAt,
         updatedAt,
         finishedAt: terminal ? parseTimestamp(job.finished_at, updatedAt) : undefined,
@@ -55,6 +65,12 @@ function correlationEventId(job: JobProgressItem): string | null {
     return null;
 }
 
+/** Stable across the browser's reclassify id and the server's video id for one event. */
+export function stableJobIdentity(job: JobProgressItem): string {
+    const eventId = correlationEventId(job);
+    return eventId ? `event:${eventId}` : `job:${job.id}`;
+}
+
 export class ServerJobsStore {
     snapshot = $state<JobsSnapshot | null>(null);
     loading = $state(false);
@@ -62,23 +78,42 @@ export class ServerJobsStore {
     private retainCount = 0;
     private timer: ReturnType<typeof setTimeout> | null = null;
     private request: Promise<void> | null = null;
+    private materializedSnapshot: JobsSnapshot | null = null;
+    private materializedActive: JobProgressItem[] = [];
+    private materializedHistory: JobProgressItem[] = [];
+    private previousById = new Map<string, JobProgressItem>();
+
+    private materializeSnapshot(): void {
+        const snapshot = this.snapshot;
+        if (snapshot === this.materializedSnapshot) return;
+        this.materializedSnapshot = snapshot;
+        if (!snapshot) {
+            this.materializedActive = [];
+            this.materializedHistory = [];
+            this.previousById.clear();
+            return;
+        }
+
+        const capturedAt = parseTimestamp(snapshot.captured_at, Date.now());
+        const nextById = new Map<string, JobProgressItem>();
+        for (const job of snapshot.items) {
+            const item = toProgressItem(job, capturedAt, this.previousById.get(job.id));
+            nextById.set(item.id, item);
+        }
+        this.previousById = nextById;
+        const items = [...nextById.values()];
+        this.materializedActive = items.filter((job) => job.status !== 'completed' && job.status !== 'failed');
+        this.materializedHistory = items.filter((job) => job.status === 'completed' || job.status === 'failed');
+    }
 
     get activeJobs(): JobProgressItem[] {
-        const snapshot = this.snapshot;
-        if (!snapshot) return [];
-        const capturedAt = parseTimestamp(snapshot.captured_at, Date.now());
-        return snapshot.items
-            .filter((job) => !['completed', 'failed'].includes(job.status))
-            .map((job) => toProgressItem(job, capturedAt));
+        this.materializeSnapshot();
+        return this.materializedActive;
     }
 
     get historyJobs(): JobProgressItem[] {
-        const snapshot = this.snapshot;
-        if (!snapshot) return [];
-        const capturedAt = parseTimestamp(snapshot.captured_at, Date.now());
-        return snapshot.items
-            .filter((job) => ['completed', 'failed'].includes(job.status))
-            .map((job) => toProgressItem(job, capturedAt));
+        this.materializeSnapshot();
+        return this.materializedHistory;
     }
 
     get queueByKind(): QueueTelemetryByKind {
@@ -99,12 +134,33 @@ export class ServerJobsStore {
 
     mergeActive(localJobs: JobProgressItem[], prominentOnly = false): JobProgressItem[] {
         const serverJobs = this.activeJobs.filter((job) => !prominentOnly || job.visibility === 'prominent');
-        const serverEventIds = new Set(serverJobs.map(correlationEventId).filter((id): id is string => Boolean(id)));
+        const localByEventId = new Map(
+            localJobs
+                .map((job) => [correlationEventId(job), job] as const)
+                .filter((entry): entry is [string, JobProgressItem] => Boolean(entry[0]))
+        );
+        const reconciledServerJobs = serverJobs.map((serverJob) => {
+            const eventId = correlationEventId(serverJob);
+            const localJob = eventId ? localByEventId.get(eventId) : undefined;
+            if (!localJob) return serverJob;
+            const current = Math.max(serverJob.current, localJob.current);
+            const total = Math.max(serverJob.total, localJob.total, current);
+            return {
+                ...serverJob,
+                current,
+                total,
+                startedAt: Math.min(serverJob.startedAt, localJob.startedAt),
+                updatedAt: Math.max(serverJob.updatedAt, localJob.updatedAt),
+                ratePerMinute: localJob.ratePerMinute ?? serverJob.ratePerMinute,
+                etaSeconds: localJob.etaSeconds ?? serverJob.etaSeconds
+            };
+        });
+        const serverEventIds = new Set(reconciledServerJobs.map(correlationEventId).filter((id): id is string => Boolean(id)));
         const local = localJobs.filter((job) => {
             const eventId = correlationEventId(job);
             return !eventId || !serverEventIds.has(eventId);
         });
-        return [...serverJobs, ...local];
+        return [...reconciledServerJobs, ...local];
     }
 
     mergeHistory(localJobs: JobProgressItem[]): JobProgressItem[] {

--- a/apps/ui/src/lib/stores/server_jobs.test.ts
+++ b/apps/ui/src/lib/stores/server_jobs.test.ts
@@ -40,7 +40,7 @@ describe('ServerJobsStore', () => {
         });
     });
 
-    it('prefers server truth over a browser-local job for the same event', () => {
+    it('keeps server identity without rolling back fresher browser progress', () => {
         const store = new ServerJobsStore();
         store.snapshot = {
             captured_at: '2026-07-22T12:00:00Z',
@@ -73,5 +73,34 @@ describe('ServerJobsStore', () => {
 
         expect(merged).toHaveLength(1);
         expect(merged[0].id).toBe('video:evt-2');
+        expect(merged[0]).toMatchObject({ current: 2, total: 15, startedAt: 1 });
+        expect(merged[0].updatedAt).toBeGreaterThanOrEqual(2);
+    });
+
+    it('keeps a missing server timestamp and progress monotonic across polls', () => {
+        const store = new ServerJobsStore();
+        store.snapshot = {
+            captured_at: '2026-07-22T12:00:00Z',
+            items: [{
+                id: 'full_visit:evt-3', event_id: 'evt-3', kind: 'full_visit', source: 'automatic',
+                status: 'running', phase: 'fetching_media', current: 4, total: 10, unit: 'items'
+            }],
+            lanes: []
+        };
+        const first = store.activeJobs[0];
+
+        store.snapshot = {
+            captured_at: '2026-07-22T12:00:05Z',
+            items: [{
+                id: 'full_visit:evt-3', event_id: 'evt-3', kind: 'full_visit', source: 'automatic',
+                status: 'running', phase: 'fetching_media', current: 2, total: 10, unit: 'items'
+            }],
+            lanes: []
+        };
+        const second = store.activeJobs[0];
+
+        expect(second.startedAt).toBe(first.startedAt);
+        expect(second.current).toBe(4);
+        expect(second.updatedAt).toBeGreaterThanOrEqual(first.updatedAt);
     });
 });

--- a/apps/ui/src/lib/utils/notification-timeline.test.ts
+++ b/apps/ui/src/lib/utils/notification-timeline.test.ts
@@ -130,6 +130,19 @@ describe('notification timeline', () => {
         expect(timeline[0].id).toBe('video:event-12');
     });
 
+    it('does not move an active process row when only its progress heartbeat changes', () => {
+        const detection = item({ id: 'bird-1', timestamp: NOW - 500 });
+        const first = buildTimelineItems([], [job({ id: 'job-1', startedAt: NOW - 1000, updatedAt: NOW })]);
+        const second = buildTimelineItems(
+            [detection],
+            [job({ id: 'job-1', current: 2, startedAt: NOW - 1000, updatedAt: NOW + 5000 })]
+        );
+
+        expect(first[0].timestamp).toBe(NOW - 1000);
+        expect(second.map((row) => row.id)).toEqual(['bird-1', 'job-1']);
+        expect(second[1].timestamp).toBe(NOW - 1000);
+    });
+
     it('counts every bucket so a chip can state its size before it is applied', () => {
         const counts = countByFilter([
             item({ id: '1', type: 'detection' }),

--- a/apps/ui/src/lib/utils/notification-timeline.ts
+++ b/apps/ui/src/lib/utils/notification-timeline.ts
@@ -51,7 +51,9 @@ function jobIdentity(job: JobProgressItem): string {
 }
 
 function jobTimestamp(job: JobProgressItem): number {
-    return Math.max(job.finishedAt ?? 0, job.updatedAt ?? 0, job.startedAt ?? 0);
+    // updatedAt is a progress heartbeat, not a new timeline event. Keeping the
+    // admission timestamp prevents active rows changing position on every tick.
+    return job.startedAt || job.finishedAt || job.updatedAt;
 }
 
 function jobAsNotification(job: JobProgressItem): NotificationItem {
@@ -107,7 +109,7 @@ export function buildTimelineItems(
             ...jobItem,
             ...notification,
             id: notification.id,
-            timestamp: Math.max(notification.timestamp, jobItem.timestamp),
+            timestamp: jobItem.timestamp,
             meta: {
                 ...notification.meta,
                 ...jobItem.meta,

--- a/backend/app/services/auto_video_classifier_service.py
+++ b/backend/app/services/auto_video_classifier_service.py
@@ -460,11 +460,17 @@ class AutoVideoClassifierService:
                         name=f"video_classifier:{frigate_event}",
                     )
                     self._active_tasks[frigate_event] = task
+                    pending_metadata = self._pending_metadata.get(frigate_event, {})
+                    started_at_epoch = time.time()
                     self._active_metadata[frigate_event] = {
                         "source": source,
                         "started_at": time.monotonic(),
-                        "started_at_epoch": time.time(),
-                        "updated_at_epoch": time.time(),
+                        # Keep the queue admission time as the job's identity timestamp.
+                        # Replacing it with the worker start time made rows jump whenever
+                        # queued work became active.
+                        "queued_at_epoch": pending_metadata.get("queued_at_epoch", started_at_epoch),
+                        "started_at_epoch": started_at_epoch,
+                        "updated_at_epoch": started_at_epoch,
                         "phase": "preparing",
                         "current": 0,
                         "total": int(settings.classification.video_classification_frames or 0),
@@ -878,7 +884,7 @@ class AutoVideoClassifierService:
             )
         for event_id, metadata in self._active_metadata.items():
             source = "manual" if metadata.get("manual_requested") else str(metadata.get("source") or "maintenance")
-            started_at = metadata.get("started_at_epoch")
+            started_at = metadata.get("queued_at_epoch") or metadata.get("started_at_epoch")
             updated_at = metadata.get("updated_at_epoch")
             kind = "reclassify" if source == "manual" else "auto_video" if source == "live" else "video_analysis"
             started_iso = (

--- a/backend/app/services/full_visit_clip_service.py
+++ b/backend/app/services/full_visit_clip_service.py
@@ -42,6 +42,7 @@ class FullVisitClipService:
         self._queue: asyncio.Queue[tuple[str, str | None, str, str]] = asyncio.Queue(maxsize=FULL_VISIT_QUEUE_MAX)
         self._queued_ids: set[str] = set()
         self._active_ids: set[str] = set()
+        self._job_timestamps: dict[str, tuple[float, float]] = {}
         self._workers: list[asyncio.Task] = []
         self._queue_full_rejections = 0
         # Queue workers, reconciliation and direct calls all share this ceiling.
@@ -136,6 +137,8 @@ class FullVisitClipService:
             )
             return False
         self._queued_ids.add(event_id)
+        now = time.time()
+        self._job_timestamps.setdefault(event_id, (now, now))
         return True
 
     async def start(self) -> None:
@@ -173,6 +176,7 @@ class FullVisitClipService:
                 break
         self._queued_ids.clear()
         self._active_ids.clear()
+        self._job_timestamps.clear()
         self._partial_upgrade_attempts.clear()
 
     async def _worker_loop(self, worker_index: int) -> None:
@@ -185,6 +189,8 @@ class FullVisitClipService:
                 break
             self._queued_ids.discard(event_id)
             self._active_ids.add(event_id)
+            created_at, _updated_at = self._job_timestamps.get(event_id, (time.time(), time.time()))
+            self._job_timestamps[event_id] = (created_at, time.time())
             try:
                 await self.trigger_for_event(event_id, camera, source=source, lang=lang)
             except asyncio.CancelledError:
@@ -198,6 +204,7 @@ class FullVisitClipService:
                 )
             finally:
                 self._active_ids.discard(event_id)
+                self._job_timestamps.pop(event_id, None)
                 self._queue.task_done()
 
     def get_status(self) -> dict[str, object]:
@@ -226,8 +233,9 @@ class FullVisitClipService:
             jobs.append(self._job_snapshot(event_id, "queued", "waiting"))
         return jobs
 
-    @staticmethod
-    def _job_snapshot(event_id: str, status: str, phase: str) -> dict[str, object]:
+    def _job_snapshot(self, event_id: str, status: str, phase: str) -> dict[str, object]:
+        now = time.time()
+        created_at, updated_at = self._job_timestamps.setdefault(event_id, (now, now))
         return {
             "id": f"full_visit:{event_id}",
             "event_id": event_id,
@@ -239,8 +247,8 @@ class FullVisitClipService:
             "total": 0,
             "unit": "items",
             "route": f"/events?detection={event_id}",
-            "created_at": None,
-            "updated_at": None,
+            "created_at": datetime.fromtimestamp(created_at, tz=timezone.utc).isoformat(),
+            "updated_at": datetime.fromtimestamp(updated_at, tz=timezone.utc).isoformat(),
             "error": None,
         }
 

--- a/backend/app/services/high_quality_snapshot_service.py
+++ b/backend/app/services/high_quality_snapshot_service.py
@@ -9,6 +9,7 @@ import os
 import sys
 import tempfile
 import hashlib
+import time
 from io import BytesIO
 from collections import Counter, deque
 from datetime import datetime, timedelta, timezone
@@ -101,6 +102,7 @@ class HighQualitySnapshotService:
         self._queued_ids: set[str] = set()
         self._deferred_ids: set[str] = set()
         self._deferred_order: deque[str] = deque()
+        self._job_timestamps: dict[str, tuple[float, float]] = {}
         self._completed_ids: set[str] = set()
         self._final_refresh_ids: set[str] = set()
         self._crop_event_hints: dict[str, dict[str, Any]] = {}
@@ -329,6 +331,7 @@ class HighQualitySnapshotService:
             return self._record_outcome(event_id, "duplicate")
 
         self._active_ids.add(event_id)
+        self._mark_job_active(event_id)
         try:
             crop_event_data = (
                 event_data if isinstance(event_data, dict) else await self._load_event_data_for_crop(event_id)
@@ -404,6 +407,7 @@ class HighQualitySnapshotService:
         finally:
             self._active_ids.discard(event_id)
             self._promote_deferred_events()
+            self._forget_finished_job(event_id)
 
     async def _load_preferred_frame_indices(
         self,
@@ -1384,6 +1388,7 @@ class HighQualitySnapshotService:
         self._queued_ids.clear()
         self._deferred_ids.clear()
         self._deferred_order.clear()
+        self._job_timestamps.clear()
         self._completed_ids.clear()
         self._final_refresh_ids.clear()
         self._crop_event_hints.clear()
@@ -1430,6 +1435,7 @@ class HighQualitySnapshotService:
                 continue
             self._final_refresh_ids.discard(event_id)
             self._active_ids.add(event_id)
+            self._mark_job_active(event_id)
             try:
                 await self.process_event(event_id)
             except asyncio.CancelledError:
@@ -1448,6 +1454,7 @@ class HighQualitySnapshotService:
                 self._active_ids.discard(event_id)
                 queue.task_done()
                 self._promote_deferred_events()
+                self._forget_finished_job(event_id)
 
     def _ensure_workers_started(self) -> None:
         self._cleanup_completed_workers()
@@ -1510,8 +1517,7 @@ class HighQualitySnapshotService:
                     "total": 0,
                     "unit": "items",
                     "route": f"/events?detection={event_id}",
-                    "created_at": None,
-                    "updated_at": None,
+                    **self._job_timestamp_fields(event_id),
                     "error": None,
                 }
             )
@@ -1528,8 +1534,7 @@ class HighQualitySnapshotService:
                     "total": 0,
                     "unit": "items",
                     "route": f"/events?detection={event_id}",
-                    "created_at": None,
-                    "updated_at": None,
+                    **self._job_timestamp_fields(event_id),
                     "error": None,
                 }
             )
@@ -1541,6 +1546,7 @@ class HighQualitySnapshotService:
         except asyncio.QueueFull:
             return False
         self._queued_ids.add(event_id)
+        self._mark_job_queued(event_id)
         return True
 
     def _defer_event(self, event_id: str) -> bool:
@@ -1556,8 +1562,30 @@ class HighQualitySnapshotService:
             return False
         self._deferred_ids.add(event_id)
         self._deferred_order.append(event_id)
+        self._mark_job_queued(event_id)
         self._queue_full_deferrals += 1
         return True
+
+    def _mark_job_queued(self, event_id: str) -> None:
+        now = time.time()
+        self._job_timestamps.setdefault(event_id, (now, now))
+
+    def _mark_job_active(self, event_id: str) -> None:
+        now = time.time()
+        created_at, _updated_at = self._job_timestamps.get(event_id, (now, now))
+        self._job_timestamps[event_id] = (created_at, now)
+
+    def _forget_finished_job(self, event_id: str) -> None:
+        if event_id not in self._active_ids and event_id not in self._queued_ids and event_id not in self._deferred_ids:
+            self._job_timestamps.pop(event_id, None)
+
+    def _job_timestamp_fields(self, event_id: str) -> dict[str, str]:
+        now = time.time()
+        created_at, updated_at = self._job_timestamps.setdefault(event_id, (now, now))
+        return {
+            "created_at": datetime.fromtimestamp(created_at, tz=timezone.utc).isoformat(),
+            "updated_at": datetime.fromtimestamp(updated_at, tz=timezone.utc).isoformat(),
+        }
 
     def _promote_deferred_events(self) -> None:
         while self._deferred_order:

--- a/backend/tests/test_auto_video_classifier_queueing.py
+++ b/backend/tests/test_auto_video_classifier_queueing.py
@@ -204,6 +204,24 @@ def test_active_manual_job_snapshot_reports_real_frame_progress():
     assert job["updated_at"] is not None
 
 
+def test_active_job_snapshot_preserves_original_queue_timestamp():
+    service = AutoVideoClassifierService()
+    service._active_metadata["evt-stable-order"] = {
+        "source": "maintenance",
+        "queued_at_epoch": 1_700_000_000.0,
+        "started_at_epoch": 1_700_000_010.0,
+        "updated_at_epoch": 1_700_000_020.0,
+        "phase": "analyzing",
+        "current": 1,
+        "total": 15,
+    }
+
+    job = service.get_jobs_snapshot()[0]
+
+    assert job["created_at"] == "2023-11-14T22:13:20+00:00"
+    assert job["updated_at"] == "2023-11-14T22:13:40+00:00"
+
+
 @pytest.mark.asyncio
 async def test_queue_classification_respects_bounded_capacity(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(auto_video_classifier_module, "MAX_PENDING_QUEUE", 2)

--- a/backend/tests/test_full_visit_clip_service.py
+++ b/backend/tests/test_full_visit_clip_service.py
@@ -9,6 +9,18 @@ import pytest
 from app.services.full_visit_clip_service import FullVisitClipService
 
 
+def test_job_snapshot_keeps_timestamp_stable_between_polls():
+    service = FullVisitClipService()
+    service._queued_ids.add("evt-stable")
+
+    first = service.get_jobs_snapshot()[0]
+    second = service.get_jobs_snapshot()[0]
+
+    assert first["created_at"] is not None
+    assert first["created_at"] == second["created_at"]
+    assert first["updated_at"] == second["updated_at"]
+
+
 def test_background_trigger_is_bounded_and_deduplicated(monkeypatch):
     monkeypatch.setattr("app.services.full_visit_clip_service.FULL_VISIT_QUEUE_MAX", 1)
     service = FullVisitClipService()

--- a/backend/tests/test_high_quality_snapshot_service.py
+++ b/backend/tests/test_high_quality_snapshot_service.py
@@ -15,6 +15,18 @@ from app.services import high_quality_snapshot_service as hq_module
 from app.services import media_cache as media_cache_module
 
 
+def test_job_snapshot_keeps_timestamp_stable_between_polls():
+    service = hq_module.HighQualitySnapshotService()
+    service._queued_ids.add("evt-stable")
+
+    first = service.get_jobs_snapshot()[0]
+    second = service.get_jobs_snapshot()[0]
+
+    assert first["created_at"] is not None
+    assert first["created_at"] == second["created_at"]
+    assert first["updated_at"] == second["updated_at"]
+
+
 def _jpeg_bytes(color: str, size: tuple[int, int] = (32, 32), *, quality: int = 92) -> bytes:
     buffer = BytesIO()
     Image.new("RGB", size, color=color).save(buffer, format="JPEG", quality=quality)


### PR DESCRIPTION
## What changed

- preserve queue admission timestamps through video, full-visit, and best-frame job lifecycles
- reconcile server polling with fresher browser progress without backwards movement or identity churn
- keep active jobs, work lanes, and combined timeline rows in stable positions
- use short transform-based progress animations with reduced-motion support
- add regressions across backend services, store reconciliation, lane ordering, timeline ordering, and layout semantics

## Root cause

Full-visit and best-frame snapshots omitted creation timestamps, so every five-second poll made them look newly started. Queued video jobs also replaced their queue time when a worker started, while server snapshots could overwrite newer SSE progress. Dynamic lane ranking and update-time timeline sorting amplified the visible movement.

## Validation

- UI: 774 tests passed
- Backend: 1,902 tests passed; 44 expected skips
- Svelte check: 0 errors
- Ruff check and format: clean
- git diff --check: clean