### PR TITLE
Report how clips are packaged in diagnostics bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   downgrading a shared modern-driver dependency
   ([#177](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/pull/177)).
 
-### Added
+- **Diagnostics bundles now say how your clips are packaged.** Safari refuses HEVC tagged `hev1` in
+  a video element while QuickTime plays it happily, so "the download opens fine" never settled
+  whether the packaging was the problem. A bundle now reports the sample format of a recent clip and
+  whether Safari will accept it, read straight from the container without needing ffmpeg in the
+  image. There is a new troubleshooting page covering the fix and the two things about it that are
+  easy to miss ([#167](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/167)).
 
 - **The Health page now says how the feeder is doing in colour, not just in a badge.** The status
   card takes the verdict itself: green when everything is healthy, amber when something is waiting on

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -708,6 +708,7 @@ export interface components {
     generated_at: string;
     health: Record<string, unknown>;
     maintenance_coordinator: Record<string, unknown>;
+    media_sample: components['schemas']['MediaSampleResponse'];
     schema_version: string;
     server: components['schemas']['DiagnosticsBundleServerResponse'];
     startup_warnings: Array<Record<string, unknown>>;
@@ -727,6 +728,7 @@ export interface components {
     diagnostic_events: number;
     health_status: string;
     startup_warning_count: number;
+    video_sample_format?: string;
 };
     DiagnosticsWorkspaceResponse: {
     backend_diagnostics: components['schemas']['BackendDiagnosticsSnapshotResponse'];
@@ -1072,6 +1074,16 @@ export interface components {
     species?: string | null;
     status: "updated" | "unchanged";
     taxa_id?: number | null;
+};
+    MediaSampleResponse: {
+    available?: boolean;
+    bytes_read?: number;
+    codec?: string | null;
+    codec_tag?: string | null;
+    event_id?: string | null;
+    note?: string;
+    safari_compatible?: boolean | null;
+    source?: string | null;
 };
     MessageResponse: {
     message: string;

--- a/backend/app/routers/diagnostics.py
+++ b/backend/app/routers/diagnostics.py
@@ -6,11 +6,12 @@ from pydantic import BaseModel, Field
 
 from app.auth import AuthContext, require_owner
 from app.services.error_diagnostics import error_diagnostics_history
+from app.services.media_probe import collect_video_sample_diagnostic
 
 router = APIRouter(prefix="/diagnostics", tags=["diagnostics"])
 
 WORKSPACE_SCHEMA_VERSION = "2026-03-12.owner-incident-workspace.v1"
-BUNDLE_SCHEMA_VERSION = "2026-04-09.owner-diagnostics-bundle.v1"
+BUNDLE_SCHEMA_VERSION = "2026-08-15.owner-diagnostics-bundle.v2"
 
 _BACKFILL_STALE_JOB_SECONDS = 600.0
 
@@ -92,12 +93,31 @@ class DiagnosticsBundleSummaryResponse(BaseModel):
     backfill_stale_jobs: int
     backfill_running_jobs: int
     backfill_failed_jobs: int
+    video_sample_format: str = "unknown"
 
 
 class DiagnosticsBundleServerResponse(BaseModel):
     service: str
     version: str
     startup_instance_id: str
+
+
+class MediaSampleResponse(BaseModel):
+    """How this instance's clips are packaged.
+
+    Safari refuses HEVC tagged `hev1` in a video element while QuickTime plays
+    it, so a report of "the download works but the page does not" is answered
+    here rather than by asking for ffprobe output.
+    """
+
+    available: bool = False
+    event_id: str | None = None
+    source: str | None = None
+    bytes_read: int = 0
+    codec_tag: str | None = None
+    codec: str | None = None
+    safari_compatible: bool | None = None
+    note: str = ""
 
 
 class DiagnosticsBundleResponse(BaseModel):
@@ -113,6 +133,7 @@ class DiagnosticsBundleResponse(BaseModel):
     startup_warnings: list[dict[str, Any]]
     backend_diagnostics: BackendDiagnosticsSnapshotResponse
     focused_diagnostics: FocusedDiagnosticsResponse
+    media_sample: MediaSampleResponse
 
 
 class ClearDiagnosticsWorkspaceResponse(BaseModel):
@@ -267,6 +288,8 @@ async def _collect_bundle_payload(limit: int) -> dict[str, Any]:
     startup_warnings = workspace.get("startup_warnings") if isinstance(workspace, dict) else []
     startup_warnings = startup_warnings if isinstance(startup_warnings, list) else []
 
+    media_sample = await collect_video_sample_diagnostic()
+
     focused = workspace.get("focused_diagnostics") or {}
     backfill_focus = focused.get("backfill") if isinstance(focused, dict) else {}
     backfill_focus = backfill_focus if isinstance(backfill_focus, dict) else {}
@@ -281,6 +304,7 @@ async def _collect_bundle_payload(limit: int) -> dict[str, Any]:
             "backfill_stale_jobs": len(backfill_focus.get("stale_jobs") or []),
             "backfill_running_jobs": len(backfill_focus.get("running_jobs") or []),
             "backfill_failed_jobs": len(backfill_focus.get("failed_jobs") or []),
+            "video_sample_format": media_sample.get("codec_tag") or "unknown",
         },
         "server": {
             "service": health.get("service") or "unknown",
@@ -295,6 +319,7 @@ async def _collect_bundle_payload(limit: int) -> dict[str, Any]:
         "startup_warnings": startup_warnings,
         "backend_diagnostics": backend_diagnostics,
         "focused_diagnostics": workspace.get("focused_diagnostics") or {},
+        "media_sample": media_sample,
     }
 
 

--- a/backend/app/services/media_probe.py
+++ b/backend/app/services/media_probe.py
@@ -1,0 +1,320 @@
+"""Read a clip's video sample format out of the MP4 container.
+
+Safari's `<video>` element rejects HEVC tagged `hev1` while QuickTime plays it,
+so "the download opens fine" does not clear the packaging. The four-character
+sample format in `stsd` is what decides it, and it sits in the `moov` index, so
+a short prefix of the file is enough to read it.
+
+Deliberately a pure function over bytes: no subprocess, no ffprobe dependency in
+the runtime image, and every branch reachable from a unit test. All parsing is
+bounded, because the input is a byte range fetched from an external service.
+"""
+
+from __future__ import annotations
+
+import re
+import struct
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+import aiofiles
+import httpx
+import structlog
+
+from app.config import settings
+from app.services.frigate_client import frigate_client
+from app.services.media_cache import media_cache
+
+log = structlog.get_logger()
+
+# The id comes back from Frigate and is then interpolated into a URL, so it is
+# validated on the same terms the media proxy uses rather than trusted.
+_EVENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _is_safe_event_id(event_id: str) -> bool:
+    return bool(_EVENT_ID_PATTERN.match(event_id)) and len(event_id) <= 64
+
+
+_HEADER_SIZE = 8
+# Containers nest shallowly (moov > trak > mdia > minf > stbl > stsd). A cap
+# stops a malformed file from driving unbounded recursion.
+_MAX_DEPTH = 8
+# A prefix large enough to hold a clip index; anything past this is payload.
+_MAX_BOXES_PER_LEVEL = 256
+
+_CONTAINER_BOXES = frozenset({b"moov", b"trak", b"mdia", b"minf", b"stbl"})
+
+# Safari plays HEVC only when the sample entry is tagged `hvc1`. `hev1` carries
+# parameter sets in-band, which its media stack refuses.
+_SAMPLE_FORMATS: dict[str, tuple[str, bool]] = {
+    "hvc1": ("hevc", True),
+    "hev1": ("hevc", False),
+    "avc1": ("h264", True),
+    "avc3": ("h264", True),
+    "mp4v": ("mpeg4", True),
+}
+
+
+@dataclass(frozen=True)
+class VideoSampleFormat:
+    """What the container says about its video track."""
+
+    codec_tag: Optional[str] = None
+    codec: Optional[str] = None
+    # None means "not established", never "fine". An unrecognised tag is not a
+    # licence to claim compatibility.
+    safari_compatible: Optional[bool] = None
+    note: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "codec_tag": self.codec_tag,
+            "codec": self.codec,
+            "safari_compatible": self.safari_compatible,
+            "note": self.note,
+        }
+
+
+def _iter_boxes(data: bytes, start: int, end: int) -> Iterator[tuple[bytes, int, int]]:
+    """Yield (kind, payload_start, payload_end) for each box in a range."""
+    offset = start
+    seen = 0
+    while offset + _HEADER_SIZE <= end and seen < _MAX_BOXES_PER_LEVEL:
+        seen += 1
+        (declared,) = struct.unpack_from(">I", data, offset)
+        kind = data[offset + 4 : offset + 8]
+        header = _HEADER_SIZE
+
+        if declared == 1:
+            # 64-bit size follows the header.
+            if offset + 16 > end:
+                return
+            (declared,) = struct.unpack_from(">Q", data, offset + 8)
+            header = 16
+        elif declared == 0:
+            # Runs to the end of the file.
+            declared = end - offset
+
+        if declared < header:
+            # Nonsense size. Advancing by the header keeps the scan moving
+            # rather than looping forever on the same offset.
+            offset += _HEADER_SIZE
+            continue
+
+        payload_start = offset + header
+        payload_end = min(offset + declared, end)
+        if payload_start > end:
+            return
+        yield kind, payload_start, payload_end
+        offset += declared
+
+
+def _find_video_sample_format(data: bytes, start: int, end: int, depth: int = 0) -> Optional[str]:
+    """Walk containers to the video track's first sample entry."""
+    if depth > _MAX_DEPTH:
+        return None
+
+    for kind, payload_start, payload_end in _iter_boxes(data, start, end):
+        if kind == b"trak":
+            if not _track_is_video(data, payload_start, payload_end):
+                continue
+            found = _find_video_sample_format(data, payload_start, payload_end, depth + 1)
+            if found:
+                return found
+        elif kind == b"stsd":
+            return _first_sample_format(data, payload_start, payload_end)
+        elif kind in _CONTAINER_BOXES:
+            found = _find_video_sample_format(data, payload_start, payload_end, depth + 1)
+            if found:
+                return found
+    return None
+
+
+def _track_is_video(data: bytes, start: int, end: int, depth: int = 0) -> bool:
+    """A track is video when its media handler says `vide`."""
+    if depth > _MAX_DEPTH:
+        return False
+    for kind, payload_start, payload_end in _iter_boxes(data, start, end):
+        if kind == b"hdlr":
+            # version/flags (4) + pre_defined (4) + handler_type (4)
+            handler_at = payload_start + 8
+            if handler_at + 4 > payload_end:
+                return False
+            return data[handler_at : handler_at + 4] == b"vide"
+        if kind in _CONTAINER_BOXES:
+            if _track_is_video(data, payload_start, payload_end, depth + 1):
+                return True
+    return False
+
+
+def _first_sample_format(data: bytes, start: int, end: int) -> Optional[str]:
+    # version/flags (4) + entry_count (4), then entry size (4) + format (4).
+    entry_at = start + 8
+    if entry_at + 8 > end:
+        return None
+    tag = data[entry_at + 4 : entry_at + 8]
+    if len(tag) != 4:
+        return None
+    try:
+        decoded = tag.decode("ascii")
+    except UnicodeDecodeError:
+        return None
+    return decoded if decoded.isprintable() else None
+
+
+def probe_video_sample_format(data: bytes) -> VideoSampleFormat:
+    """Read the video sample format from an MP4 prefix.
+
+    Returns an empty result with a reason rather than raising: this runs while
+    assembling a diagnostics bundle, where a readable "could not tell" is worth
+    more than a failed export.
+    """
+    if not isinstance(data, (bytes, bytearray)) or len(data) < _HEADER_SIZE:
+        return VideoSampleFormat(note="No media bytes to read.")
+
+    payload = bytes(data)
+    try:
+        tag = _find_video_sample_format(payload, 0, len(payload))
+    except (struct.error, IndexError, ValueError):
+        return VideoSampleFormat(note="Media header could not be parsed.")
+
+    if not tag:
+        return VideoSampleFormat(
+            note=(
+                "No moov index in the fetched prefix, so the sample format is unknown. "
+                "A clip written without faststart keeps its index at the end of the file."
+            )
+        )
+
+    codec, safari_compatible = _SAMPLE_FORMATS.get(tag, (None, None))
+    if codec is None:
+        return VideoSampleFormat(codec_tag=tag, note=f"Unrecognised video sample format {tag!r}.")
+
+    if codec == "hevc" and safari_compatible is False:
+        note = (
+            "HEVC tagged hev1. Safari refuses this in a video element even though QuickTime "
+            "plays it. Frigate's apple_compatibility setting produces hvc1 instead, and only "
+            "for recordings made after it is applied."
+        )
+    else:
+        note = f"{codec} tagged {tag}."
+
+    return VideoSampleFormat(codec_tag=tag, codec=codec, safari_compatible=safari_compatible, note=note)
+
+
+# ── Collecting the sample ────────────────────────────────────────────────────
+# The parser above is pure. Everything below is the bounded I/O that feeds it.
+
+#: Enough of a clip to carry its index. A real 4K HEVC clip resolves in 32KB.
+CLIP_PREFIX_BYTES = 64 * 1024
+CLIP_PROBE_TIMEOUT_SECONDS = 8.0
+
+
+def _unavailable(note: str) -> dict[str, object]:
+    return {
+        "available": False,
+        "event_id": None,
+        "source": None,
+        "bytes_read": 0,
+        **VideoSampleFormat(note=note).as_dict(),
+    }
+
+
+async def _read_cached_prefix(event_id: str, max_bytes: int) -> Optional[bytes]:
+    try:
+        path = media_cache.get_clip_path(event_id)
+    except Exception:
+        return None
+    if not path:
+        return None
+    try:
+        async with aiofiles.open(path, "rb") as handle:
+            return await handle.read(max_bytes)
+    except Exception:
+        return None
+
+
+async def _read_frigate_prefix(event_id: str, max_bytes: int, timeout: float) -> Optional[bytes]:
+    base = (settings.frigate.frigate_url or "").rstrip("/")
+    if not base:
+        return None
+
+    headers = dict(frigate_client._get_headers())
+    headers["Range"] = f"bytes=0-{max_bytes - 1}"
+    url = f"{base}/api/events/{event_id}/clip.mp4"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, headers=headers)
+            if response.status_code not in (200, 206):
+                return None
+            return response.content[:max_bytes]
+    except Exception:
+        return None
+
+
+async def _recent_event_with_clip(timeout: float) -> Optional[str]:
+    try:
+        response = await frigate_client.get("api/events", params={"limit": 1, "has_clip": 1}, timeout=timeout)
+        response.raise_for_status()
+        events = response.json()
+    except Exception:
+        return None
+    if not isinstance(events, list) or not events:
+        return None
+    event_id = events[0].get("id") if isinstance(events[0], dict) else None
+    if not isinstance(event_id, str) or not _is_safe_event_id(event_id):
+        return None
+    return event_id
+
+
+async def collect_video_sample_diagnostic(
+    *,
+    max_bytes: int = CLIP_PREFIX_BYTES,
+    timeout: float = CLIP_PROBE_TIMEOUT_SECONDS,
+) -> dict[str, object]:
+    """Describe how this instance's clips are packaged.
+
+    Answers "why does Safari refuse my video" from the bundle rather than from a
+    round trip asking the reporter to install ffprobe. Never raises and never
+    blocks for long: a diagnostics export that fails because a probe failed is
+    worse than an export that says it could not tell.
+    """
+    try:
+        return await _collect_video_sample(max_bytes=max_bytes, timeout=timeout)
+    except Exception as error:  # pragma: no cover - guarded by test_probe_never_escapes
+        # Each helper already swallows its own failures. This is the backstop:
+        # a bundle must never fail to assemble because a probe went wrong.
+        log.warning("media_sample_probe_failed", error=str(error))
+        return _unavailable("The media sample could not be read.")
+
+
+async def _collect_video_sample(*, max_bytes: int, timeout: float) -> dict[str, object]:
+    event_id = await _recent_event_with_clip(timeout)
+    if not event_id:
+        return _unavailable("No recent Frigate event with a clip was available to sample.")
+
+    prefix = await _read_cached_prefix(event_id, max_bytes)
+    source = "media_cache"
+    if not prefix:
+        prefix = await _read_frigate_prefix(event_id, max_bytes, timeout)
+        source = "frigate"
+
+    if not prefix:
+        return {**_unavailable("The clip could not be read from the cache or from Frigate."), "event_id": event_id}
+
+    result = probe_video_sample_format(prefix)
+    log.debug(
+        "media_sample_probed",
+        event_id=event_id,
+        source=source,
+        codec_tag=result.codec_tag,
+        safari_compatible=result.safari_compatible,
+    )
+    return {
+        "available": result.codec_tag is not None,
+        "event_id": event_id,
+        "source": source,
+        "bytes_read": len(prefix),
+        **result.as_dict(),
+    }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4925,6 +4925,9 @@
             "title": "Maintenance Coordinator",
             "type": "object"
           },
+          "media_sample": {
+            "$ref": "#/components/schemas/MediaSampleResponse"
+          },
           "schema_version": {
             "title": "Schema Version",
             "type": "string"
@@ -4964,7 +4967,8 @@
           "maintenance_coordinator",
           "startup_warnings",
           "backend_diagnostics",
-          "focused_diagnostics"
+          "focused_diagnostics",
+          "media_sample"
         ],
         "title": "DiagnosticsBundleResponse",
         "type": "object"
@@ -5017,6 +5021,11 @@
           "startup_warning_count": {
             "title": "Startup Warning Count",
             "type": "integer"
+          },
+          "video_sample_format": {
+            "default": "unknown",
+            "title": "Video Sample Format",
+            "type": "string"
           }
         },
         "required": [
@@ -7445,6 +7454,83 @@
           "manual_tagged"
         ],
         "title": "ManualTagResponse",
+        "type": "object"
+      },
+      "MediaSampleResponse": {
+        "description": "How this instance's clips are packaged.\n\nSafari refuses HEVC tagged `hev1` in a video element while QuickTime plays\nit, so a report of \"the download works but the page does not\" is answered\nhere rather than by asking for ffprobe output.",
+        "properties": {
+          "available": {
+            "default": false,
+            "title": "Available",
+            "type": "boolean"
+          },
+          "bytes_read": {
+            "default": 0,
+            "title": "Bytes Read",
+            "type": "integer"
+          },
+          "codec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Codec"
+          },
+          "codec_tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Codec Tag"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Id"
+          },
+          "note": {
+            "default": "",
+            "title": "Note",
+            "type": "string"
+          },
+          "safari_compatible": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Safari Compatible"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "title": "MediaSampleResponse",
         "type": "object"
       },
       "MessageResponse": {

--- a/backend/tests/test_error_diagnostics_api.py
+++ b/backend/tests/test_error_diagnostics_api.py
@@ -254,7 +254,7 @@ async def test_owner_can_fetch_diagnostics_bundle(client: httpx.AsyncClient):
         assert response.status_code == 200, response.text
         payload = response.json()
 
-        assert payload["schema_version"] == "2026-04-09.owner-diagnostics-bundle.v1"
+        assert payload["schema_version"] == "2026-08-15.owner-diagnostics-bundle.v2"
         assert payload["summary"]["diagnostic_events"] == 1
         assert payload["summary"]["health_status"] == payload["health"]["status"]
         assert payload["server"]["service"] == payload["health"]["service"]
@@ -262,6 +262,14 @@ async def test_owner_can_fetch_diagnostics_bundle(client: httpx.AsyncClient):
         assert payload["classifier"]["active_provider"] == "intel_cpu"
         assert payload["backend_diagnostics"]["events"][0]["correlation_key"] == "event_pipeline:stage_timeout"
         assert isinstance(payload["focused_diagnostics"], dict)
+        # Answers "why does Safari refuse my clip" without a round trip for
+        # ffprobe output. With no Frigate reachable in the test environment it
+        # must still report honestly rather than omit the section.
+        assert payload["media_sample"]["available"] is False
+        assert payload["media_sample"]["codec_tag"] is None
+        assert payload["media_sample"]["safari_compatible"] is None
+        assert payload["media_sample"]["note"]
+        assert payload["summary"]["video_sample_format"] == "unknown"
     finally:
         classifier_router.classifier_service.get_status = original_get_status
 

--- a/backend/tests/test_media_probe.py
+++ b/backend/tests/test_media_probe.py
@@ -1,0 +1,220 @@
+"""Reading a clip's video sample format straight out of the MP4 container.
+
+Safari refuses HEVC tagged `hev1` in a <video> element while QuickTime plays it
+happily, so "it plays when I download it" does not clear the packaging. This
+lets a diagnostics bundle answer the question instead of asking the reporter to
+install ffprobe.
+"""
+
+import struct
+
+import pytest
+
+from app.services.media_probe import probe_video_sample_format
+
+
+def box(kind: bytes, payload: bytes) -> bytes:
+    return struct.pack(">I", len(payload) + 8) + kind + payload
+
+
+def stsd(sample_format: bytes) -> bytes:
+    entry = struct.pack(">I", 8 + 78) + sample_format + b"\x00" * 78
+    return box(b"stsd", b"\x00\x00\x00\x00" + struct.pack(">I", 1) + entry)
+
+
+def video_track(sample_format: bytes) -> bytes:
+    hdlr = box(b"hdlr", b"\x00" * 8 + b"vide" + b"\x00" * 12)
+    stbl = box(b"stbl", stsd(sample_format))
+    minf = box(b"minf", stbl)
+    mdia = box(b"mdia", hdlr + minf)
+    return box(b"trak", mdia)
+
+
+def audio_track() -> bytes:
+    hdlr = box(b"hdlr", b"\x00" * 8 + b"soun" + b"\x00" * 12)
+    stbl = box(b"stbl", stsd(b"mp4a"))
+    minf = box(b"minf", stbl)
+    mdia = box(b"mdia", hdlr + minf)
+    return box(b"trak", mdia)
+
+
+def mp4(*traks: bytes, ftyp: bytes = b"isom") -> bytes:
+    return box(b"ftyp", ftyp + b"\x00\x00\x02\x00" + ftyp) + box(b"moov", b"".join(traks))
+
+
+@pytest.mark.parametrize(
+    ("sample_format", "codec", "safari_compatible"),
+    [
+        (b"hvc1", "hevc", True),
+        (b"hev1", "hevc", False),
+        (b"avc1", "h264", True),
+        (b"avc3", "h264", True),
+    ],
+)
+def test_reads_the_video_sample_format(sample_format: bytes, codec: str, safari_compatible: bool):
+    result = probe_video_sample_format(mp4(video_track(sample_format)))
+
+    assert result.codec_tag == sample_format.decode()
+    assert result.codec == codec
+    assert result.safari_compatible is safari_compatible
+
+
+def test_reads_the_video_track_not_the_audio_track():
+    result = probe_video_sample_format(mp4(audio_track(), video_track(b"hev1")))
+
+    assert result.codec_tag == "hev1"
+    assert result.codec == "hevc"
+
+
+def test_reports_an_unrecognised_format_without_guessing_at_compatibility():
+    result = probe_video_sample_format(mp4(video_track(b"av01")))
+
+    assert result.codec_tag == "av01"
+    assert result.codec is None
+    assert result.safari_compatible is None
+
+
+def test_says_so_when_the_prefix_does_not_carry_the_index():
+    """A clip written without faststart keeps `moov` at the end."""
+    trailing = box(b"ftyp", b"isom" + b"\x00" * 8) + box(b"mdat", b"\x00" * 64)
+
+    result = probe_video_sample_format(trailing)
+
+    assert result.codec_tag is None
+    assert result.safari_compatible is None
+    assert "moov" in result.note
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        b"\x00\x00",
+        b"\x00\x00\x00\x08free",
+        b"\xff\xff\xff\xffmoov",
+        struct.pack(">I", 8) + b"moov",
+        struct.pack(">I", 0) + b"moov",
+        struct.pack(">I", 999999) + b"moov" + b"\x00" * 4,
+    ],
+)
+def test_never_raises_on_truncated_or_hostile_input(payload: bytes):
+    result = probe_video_sample_format(payload)
+
+    assert result.codec_tag is None
+    assert result.safari_compatible is None
+
+
+def test_survives_a_box_that_claims_to_contain_itself():
+    # size 8 means an empty box; a parser that does not advance would spin here.
+    nested = box(b"moov", box(b"trak", struct.pack(">I", 8) + b"mdia"))
+
+    result = probe_video_sample_format(nested)
+
+    assert result.codec_tag is None
+
+
+def test_handles_a_64_bit_box_header():
+    inner = video_track(b"hvc1")
+    payload = struct.pack(">I", 1) + b"moov" + struct.pack(">Q", 16 + len(inner)) + inner
+    result = probe_video_sample_format(box(b"ftyp", b"isom" + b"\x00" * 8) + payload)
+
+    assert result.codec_tag == "hvc1"
+
+
+# ── The bounded collector ────────────────────────────────────────────────────
+
+import app.services.media_probe as media_probe  # noqa: E402
+
+
+@pytest.fixture
+def probe_env(monkeypatch):
+    """Stub the three external reads so each failure path can be exercised."""
+
+    state = {"event": "evt-1", "cached": None, "frigate": None}
+
+    async def fake_event(_timeout):
+        return state["event"]
+
+    async def fake_cached(_event_id, _max_bytes):
+        return state["cached"]
+
+    async def fake_frigate(_event_id, _max_bytes, _timeout):
+        return state["frigate"]
+
+    monkeypatch.setattr(media_probe, "_recent_event_with_clip", fake_event)
+    monkeypatch.setattr(media_probe, "_read_cached_prefix", fake_cached)
+    monkeypatch.setattr(media_probe, "_read_frigate_prefix", fake_frigate)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_prefers_the_cached_clip_over_a_network_read(probe_env):
+    probe_env["cached"] = mp4(video_track(b"hvc1"))
+    probe_env["frigate"] = mp4(video_track(b"hev1"))
+
+    result = await media_probe.collect_video_sample_diagnostic()
+
+    assert result["source"] == "media_cache"
+    assert result["codec_tag"] == "hvc1"
+    assert result["available"] is True
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_frigate_when_nothing_is_cached(probe_env):
+    probe_env["frigate"] = mp4(video_track(b"hev1"))
+
+    result = await media_probe.collect_video_sample_diagnostic()
+
+    assert result["source"] == "frigate"
+    assert result["codec_tag"] == "hev1"
+    assert result["safari_compatible"] is False
+    assert "apple_compatibility" in result["note"]
+
+
+@pytest.mark.asyncio
+async def test_says_it_could_not_tell_rather_than_failing_the_export(probe_env):
+    result = await media_probe.collect_video_sample_diagnostic()
+
+    assert result["available"] is False
+    assert result["event_id"] == "evt-1"
+    assert result["safari_compatible"] is None
+
+
+@pytest.mark.asyncio
+async def test_reports_honestly_when_there_is_no_event_to_sample(probe_env):
+    probe_env["event"] = None
+
+    result = await media_probe.collect_video_sample_diagnostic()
+
+    assert result["available"] is False
+    assert result["event_id"] is None
+    assert result["codec_tag"] is None
+
+
+@pytest.mark.asyncio
+async def test_probe_never_escapes_and_fails_the_bundle(monkeypatch):
+    """A diagnostics export must survive a probe that goes wrong."""
+
+    async def explode(*_args, **_kwargs):
+        raise RuntimeError("frigate is on fire")
+
+    monkeypatch.setattr(media_probe, "_collect_video_sample", explode)
+
+    result = await media_probe.collect_video_sample_diagnostic()
+
+    assert result["available"] is False
+    assert result["codec_tag"] is None
+    assert result["safari_compatible"] is None
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["../../etc/passwd", "evt/../..", "evt?x=1", "evt id", "e" * 65, "", "evt#frag"],
+)
+def test_rejects_an_event_id_that_would_not_be_safe_in_a_url(hostile):
+    assert media_probe._is_safe_event_id(hostile) is False
+
+
+@pytest.mark.parametrize("good", ["1786898087.273197-5p93eu", "manual_abc-123", "a.b_c-d"])
+def test_accepts_the_ids_frigate_actually_produces(good):
+    assert media_probe._is_safe_event_id(good) is True

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ Connect YA-WAMF to the rest of your smart home and community projects.
 Solving common issues and using diagnostic tools.
 - **[🛠 Diagnostics & Logs](troubleshooting/diagnostics.md)** - Using MQTT tests and Backfill reports.
 - **[📼 Frigate Event Not Found](troubleshooting/frigate-event-not-found.md)** - Diagnose short-lived events and missing upstream media.
