### PR TITLE
Hide stale analysis warnings after manual identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Manual identifications no longer show stale automatic-analysis warnings.** The earlier video
+  evidence remains stored for diagnostics, but once an owner identifies the species the detection
+  view stops presenting an inconclusive model run as if it still describes the current result.
+
 - **Live work now stays put while it progresses.** Full-visit and best-frame jobs retain one
   timestamp from queue admission through execution, queued video work keeps that timestamp when a
   worker starts, and the browser reconciles polling with fresher live progress without moving a row

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -50,7 +50,11 @@
     import { trapFocus } from '../utils/focus-trap';
     import { FRIGATE_LOGO_URL } from '../assets';
     import { getErrorMessage } from '../utils/error-handling';
-    import { getClassificationInputKind, getDetectionClassificationSource } from '../detection-classification-source';
+    import {
+        getClassificationInputKind,
+        getDetectionClassificationSource,
+        shouldShowVideoStatusNotice
+    } from '../detection-classification-source';
     import { formatDateTime } from '../utils/datetime';
     import { formatTemperature } from '../utils/temperature';
     import { getManualTagSearchOptions } from '../search/manual-tag-search';
@@ -871,15 +875,7 @@
     // snapshot" amber notice, "Video Analysis Failed" red card) that used to
     // co-exist for the same underlying state.
     const videoStatusNoticeVisible = $derived.by(() => {
-        const status = (detection.video_classification_status || '').trim().toLowerCase();
-        const error = (detection.video_classification_error || '').trim();
-        // Failed video classification of any kind.
-        if (status === 'failed' && error) return true;
-        // Snapshot fallback already produced a result, but the underlying
-        // Frigate event is gone — surface that so the modal isn't silent
-        // about why the player and the diagnostics disagree.
-        if (currentClassificationSource === 'snapshot' && missingEventNoticeVisible) return true;
-        return false;
+        return shouldShowVideoStatusNotice(detection, missingEventNoticeVisible);
     });
     const videoStatusNoticeTone = $derived.by(() => {
         const status = (detection.video_classification_status || '').trim().toLowerCase();

--- a/apps/ui/src/lib/detection-classification-source.test.ts
+++ b/apps/ui/src/lib/detection-classification-source.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getClassificationInputKind, getDetectionClassificationSource } from './detection-classification-source';
+import {
+    getClassificationInputKind,
+    getDetectionClassificationSource,
+    shouldShowVideoStatusNotice
+} from './detection-classification-source';
 import type { Detection } from './api';
 
 function buildDetection(overrides: Partial<Detection> = {}): Detection {
@@ -75,5 +79,31 @@ describe('getDetectionClassificationSource', () => {
         });
 
         expect(getDetectionClassificationSource(detection)).toBe('snapshot');
+    });
+});
+
+describe('shouldShowVideoStatusNotice', () => {
+    it('hides an earlier inconclusive video result after a manual identification', () => {
+        const detection = buildDetection({
+            manual_tagged: true,
+            category_name: 'Prunella modularis',
+            video_classification_status: 'failed',
+            video_classification_error: 'video_no_results'
+        });
+
+        expect(shouldShowVideoStatusNotice(detection, false)).toBe(false);
+    });
+
+    it('still shows an inconclusive video result when it remains relevant to the current identification', () => {
+        const detection = buildDetection({
+            video_classification_status: 'failed',
+            video_classification_error: 'video_no_results'
+        });
+
+        expect(shouldShowVideoStatusNotice(detection, false)).toBe(true);
+    });
+
+    it('still explains missing upstream media for a snapshot identification', () => {
+        expect(shouldShowVideoStatusNotice(buildDetection(), true)).toBe(true);
     });
 });

--- a/apps/ui/src/lib/detection-classification-source.ts
+++ b/apps/ui/src/lib/detection-classification-source.ts
@@ -57,6 +57,20 @@ export function getDetectionClassificationSource(detection: Detection): Detectio
     return 'snapshot';
 }
 
+export function shouldShowVideoStatusNotice(
+    detection: Detection,
+    missingEventNoticeVisible: boolean
+): boolean {
+    const classificationSource = getDetectionClassificationSource(detection);
+    if (classificationSource === 'manual') return false;
+
+    const status = String(detection.video_classification_status ?? '').trim().toLowerCase();
+    const error = String(detection.video_classification_error ?? '').trim();
+    if (status === 'failed' && error) return true;
+
+    return classificationSource === 'snapshot' && missingEventNoticeVisible;
+}
+
 export function getClassificationInputKind(value: unknown): ClassificationInputKind {
     const source = typeof value === 'string' ? value.trim().toLowerCase() : '';
     if (VIDEO_CROP_SOURCES.has(source)) return 'video_crop';


### PR DESCRIPTION
## Outcome

Manual identifications now replace obsolete automatic-analysis warnings in the detection detail view.

## Included

- Hide the video-analysis status notice when the current classification source is manual.
- Keep the underlying diagnostic data intact for auditability.
- Cover the display rule with focused unit tests.
- Document the fix in the changelog.

## Excluded

- No classification thresholds or stored detection data are changed.

## Verification

- Frontend: 145 files, 777 tests passed.
- Backend: 1902 passed, 44 skipped.
- Frontend production build passed.
- Ruff check and format checks passed.
- Svelte check passed with zero errors; six existing ambient type warnings remain.

## Risk

Low. This is a presentation rule for manually classified detections and does not mutate persisted analysis results.