### PR TITLE
Show every species in Explorer filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **The Explorer species facet now includes every recorded species.** The desktop list uses the
+  remaining viewport height and scrolls only when the complete set is taller than that space;
+  smaller filter panels stay bounded and searchable ([#197](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/197)).
+
 - **Live work now stays put while it progresses.** Full-visit and best-frame jobs retain one
   timestamp from queue admission through execution, queued video work keeps that timestamp when a
   worker starts, and the browser reconciles polling with fresher live progress without moving a row

--- a/apps/ui/src/lib/components/ExplorerFilters.svelte
+++ b/apps/ui/src/lib/components/ExplorerFilters.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { EventFilterSpecies, EventFilters } from '../api';
     import { _ } from 'svelte-i18n';
+    import { filterExplorerSpecies } from '../utils/explorer-species';
 
     type DatePreset = 'all' | 'today' | 'week' | 'month' | 'custom';
 
@@ -118,29 +119,14 @@
         return applied;
     });
 
-    const visibleSpecies = $derived.by(() => {
-        const term = search.trim().toLowerCase();
-        const matched = term
-            ? species.filter((item) =>
-                  [item.display_name, item.common_name, item.scientific_name]
-                      .filter(Boolean)
-                      .some((name) => String(name).toLowerCase().includes(term))
-              )
-            : species;
-        // Counts are absent on older backends, where sorting by them would leave an
-        // arbitrary order, so fall back to alphabetical.
-        return [...matched]
-            .sort(
-                (left, right) =>
-                    (right.count ?? 0) - (left.count ?? 0) ||
-                    left.display_name.localeCompare(right.display_name)
-            )
-            .slice(0, 12);
-    });
+    const visibleSpecies = $derived(filterExplorerSpecies(species, search));
 </script>
 
