### PR TITLE
Resolve eBird locales against the codes eBird publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Portuguese installations were getting English bird names from eBird.** eBird publishes its
+  locale codes with underscores and has no plain `pt`, so the regional fallback could never match
+  and every Portuguese lookup quietly resolved to English. Chinese resolved to a variant carrying a
+  quarter of the translated names of the one it should have used. Both now resolve correctly, and
+  an explicit regional choice such as `zh_HK` is still honoured.
+
 - **Guest sessions no longer poll owner-only endpoints into a wall of 403s.** A public visit
   repeated requests for `/api/settings` and camera status that the backend always refuses, filling
   the browser console and the server log with expected failures. Settings refresh and both camera

--- a/backend/app/services/ebird_service.py
+++ b/backend/app/services/ebird_service.py
@@ -25,6 +25,20 @@ def _normalize_name(value: str) -> str:
     return re.sub(r"\s+", " ", normalized).strip()
 
 
+#: Languages whose bare code eBird does not publish, or publishes far less
+#: completely than a regional variant. See
+#: docs/plans/2026-08-19-species-reference-source-decision.md for the figures.
+_PREFERRED_REGIONAL_LOCALE = {
+    "pt": "pt_BR",
+    "zh": "zh_SIM",
+}
+
+
+def _normalize_locale(value: str) -> str:
+    """One comparable form for codes written `pt_BR`, `pt-BR` or `PT-br`."""
+    return str(value or "").strip().replace("_", "-").lower()
+
+
 class EbirdService:
     def __init__(self) -> None:
         # Cache results per locale: {locale: {"fetched_at": datetime, "items": [], "index": {}}}
@@ -100,23 +114,41 @@ class EbirdService:
         return set(codes)
 
     async def resolve_locale(self, locale: Optional[str] = None) -> str:
-        requested = (locale or settings.ebird.locale or "en").strip().replace("_", "-")
-        if not requested:
-            requested = "en"
+        """Map a requested language onto the closest code eBird actually publishes.
+
+        eBird publishes codes with underscores (`pt_BR`), while requests arrive
+        with either separator, so everything is compared on one normalized form.
+        Some languages need a regional variant: `pt` is not published at all, and
+        `zh` carries far fewer translated names than `zh_SIM`. Figures are in
+        docs/plans/2026-08-19-species-reference-source-decision.md.
+        """
+        requested = _normalize_locale(locale or settings.ebird.locale or "en") or "en"
 
         supported = await self._get_supported_locales()
-        lower_map = {c.lower(): c for c in supported}
+        lower_map = {_normalize_locale(code): code for code in supported}
 
-        exact = lower_map.get(requested.lower())
+        lang = requested.split("-")[0]
+        preferred = lower_map.get(_normalize_locale(_PREFERRED_REGIONAL_LOCALE.get(lang, "")))
+
+        # A bare language with a preferred variant takes it. An explicit regional
+        # request is matched exactly below, so choosing `zh_HK` still works.
+        if requested == lang and preferred:
+            return preferred
+
+        exact = lower_map.get(requested)
         if exact:
             return exact
 
-        lang = requested.split("-")[0].lower()
+        # An unrecognised regional variant belongs with its language's preferred
+        # form rather than whichever region happens to sort first.
+        if preferred:
+            return preferred
+
         bare_lang = lower_map.get(lang)
         if bare_lang:
             return bare_lang
 
-        regional_matches = sorted(c for c in supported if c.lower().startswith(f"{lang}-"))
+        regional_matches = sorted(code for key, code in lower_map.items() if key.startswith(f"{lang}-"))
         if regional_matches:
             return regional_matches[0]
 

--- a/backend/tests/test_ebird_service.py
+++ b/backend/tests/test_ebird_service.py
@@ -47,3 +47,84 @@ async def test_resolve_species_code_matches_unicode_name(monkeypatch):
 
     code = await service.resolve_species_code("Чёрный дрозд", locale="ru")
     assert code == "tumeru"
