### PR TITLE
Acknowledge reviewed historical Gitleaks findings

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+757296437e3d7bdb33cea2e4d5391af5fc12f416:docs/api.md:curl-auth-header:41
+757296437e3d7bdb33cea2e4d5391af5fc12f416:docs/api.md:curl-auth-header:56
+ad3a30dec268fc72a9ce335fbd9fcf7b1f783478:docs/api.md:curl-auth-header:35
+ad3a30dec268fc72a9ce335fbd9fcf7b1f783478:docs/api.md:curl-auth-header:50
+4276d22719ceb29aa89425a590d87660eec64cb4:docs/api.md:curl-auth-header:27
+2e9f9545c642094807b71d90cee5713aa1acfe6c:backend/scripts/debug_mqtt.py:generic-api-key:8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The weekly secret scan now acknowledges six reviewed historical findings.** Five exact
+  fingerprints belong to documentation-only authorization examples, while the sixth belongs to
+  an MQTT credential removed in February 2026 and subsequently rotated. New or changed findings
+  continue to fail Gitleaks.
 - **Manual reclassification no longer rejects good fleeting sightings or applies unsafe weak
   replacements.** Retained recordings use Frigate boxes only at timestamps backed by `path_data`,
   so one stale box cannot repeatedly classify background after the bird has moved. A video


### PR DESCRIPTION
## Outcome

The weekly scheduled Gitleaks scan (failing since 2026-08-17) is acknowledged clean: a new `.gitleaksignore` suppresses the six findings by exact fingerprint.

## Scope

- Five findings are placeholder docs examples (`your-api-key`, `YOUR_JWT`) in historical revisions of `docs/api.md`.
- One finding is a credential for an internal LAN-only MQTT broker in a long-removed debug script (`backend/scripts/debug_mqtt.py`, commit `2e9f9545`); reviewed and accepted by the owner as non-sensitive.
- Suppression is per-commit fingerprint only — new or changed findings still fail the scan.

## Verification

- All six fingerprints match the failed scheduled run's output verbatim.
- The branch merges cleanly onto current `dev`; CI's PR-event secret scan is the gate.

## Notes

- The scheduled scan checks out `main`, so the Monday run stays red until a release promotes this file to `main`.