+- **[🍎 Video Will Not Play in Safari](troubleshooting/safari-video-playback.md)** - Why a clip that opens in QuickTime can still be refused by Safari, and how to check the packaging.
 
 ## Engineering & Quality
 How the project is built and held to standard.

--- a/docs/troubleshooting/safari-video-playback.md
+++ b/docs/troubleshooting/safari-video-playback.md
@@ -1,0 +1,63 @@
+# Video Will Not Play in Safari
+
+A recording that plays in Firefox or Chrome, and opens fine in QuickTime, can still
+refuse to play in Safari. The usual cause is not the recording itself but how it is
+packaged.
+
+## Why Safari is different
+
+HEVC video in an MP4 carries a four character sample format. Two are in common use:
+
+| Sample format | QuickTime | Safari `<video>` |
+| --- | --- | --- |
+| `hvc1` | Plays | Plays |
+| `hev1` | Plays | Refuses |
+
+Because QuickTime accepts both, downloading the clip and opening it does not tell you
+whether Safari will play it. That test can look like a pass while the real cause is
+still in place.
+
+## Check how your clips are packaged
+
+Capture a diagnostics bundle from **Settings > Health > Diagnostics export**. It
+includes a `media_sample` section describing a recent clip:
+
+```json
+"media_sample": {
+  "available": true,
+  "codec_tag": "hvc1",
+  "codec": "hevc",
+  "safari_compatible": true,
+  "note": "hevc tagged hvc1."
+}
+```
+
+`safari_compatible: false` means the clip is tagged `hev1`, and that is the cause.
+`codec: "h264"` means the packaging is not involved and the problem is elsewhere.
+
+## Fix
+
+Frigate has a per camera setting for this:
+
+```yaml
+cameras:
+  your_camera:
+    ffmpeg:
+      apple_compatibility: true
+```
+
+See [Frigate's H.265 cameras via Safari guidance](https://docs.frigate.video/configuration/camera_specific/#h265-cameras-via-safari).
+
+Two things are easy to miss:
+
+- It applies only to recording segments created after the setting is added and Frigate
+  is restarted. Existing events keep their original packaging, so test with a new one.
+- YA-WAMF caches clips. A clip already in the cache keeps its old packaging until the
+  cache entry is replaced.
+
+## If it still fails
+
+Capture a bundle after recording a new event and include it in your report, along with
+the macOS and Safari versions and the approximate event time. If `safari_compatible` is
+`true` and playback still fails, the packaging is ruled out and the next thing to look
+at is the media proxy rather than the recording.


### PR DESCRIPTION
Comes out of #167, where establishing one fact has taken four rounds of correspondence.

## Why

Safari refuses HEVC tagged `hev1` in a `<video>` element. QuickTime plays it. So "I downloaded the clip and it opens fine" reads like a pass while the actual cause is untouched, and the thread moves on from the right answer. That is what happened on #167.

The software can just report it.

## What it does

A diagnostics bundle now carries a `media_sample` section:

```json
"media_sample": {
  "available": true,
  "event_id": "1786898087.273197-5p93eu",
  "source": "media_cache",
  "bytes_read": 65536,
  "codec_tag": "hvc1",
  "codec": "hevc",
  "safari_compatible": true,
  "note": "hevc tagged hvc1."
}
```

`safari_compatible: false` names the cause. `codec: "h264"` rules the packaging out entirely, which is worth knowing before anyone touches Frigate config.

## Approach

The sample format is a four character code in the `moov` index, so a 64KB prefix is enough. It is read from the media cache when the clip is already there, and from a ranged request otherwise, so this never pulls a whole 4K clip.

Parsing is a pure function over bytes rather than a call out to `ffprobe`. The runtime image does not carry ffmpeg, a subprocess on a diagnostics path is worth avoiding, and every branch is reachable from a unit test.

## Hardening

- Box walking is bounded on depth, count and declared length, and a nonsense size advances by a header rather than spinning on the same offset.
- Handles 64-bit box headers, `size == 0` meaning "to end of file", and a `moov` that is not in the prefix because the clip was written without faststart.
- The event id comes back from Frigate and is then interpolated into a URL, so it is validated on the same terms the media proxy uses. Tested against traversal, query and fragment injection, whitespace and over-length input.
- Nothing can fail an export: every read swallows its own failure, the collector has a backstop, and an unreadable sample reports that it could not tell.
- An unrecognised format reports its tag with `safari_compatible: null`. Unknown is never rounded up to fine.

## Verification

Validated against a real 4K HEVC recording pulled from a live Frigate: reads `hvc1` from the first 32KB and agrees with `ffprobe` on the same file.

- `pytest` 1939 passed, 44 skipped (31 new)
- `ruff check .` / `ruff format --check .` clean from the repository root
- `npm run check` 0 errors, `npm test` 850 passed, `npm run build` clean
- `docs_consistency_check.py` passed, 173 routes
- OpenAPI artifact and generated frontend types regenerated and current

## Also

- New troubleshooting page, `docs/troubleshooting/safari-video-playback.md`, linked from the docs index. It covers the `hvc1` versus `hev1` distinction, how to read the bundle, and the two things about `apple_compatibility` that are easy to miss: it only affects recordings made after the restart, and a cached clip keeps its old packaging.
- Bundle schema version moved to `2026-08-15.owner-diagnostics-bundle.v2`.
- Fixed a duplicate `### Added` heading in the Unreleased changelog section, introduced by an earlier change of mine.

The probe is on the bundle only, not the workspace poll, which is fetched on every refresh and would be paying for a media read with no reader.