### PR TITLE
Use full-resolution frame previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Alternative frame previews now use their retained full-resolution images.** The compact 240px
+  JPEGs remain limited to the filmstrip, while selecting a frame or comparing its full-frame peer
+  loads the authenticated full-size candidate instead of stretching a thumbnail across the modal.
 - **Finished jobs now remain newest-first before and after a browser refresh.** Active work keeps
   its queue-admission position while progress arrives, but a completion or failure is placed once
   at its terminal time instead of temporarily inheriting the older job-start time.

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -1608,6 +1608,7 @@ export interface components {
     crop_strategy?: string | null;
     frame_index: number;
     frame_offset_seconds?: number | null;
+    image_url?: string | null;
     ranking_score: number;
     selected: boolean;
     snapshot_source?: string | null;
@@ -2858,6 +2859,18 @@ export interface paths {
       query: never;
       requestBody: unknown;
       response: components['schemas']['SnapshotCandidateListResponse'];
+    };
+  };
+  "/api/frigate/{event_id}/snapshot/candidates/{candidate_id}/image.jpg": {
+    get: {
+      operationId: "get_snapshot_candidate_image_api_frigate__event_id__snapshot_candidates__candidate_id__image_jpg_get";
+      path: {
+    candidate_id: string;
+    event_id: string;
+};
+      query: never;
+      requestBody: unknown;
+      response: unknown;
     };
   };
   "/api/frigate/{event_id}/snapshot/candidates/{candidate_id}/thumbnail.jpg": {

--- a/apps/ui/src/lib/api/media.test.ts
+++ b/apps/ui/src/lib/api/media.test.ts
@@ -127,6 +127,7 @@ describe('snapshot HQ crop helpers', () => {
                         clip_variant: 'recording',
                         ranking_score: 0.92,
                         selected: true,
+                        image_url: '/api/frigate/evt-9/snapshot/candidates/cand-1/image.jpg',
                         thumbnail_url: '/api/frigate/evt-9/snapshot/candidates/cand-1/thumbnail.jpg'
                     }
                 ]
@@ -139,6 +140,7 @@ describe('snapshot HQ crop helpers', () => {
             candidates: [
                 expect.objectContaining({
                     candidate_id: 'cand-1',
+                    image_url: expect.stringContaining('/api/frigate/evt-9/snapshot/candidates/cand-1/image.jpg'),
                     thumbnail_url: expect.stringContaining('/api/frigate/evt-9/snapshot/candidates/cand-1/thumbnail.jpg')
                 })
             ]

--- a/apps/ui/src/lib/api/media.ts
+++ b/apps/ui/src/lib/api/media.ts
@@ -202,6 +202,7 @@ export async function fetchSnapshotCandidates(frigateEvent: string): Promise<Sna
         ...body,
         candidates: (body.candidates || []).map((candidate) => ({
             ...candidate,
+            image_url: candidate.image_url ? withAuthParams(candidate.image_url) : candidate.image_url,
             thumbnail_url: candidate.thumbnail_url ? withAuthParams(candidate.thumbnail_url) : candidate.thumbnail_url
         }))
     };

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -743,7 +743,7 @@
     // The frame rail previews a choice in place. Persisting it remains a separate, explicit action.
     let mediaView = $state<'stored' | 'full' | 'candidate' | 'original'>('stored');
     const canShowFullFrame = $derived(
-        authStore.hasOwnerAccess && !!fullFrameSnapshotCandidate?.thumbnail_url
+        authStore.hasOwnerAccess && !!(fullFrameSnapshotCandidate?.image_url ?? fullFrameSnapshotCandidate?.thumbnail_url)
     );
     const previewedSnapshotCandidate = $derived(
         pendingSnapshotMode === 'candidate' && pendingSnapshotCandidateId
@@ -754,8 +754,14 @@
         if (mediaView === 'original' && originalFrigateSnapshotAvailable) {
             return originalFrigateSnapshotUrl;
         }
+        if (mediaView === 'candidate' && previewedSnapshotCandidate?.image_url) {
+            return previewedSnapshotCandidate.image_url;
+        }
         if (mediaView === 'candidate' && previewedSnapshotCandidate?.thumbnail_url) {
             return previewedSnapshotCandidate.thumbnail_url;
+        }
+        if (mediaView === 'full' && fullFrameSnapshotCandidate?.image_url) {
+            return fullFrameSnapshotCandidate.image_url;
         }
         if (mediaView === 'full' && fullFrameSnapshotCandidate?.thumbnail_url) {
             return fullFrameSnapshotCandidate.thumbnail_url;

--- a/apps/ui/src/lib/components/ReviewQueueModal.svelte
+++ b/apps/ui/src/lib/components/ReviewQueueModal.svelte
@@ -68,7 +68,7 @@
                 const response = await fetchSnapshotCandidates(eventId);
                 if (cancelled) return;
                 const cropped = (response.candidates ?? []).filter(
-                    (candidate) => candidate.crop_box && candidate.thumbnail_url
+                    (candidate) => candidate.crop_box && (candidate.image_url || candidate.thumbnail_url)
                 );
                 const preferredCrop =
                     cropped.find((candidate) => candidate.selected) ??
@@ -96,10 +96,10 @@
     });
 
     const imageUrl = $derived(
-        view === 'crop' && crop?.thumbnail_url
-            ? crop.thumbnail_url
-            : view === 'full' && fullFrame?.thumbnail_url
-              ? fullFrame.thumbnail_url
+        view === 'crop' && (crop?.image_url || crop?.thumbnail_url)
+            ? (crop.image_url ?? crop.thumbnail_url ?? '')
+            : view === 'full' && (fullFrame?.image_url || fullFrame?.thumbnail_url)
+              ? (fullFrame.image_url ?? fullFrame.thumbnail_url ?? '')
             : session.current
               ? getThumbnailUrl(session.current.frigate_event)
               : ''

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -45,6 +45,9 @@ describe('detection surface polish', () => {
         // Candidates are owner-gated, so a guest gets no strip rather than an empty one.
         expect(detectionModalSource).toContain('authStore.hasOwnerAccess ? snapshotCandidates.filter');
         expect(detectionModalSource).toContain('previewSnapshotCandidate(candidate)');
+        expect(detectionModalSource).toContain('previewedSnapshotCandidate?.image_url');
+        expect(detectionModalSource).toContain('fullFrameSnapshotCandidate?.image_url');
+        expect(detectionModalSource).toContain('src={candidate.thumbnail_url ?? undefined}');
         expect(detectionModalSource).toContain('handleSaveSnapshotSelection');
         expect(detectionModalSource).toContain('stageOriginalFrigateSnapshot');
         expect(detectionModalSource).toContain('aria-busy={snapshotCandidatesLoading || snapshotApplyPending || snapshotGeneratePending}');

--- a/apps/ui/src/lib/components/review-queue-modal.layout.test.ts
+++ b/apps/ui/src/lib/components/review-queue-modal.layout.test.ts
@@ -35,6 +35,8 @@ describe('review queue walk-through', () => {
 
     it('shows the crop the classifier scored when one exists, and says so when it does not', () => {
         expect(modalSource).toContain('fetchSnapshotCandidates');
+        expect(modalSource).toContain('crop.image_url ?? crop.thumbnail_url');
+        expect(modalSource).toContain('fullFrame.image_url ?? fullFrame.thumbnail_url');
         expect(modalSource).toContain("import { findMatchingFullFrameCandidate } from '../utils/detection-evidence'");
         expect(modalSource).toMatch(
             /findMatchingFullFrameCandidate\(\s*response\.candidates \?\? \[\],\s*preferredCrop\?\.candidate_id \?\? null\s*\)/

--- a/backend/app/routers/proxy.py
+++ b/backend/app/routers/proxy.py
@@ -260,6 +260,19 @@ def _candidate_thumbnail_url(request: Request, event_id: str, candidate_id: str)
     )
 
 
+def _candidate_image_url(request: Request, event_id: str, candidate_id: str) -> str:
+    import time
+
+    return (
+        request.url_for(
+            "get_snapshot_candidate_image",
+            event_id=event_id,
+            candidate_id=candidate_id,
+        ).path
+        + f"?v={int(time.time())}"
+    )
+
+
 async def _build_snapshot_candidates_response(request: Request, event_id: str) -> "SnapshotCandidateListResponse":
     status = await _build_snapshot_status(event_id, check_original_frigate_snapshot=False)
     candidates = await _list_snapshot_candidates(event_id)
@@ -317,6 +330,15 @@ async def _build_snapshot_candidates_response(request: Request, event_id: str) -
                 selected=bool(candidate.get("selected")),
                 snapshot_source=(
                     str(candidate.get("snapshot_source")) if candidate.get("snapshot_source") is not None else None
+                ),
+                image_url=(
+                    _candidate_image_url(
+                        request,
+                        event_id,
+                        str(candidate.get("candidate_id") or ""),
+                    )
+                    if str(candidate.get("image_ref") or "").strip()
+                    else None
                 ),
                 thumbnail_url=_candidate_thumbnail_url(
                     request,
@@ -504,6 +526,7 @@ class SnapshotCandidateResponse(BaseModel):
     ranking_score: float
     selected: bool
     snapshot_source: str | None = None
+    image_url: str | None = None
     thumbnail_url: str | None = None
 
 
@@ -1516,6 +1539,31 @@ async def get_snapshot_candidate_thumbnail(
     if not thumbnail_bytes:
         raise HTTPException(status_code=404, detail="Snapshot candidate thumbnail unavailable")
     return Response(content=thumbnail_bytes, media_type="image/jpeg", headers=SNAPSHOT_NO_STORE_HEADERS)
+
+
+@router.get("/frigate/{event_id}/snapshot/candidates/{candidate_id}/image.jpg", response_class=Response)
+async def get_snapshot_candidate_image(
+    event_id: str = Path(..., min_length=1, max_length=64),
+    candidate_id: str = Path(..., min_length=1, max_length=160),
+    auth: AuthContext = Depends(require_owner),
+):
+    """Return the retained full-resolution candidate for the large preview surface."""
+    del auth
+    if not validate_event_id(event_id):
+        raise HTTPException(status_code=400, detail="Invalid event ID format")
+    candidates = await _list_snapshot_candidates(event_id)
+    candidate = next((item for item in candidates if str(item.get("candidate_id") or "") == candidate_id), None)
+    if candidate is None:
+        raise HTTPException(status_code=404, detail="Snapshot candidate not found")
+    from app.services.media_cache import media_cache
+
+    image_ref = str(candidate.get("image_ref") or "").strip()
+    if not image_ref:
+        raise HTTPException(status_code=404, detail="Snapshot candidate image unavailable")
+    image_bytes = await media_cache.get_snapshot(image_ref)
+    if not image_bytes:
+        raise HTTPException(status_code=404, detail="Snapshot candidate image unavailable")
+    return Response(content=image_bytes, media_type="image/jpeg", headers=SNAPSHOT_NO_STORE_HEADERS)
 
 
 @router.post("/frigate/{event_id}/snapshot/apply", response_model=SnapshotApplyResponse)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -12426,6 +12426,17 @@
             ],
             "title": "Frame Offset Seconds"
           },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          },
           "ranking_score": {
             "title": "Ranking Score",
             "type": "number"
@@ -19667,6 +19678,63 @@
           }
         ],
         "summary": "Get Snapshot Candidates"
+      }
+    },
+    "/api/frigate/{event_id}/snapshot/candidates/{candidate_id}/image.jpg": {
+      "get": {
+        "description": "Return the retained full-resolution candidate for the large preview surface.",
+        "operationId": "get_snapshot_candidate_image_api_frigate__event_id__snapshot_candidates__candidate_id__image_jpg_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "maxLength": 64,
+              "minLength": 1,
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "candidate_id",
+            "required": true,
+            "schema": {
+              "maxLength": 160,
+              "minLength": 1,
+              "title": "Candidate Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ],
+        "summary": "Get Snapshot Candidate Image"
       }
     },
     "/api/frigate/{event_id}/snapshot/candidates/{candidate_id}/thumbnail.jpg": {

--- a/backend/tests/test_proxy.py
+++ b/backend/tests/test_proxy.py
@@ -1590,11 +1590,70 @@ async def test_proxy_snapshot_candidates_lists_persisted_candidates(client: http
     assert body["candidates"][0]["candidate_id"] == "cand-1"
     assert body["candidates"][0]["crop_strategy"] == "frigate_guided"
     thumbnail_url = body["candidates"][0]["thumbnail_url"]
+    image_url = body["candidates"][0]["image_url"]
     # A cache-busting `?v=<mtime>` query is appended so promoted candidates refresh in the browser.
     assert thumbnail_url.split("?", 1)[0].endswith(
         "/api/frigate/test_event_id/snapshot/candidates/cand-1/thumbnail.jpg"
     )
     assert "?v=" in thumbnail_url
+    assert image_url.split("?", 1)[0].endswith("/api/frigate/test_event_id/snapshot/candidates/cand-1/image.jpg")
+    assert "?v=" in image_url
+
+
+@pytest.mark.asyncio
+async def test_proxy_snapshot_candidate_image_returns_retained_full_resolution_image(client: httpx.AsyncClient):
+    with (
+        patch("app.routers.proxy.get_db") as mock_get_db,
+        patch("app.routers.proxy.DetectionRepository") as mock_repo_cls,
+        patch("app.services.media_cache.media_cache.get_snapshot", new_callable=AsyncMock) as mock_get_snapshot,
+    ):
+        mock_db = AsyncMock()
+        mock_get_db.return_value.__aenter__.return_value = mock_db
+        mock_repo = mock_repo_cls.return_value
+        mock_repo.list_snapshot_candidates = AsyncMock(
+            return_value=[
+                {
+                    "candidate_id": "cand-1",
+                    "image_ref": "evt__cand-1__image",
+                }
+            ]
+        )
+        mock_get_snapshot.return_value = b"full-resolution-jpeg"
+
+        response = await client.get("/api/frigate/test_event_id/snapshot/candidates/cand-1/image.jpg")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/jpeg")
+    assert response.content == b"full-resolution-jpeg"
+    mock_get_snapshot.assert_awaited_once_with("evt__cand-1__image")
+
+
+@pytest.mark.asyncio
+async def test_proxy_snapshot_candidate_image_returns_404_when_retained_image_is_missing(
+    client: httpx.AsyncClient,
+):
+    with (
+        patch("app.routers.proxy.get_db") as mock_get_db,
+        patch("app.routers.proxy.DetectionRepository") as mock_repo_cls,
+        patch("app.services.media_cache.media_cache.get_snapshot", new_callable=AsyncMock) as mock_get_snapshot,
+    ):
+        mock_db = AsyncMock()
+        mock_get_db.return_value.__aenter__.return_value = mock_db
+        mock_repo = mock_repo_cls.return_value
+        mock_repo.list_snapshot_candidates = AsyncMock(
+            return_value=[
+                {
+                    "candidate_id": "cand-1",
+                    "image_ref": "evt__cand-1__image",
+                }
+            ]
+        )
+        mock_get_snapshot.return_value = None
+
+        response = await client.get("/api/frigate/test_event_id/snapshot/candidates/cand-1/image.jpg")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Snapshot candidate image unavailable"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expose retained full-resolution snapshot candidates through an owner-authenticated, no-store endpoint
- use full candidate images in detection details and review queue previews while preserving compact filmstrip thumbnails
- update generated API contracts and add backend/frontend regression coverage

## Root cause

The picker retained full-size JPEGs but exposed only its 240px quality-82 thumbnails. Selecting an alternative frame then stretched that thumbnail across the modal.

## Validation

- 145 frontend test files, 781 tests passed
- frontend production build passed
- Svelte check passed with zero errors and six existing ambient type warnings
- 1,904 backend tests passed, 44 skipped
- Ruff lint and format checks passed
- OpenAPI and TypeScript API contract checks passed
- git diff check passed