-<section class="border-y border-slate-200 py-3 lg:border-0 lg:py-0" data-events-filter-bar>
-    <div class="flex flex-wrap items-center gap-2">
+<section
+    class="border-y border-slate-200 py-3 lg:flex lg:h-[calc(100dvh-2rem)] lg:max-h-[calc(100dvh-2rem)] lg:flex-col lg:border-0 lg:py-0"
+    data-events-filter-bar
+>
+    <div class="flex shrink-0 flex-wrap items-center gap-2">
         <p class="text-sm font-semibold text-slate-900 dark:text-white">
             {$_('events.filters.result_count', {
                 values: { count: resultCount.toLocaleString() },
@@ -177,9 +163,9 @@
     </div>
 
     <div
-        class="mt-3 gap-5 border-t border-slate-200 pt-3 lg:!block dark:border-slate-700 {panelOpen
+        class="mt-3 gap-5 border-t border-slate-200 pt-3 lg:!flex dark:border-slate-700 {panelOpen
             ? 'grid grid-cols-1 sm:grid-cols-3'
-            : 'hidden'} lg:mt-0 lg:space-y-5 lg:border-t-0 lg:pt-0"
+            : 'hidden'} lg:mt-0 lg:min-h-0 lg:flex-1 lg:flex-col lg:gap-5 lg:overflow-hidden lg:border-t-0 lg:pt-0"
         data-explorer-facets
     >
             <div>
@@ -279,7 +265,7 @@
                 </div>
             </div>
 
-            <div>
+            <div class="lg:flex lg:min-h-0 lg:flex-1 lg:flex-col" data-explorer-species-facet>
                 <p class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
                     {$_('events.filters.all_species')}
                 </p>
@@ -287,7 +273,10 @@
                     <span class="sr-only">{$_('events.filters.search_species', { default: 'Search species' })}</span>
                     <input class="input-base text-xs" type="search" bind:value={search} placeholder={$_('events.filters.search_species', { default: 'Search species' })} />
                 </label>
-                <div class="mt-2 max-h-56 space-y-0.5 overflow-y-auto">
+                <div
+                    class="mt-2 max-h-56 space-y-0.5 overflow-y-auto overscroll-contain lg:min-h-0 lg:max-h-none lg:flex-1"
+                    data-explorer-species-list
+                >
                     {#each visibleSpecies as item (item.value)}
                         <button
                             class="flex min-h-11 w-full items-center justify-between gap-3 rounded-lg px-2 text-left text-xs transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:hover:bg-slate-800/60 {speciesFilter ===

--- a/apps/ui/src/lib/pages/Events.layout.test.ts
+++ b/apps/ui/src/lib/pages/Events.layout.test.ts
@@ -24,6 +24,15 @@ describe('Explorer page layout', () => {
         expect(eventsSource).not.toContain('species={availableSpecies}');
     });
 
+    it('shows the complete species facet and lets it use the remaining desktop viewport', () => {
+        expect(filtersSource).toContain("filterExplorerSpecies(species, search)");
+        expect(filtersSource).not.toContain('.slice(0, 12)');
+        expect(filtersSource).toContain('data-explorer-species-facet');
+        expect(filtersSource).toContain('data-explorer-species-list');
+        expect(filtersSource).toContain('lg:max-h-[calc(100dvh-2rem)]');
+        expect(filtersSource).toContain('lg:min-h-0 lg:max-h-none lg:flex-1');
+    });
+
     it('separates the timeline and pagination with space, not rules', () => {
         expect(eventsSource).toContain('data-events-timeline');
         // Both used to be wrapped in a rule above and below. Against a grid of cards that

--- a/apps/ui/src/lib/utils/explorer-species.test.ts
+++ b/apps/ui/src/lib/utils/explorer-species.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { EventFilterSpecies } from '../api';
+import { filterExplorerSpecies } from './explorer-species';
+
+function species(index: number, count: number): EventFilterSpecies {
+    return {
+        value: `species-${index}`,
+        display_name: `Species ${String(index).padStart(2, '0')}`,
+        scientific_name: `Scientific ${index}`,
+        count
+    };
+}
+
+describe('filterExplorerSpecies', () => {
+    it('returns every recorded species instead of truncating the unfiltered facet', () => {
+        const recordedSpecies = Array.from({ length: 18 }, (_, index) => species(index + 1, 18 - index));
+
+        expect(filterExplorerSpecies(recordedSpecies, '')).toHaveLength(18);
+    });
+
+    it('searches common and scientific names before sorting matches by frequency', () => {
+        const recordedSpecies: EventFilterSpecies[] = [
+            { value: 'dunnock', display_name: 'Dunnock', scientific_name: 'Prunella modularis', count: 4 },
+            { value: 'house-sparrow', display_name: 'House Sparrow', scientific_name: 'Passer domesticus', count: 9 },
+            { value: 'tree-sparrow', display_name: 'Eurasian Tree Sparrow', scientific_name: 'Passer montanus', count: 2 }
+        ];
+
+        expect(filterExplorerSpecies(recordedSpecies, 'passer').map((item) => item.value)).toEqual([
+            'house-sparrow',
+            'tree-sparrow'
+        ]);
+    });
+});

--- a/apps/ui/src/lib/utils/explorer-species.ts
+++ b/apps/ui/src/lib/utils/explorer-species.ts
@@ -1,0 +1,21 @@
+import type { EventFilterSpecies } from '../api';
+
+export function filterExplorerSpecies(
+    species: EventFilterSpecies[],
+    search: string
+): EventFilterSpecies[] {
+    const term = search.trim().toLowerCase();
+    const matched = term
+        ? species.filter((item) =>
+              [item.display_name, item.common_name, item.scientific_name]
+                  .filter(Boolean)
+                  .some((name) => String(name).toLowerCase().includes(term))
+          )
+        : species;
+
+    return [...matched].sort(
+        (left, right) =>
+            (right.count ?? 0) - (left.count ?? 0) ||
+            left.display_name.localeCompare(right.display_name)
+    );
+}


### PR DESCRIPTION
## Outcome

Explorer now makes every detected species available in the All Species facet while using the available viewport cleanly on desktop and remaining bounded on smaller screens. Fixes #197.

## Included

- Remove the hidden 12-species truncation.
- Preserve count-first, name-stable ordering.
- Search common, display, and scientific names.
- Let the desktop facet use the remaining viewport height with its own scroll area.
- Keep a compact bounded facet on tablet and mobile.
- Add utility and structural layout tests.
- Document the fix in the changelog.

## Excluded

- No detection records, taxonomy data, or Explorer query semantics are changed.

## Verification

- Frontend: 145 files, 777 tests passed.
- Backend: 1902 passed, 44 skipped.
- Frontend production build passed.
- Ruff check and format checks passed.
- Svelte check passed with zero errors; six existing ambient type warnings remain.
- Browser-tested with 28 species at desktop, tablet, phone, and landscape sizes; the final species remained selectable and search/clear restored the complete list.

## Risk

Low. The change removes an artificial UI cap and confines scrolling to the facet without changing backend data.