+
+
+# ── Locale resolution ────────────────────────────────────────────────────────
+#
+# eBird publishes its locale codes with underscores (`pt_BR`, `zh_SIM`). Measured
+# against the live endpoint on 2026-08-19: `pt` is not a supported code at all,
+# and `zh` is supported but carries only 7.1% of names translated against
+# `zh_SIM`'s 30.8%.
+
+EBIRD_LOCALE_CODES = [
+    "en",
+    "de",
+    "es",
+    "fr",
+    "it",
+    "ja",
+    "ru",
+    "pt_AO",
+    "pt_BR",
+    "pt_PT",
+    "pt_RAA",
+    "pt_RAM",
+    "zh",
+    "zh_HK",
+    "zh_SIM",
+]
+
+
+@pytest.fixture
+def locale_service(monkeypatch):
+    from app.services.ebird_service import EbirdService
+
+    service = EbirdService()
+    monkeypatch.setattr(service, "is_configured", lambda: True)
+
+    async def supported():
+        return set(EBIRD_LOCALE_CODES)
+
+    monkeypatch.setattr(service, "_get_supported_locales", supported)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_portuguese_resolves_to_a_portuguese_locale_not_english(locale_service):
+    """`pt` is not an eBird code, so it used to fall through to English."""
+    assert await locale_service.resolve_locale("pt") == "pt_BR"
+
+
+@pytest.mark.asyncio
+async def test_chinese_resolves_to_the_variant_that_is_actually_translated(locale_service):
+    assert await locale_service.resolve_locale("zh") == "zh_SIM"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", ["de", "es", "fr", "it", "ja", "ru", "en"])
+async def test_a_language_ebird_supports_directly_is_left_alone(locale_service, code):
+    assert await locale_service.resolve_locale(code) == code
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_regional_choice_is_honoured(locale_service):
+    assert await locale_service.resolve_locale("pt_PT") == "pt_PT"
+    assert await locale_service.resolve_locale("zh_HK") == "zh_HK"
+
+
+@pytest.mark.asyncio
+async def test_a_hyphenated_request_matches_an_underscored_code(locale_service):
+    """Browsers and settings emit `pt-BR`; eBird publishes `pt_BR`."""
+    assert await locale_service.resolve_locale("pt-BR") == "pt_BR"
+    assert await locale_service.resolve_locale("ZH-sim") == "zh_SIM"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_regional_variant_falls_back_within_its_language(locale_service):
+    assert await locale_service.resolve_locale("pt_XX") == "pt_BR"
+
+
+@pytest.mark.asyncio
+async def test_an_unsupported_language_falls_back_to_english(locale_service):
+    assert await locale_service.resolve_locale("xx") == "en"
+    assert await locale_service.resolve_locale("") == "en"

--- a/docs/plans/2026-08-19-species-reference-source-decision.md
+++ b/docs/plans/2026-08-19-species-reference-source-decision.md
@@ -163,7 +163,24 @@ The Dockerfile already downloads that label file with a pinned sha256, so the in
 
 ### Still to do
 
-- Persist eBird taxonomy into `taxon_name` per locale, with `pt` mapped to `pt_BR` and `zh` to
-  `zh_SIM`, and a refresh policy.
+- Persist eBird taxonomy into `taxon_name` per locale, and a refresh policy. The locale mapping
+  itself is done: `resolve_locale` now compares underscored and hyphenated codes on one form and
+  prefers a regional variant where the bare code is absent or thinner. See below.
 - Decide the Italian and Chinese question.
 - The model-output-index mapping, if the roadmap keeps that criterion after the reconciliation above.
+
+
+### The locale mapping was a live bug, not just a gap
+
+`resolve_locale` normalized the *requested* locale from `pt_BR` to `pt-BR`, but compared it against
+eBird's published codes unchanged, which use underscores. Its regional fallback tested
+`code.startswith("pt-")` against values like `pt_AO`, so it could never match. eBird publishes no
+bare `pt` either, so a Portuguese installation fell through every branch to English and silently
+received English bird names.
+
+Chinese resolved to the supported but sparse `zh` rather than `zh_SIM`, which carries four times as
+many translated names.
+
+Both are fixed. Codes are compared on one normalized form, and a bare language with a thin or absent
+code takes its preferred regional variant. An explicit regional choice such as `zh_HK` is matched
+exactly and is unaffected.


### PR DESCRIPTION
A live bug found while measuring source coverage for the species catalogue (#218).

## The bug

**A Portuguese installation received English bird names, silently.**

`resolve_locale` normalized the *requested* locale from `pt_BR` to `pt-BR`, then compared it against eBird's published codes unchanged. Those use underscores. So the regional fallback tested `code.startswith("pt-")` against values like `pt_AO` and could never match. eBird publishes no bare `pt` either, so every branch fell through to English.

Chinese resolved to `zh`, which eBird does publish, but which carries **7.1%** of names translated against `zh_SIM`'s **30.8%**.

Nothing surfaced either case. The user picks Portuguese, eBird enrichment is on, and English names arrive with no error.

## The fix

- Codes are compared on one normalized form, so a hyphenated request matches an underscored code and the regional fallback works at all.
- A bare language whose code is absent or thin takes a preferred regional variant: `pt` to `pt_BR`, `zh` to `zh_SIM`.
- An unrecognised regional variant falls back to that same preferred form rather than whichever region sorts first, so `pt_XX` gives `pt_BR` and not `pt_AO`.
- An explicit regional choice is matched exactly first, so `zh_HK` still resolves to `zh_HK`.

## Verification

Checked against the 117 codes `/ref/taxa-locales/ebird` actually returns, with the translation percentages measured per locale in #218:

| App locale | Resolves to | Translated |
| --- | --- | ---: |
| `pt` | `pt_BR` | 100% (was English) |
| `zh` | `zh_SIM` | 30.8% (was 7.1%) |
| `de` / `es` / `fr` / `it` / `ja` / `ru` / `en` | unchanged | unchanged |

- `pytest` 2006 passed, 44 skipped (8 new)
- `ruff check .` / `ruff format --check .` clean from the repository root
- `docs_consistency_check.py` passed

The new tests use the real code list rather than an invented one, and cover the bare-language case, explicit regional choices, hyphen and case variation, an unknown regional variant, and an unsupported language.

## Scope

No schema change, no API change, no behaviour change for the six languages eBird supports directly. The preferred-variant map is two entries with the measurement recorded beside it, so a future locale can be added on evidence rather than guesswork.