### PR TITLE
Keep finished jobs newest first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Finished jobs now remain newest-first before and after a browser refresh.** Active work keeps
+  its queue-admission position while progress arrives, but a completion or failure is placed once
+  at its terminal time instead of temporarily inheriting the older job-start time.
 - **Manual identifications no longer show stale automatic-analysis warnings.** The earlier video
   evidence remains stored for diagnostics, but once an owner identifies the species the detection
   view stops presenting an inconclusive model run as if it still describes the current result.

--- a/apps/ui/src/lib/utils/notification-timeline.test.ts
+++ b/apps/ui/src/lib/utils/notification-timeline.test.ts
@@ -143,6 +143,32 @@ describe('notification timeline', () => {
         expect(second[1].timestamp).toBe(NOW - 1000);
     });
 
+    it('keeps a completed job newest-first before and after transient live state is cleared', () => {
+        const detection = item({ id: 'bird-1', timestamp: NOW });
+        const completion = item({
+            id: 'job-1',
+            type: 'update',
+            timestamp: NOW + 5000,
+            meta: { current: 8, total: 8 }
+        });
+        const completedJob = job({
+            id: 'job-1',
+            status: 'completed',
+            current: 8,
+            total: 8,
+            startedAt: NOW - 60_000,
+            updatedAt: NOW + 5000,
+            finishedAt: NOW + 5000
+        });
+
+        const whileLive = buildTimelineItems([detection, completion], [completedJob]);
+        const afterRefresh = buildTimelineItems([detection, completion], []);
+
+        expect(whileLive.map((row) => row.id)).toEqual(['job-1', 'bird-1']);
+        expect(whileLive[0].timestamp).toBe(NOW + 5000);
+        expect(afterRefresh.map((row) => row.id)).toEqual(['job-1', 'bird-1']);
+    });
+
     it('counts every bucket so a chip can state its size before it is applied', () => {
         const counts = countByFilter([
             item({ id: '1', type: 'detection' }),

--- a/apps/ui/src/lib/utils/notification-timeline.ts
+++ b/apps/ui/src/lib/utils/notification-timeline.ts
@@ -51,8 +51,12 @@ function jobIdentity(job: JobProgressItem): string {
 }
 
 function jobTimestamp(job: JobProgressItem): number {
-    // updatedAt is a progress heartbeat, not a new timeline event. Keeping the
-    // admission timestamp prevents active rows changing position on every tick.
+    // A terminal transition is a real timeline event, so it belongs at its completion time.
+    // Active updatedAt values are only progress heartbeats; retaining admission time there
+    // prevents rows changing position on every tick.
+    if (job.status === 'completed' || job.status === 'failed') {
+        return job.finishedAt || job.updatedAt || job.startedAt;
+    }
     return job.startedAt || job.finishedAt || job.updatedAt;
 }
 


### PR DESCRIPTION
## Outcome

Completed and failed jobs now take their correct newest-first position immediately and stay there after a browser refresh.

## Root cause

The combined timeline deliberately used a job's start time while it was active so progress heartbeats could not shuffle rows. That same start time was still overriding the newer completion notification after the job became terminal. Refreshing cleared the transient browser job state and exposed the completion timestamp, which made the row jump to the top only then.

## Included

- Keep active and queued work anchored to its admission time.
- Use the terminal timestamp once a job completes or fails.
- Add a regression test comparing the live sequence with the post-refresh sequence.
- Document the fix in the changelog.

## Excluded

- No visual layout, progress calculation, backend scheduling, or persisted job data changes.

## Verification

- Frontend: 144 files, 778 tests passed.
- Backend: 1902 passed, 44 skipped.
- Frontend production build passed.
- Ruff check and format checks passed.
- Svelte check passed with zero errors; six existing ambient type warnings remain.
- The focused regression test failed before the implementation and passes after it.

## Risk

Low. Active rows retain their prior stable ordering; only the real completed/failed transition receives a new timeline position.