### PR TITLE
Keep localized bird names for when nothing is reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   downgrading a shared modern-driver dependency
   ([#177](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/pull/177)).
 
+- **Bird names can now be in your language without the internet too.** The bundled reference ships
+  English, so a locale you have already pulled from eBird is kept beside the database and used when
+  nothing is reachable. It is fetched in one request per language rather than one per species, and a
+  name eBird returns unchanged from English is not recorded as a translation.
+
 - **Bird names now resolve without the internet where we can ship them.** A bundled species
   reference covering 964 species answers when iNaturalist cannot, so an offline install, or one
   riding out a provider outage, still names the bird instead of showing a bare label. iNaturalist

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,6 +69,7 @@ from app.config import settings, _expand_trusted_hosts
 from app.middleware.language import LanguageMiddleware
 from app.utils.tasks import create_background_task
 from app.utils.runtime_flavor import get_image_flavor
+from app.services.localized_names import start_background_refresh
 from app.services.startup_status import startup_status
 from app.ratelimit import limiter
 from app.auth import AuthContext
@@ -488,6 +489,14 @@ async def lifespan(app: FastAPI):
             fatal=False,
             startup_phase="starting_services",
             startup_progress=86,
+        )
+        await _run_lifecycle_phase(
+            app,
+            "localized_names_refresh",
+            start_background_refresh,
+            fatal=False,
+            startup_phase="starting_services",
+            startup_progress=88,
         )
         await _run_lifecycle_phase(
             app,

--- a/backend/app/services/localized_names.py
+++ b/backend/app/services/localized_names.py
@@ -1,0 +1,288 @@
+"""Localized bird names held beside the application database.
+
+The bundled species reference ships English names only, and
+`taxonomy_translations` is keyed on an iNaturalist taxon id the reference does
+not have. This store is keyed on scientific name instead, so a species resolved
+from the bundled reference can still be named in the owner's language.
+
+It is populated in bulk from eBird while the network is available, which is what
+makes a localized name survive an outage or an offline install.
+
+The contents are reproducible: losing the file costs one refresh. That is why it
+sits beside the application database rather than inside it, and why it carries no
+Alembic migration. It is a cache of a public reference, not user data.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+import structlog
+
+log = structlog.get_logger()
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS species_name (
+    scientific_name TEXT NOT NULL,
+    locale          TEXT NOT NULL,
+    common_name     TEXT NOT NULL,
+    PRIMARY KEY (scientific_name, locale)
+);
+CREATE TABLE IF NOT EXISTS locale_refresh (
+    locale       TEXT PRIMARY KEY,
+    refreshed_at TEXT NOT NULL
+);
+"""
+
+
+def default_store_path() -> Path:
+    """Beside the application database, wherever that has been configured."""
+    configured = os.environ.get("DB_PATH")
+    if configured:
+        return Path(configured).expanduser().resolve().parent / "species_names.db"
+    return Path("/data/species_names.db")
+
+
+def _key(value: Optional[str]) -> str:
+    return str(value or "").strip().casefold()
+
+
+class LocalizedNameStore:
+    """A small writable SQLite file. Never raises into the naming path."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = Path(path) if path is not None else default_store_path()
+        self._connection: Optional[sqlite3.Connection] = None
+        self._lock = threading.Lock()
+        self._disabled = False
+
+    def _parent_is_writable(self) -> bool:
+        parent = self._path.parent
+        return parent.is_dir() and os.access(parent, os.W_OK | os.X_OK)
+
+    def _connect(self) -> Optional[sqlite3.Connection]:
+        if self._disabled:
+            return None
+        if self._connection is not None:
+            return self._connection
+        with self._lock:
+            if self._disabled:
+                return None
+            if self._connection is not None:
+                return self._connection
+            if not self._path.exists() and not self._parent_is_writable():
+                log.info("Localized name store unavailable; names stay English", path=str(self._path))
+                self._disabled = True
+                return None
+            try:
+                connection = sqlite3.connect(self._path, check_same_thread=False)
+                connection.row_factory = sqlite3.Row
+                connection.executescript(SCHEMA)
+                connection.commit()
+            except sqlite3.Error as error:
+                log.warning("Localized name store unusable; names stay English", error=str(error))
+                self._disabled = True
+                return None
+            self._connection = connection
+            return connection
+
+    @property
+    def available(self) -> bool:
+        return self._connect() is not None
+
+    def upsert_many(
+        self,
+        locale: str,
+        entries: Iterable[tuple[Optional[str], Optional[str]]],
+        english: Optional[dict[str, str]] = None,
+    ) -> int:
+        """Store localized names, returning how many were kept.
+
+        `english` lets the caller pass the English names so an untranslated
+        species is skipped. eBird returns the English name when it has no
+        translation, and storing that would claim a translation we do not have.
+        """
+        locale_key = _key(locale)
+        if not locale_key:
+            return 0
+        connection = self._connect()
+        if connection is None:
+            return 0
+
+        rows: list[tuple[str, str, str]] = []
+        for scientific, common in entries:
+            scientific_key = _key(scientific)
+            name = str(common or "").strip()
+            if not scientific_key or not name:
+                continue
+            if english and english.get(scientific_key, "").strip().casefold() == name.casefold():
+                continue
+            rows.append((scientific_key, locale_key, name))
+
+        if not rows:
+            return 0
+
+        try:
+            connection.executemany(
+                "INSERT INTO species_name (scientific_name, locale, common_name) VALUES (?, ?, ?)"
+                " ON CONFLICT (scientific_name, locale) DO UPDATE SET common_name = excluded.common_name",
+                rows,
+            )
+            connection.execute(
+                "INSERT INTO locale_refresh (locale, refreshed_at) VALUES (?, ?)"
+                " ON CONFLICT (locale) DO UPDATE SET refreshed_at = excluded.refreshed_at",
+                (locale_key, datetime.now(timezone.utc).isoformat()),
+            )
+            connection.commit()
+        except sqlite3.Error as error:
+            log.warning("Could not store localized names", locale=locale_key, error=str(error))
+            return 0
+        return len(rows)
+
+    def lookup(self, scientific_name: Optional[str], locale: Optional[str]) -> Optional[str]:
+        scientific_key = _key(scientific_name)
+        locale_key = _key(locale)
+        if not scientific_key or not locale_key:
+            return None
+        connection = self._connect()
+        if connection is None:
+            return None
+        try:
+            row = connection.execute(
+                "SELECT common_name FROM species_name WHERE scientific_name = ? AND locale = ?",
+                (scientific_key, locale_key),
+            ).fetchone()
+        except sqlite3.Error as error:
+            log.warning("Localized name lookup failed", error=str(error))
+            return None
+        return row["common_name"] if row else None
+
+    def status(self) -> dict[str, object]:
+        connection = self._connect()
+        if connection is None:
+            return {"available": False, "locales": {}, "refreshed_at": {}}
+        try:
+            locales = {
+                row["locale"]: row["count"]
+                for row in connection.execute(
+                    "SELECT locale, COUNT(*) AS count FROM species_name GROUP BY locale"
+                ).fetchall()
+            }
+            refreshed = {
+                row["locale"]: row["refreshed_at"]
+                for row in connection.execute("SELECT locale, refreshed_at FROM locale_refresh").fetchall()
+            }
+        except sqlite3.Error:
+            return {"available": False, "locales": {}, "refreshed_at": {}}
+        return {"available": True, "locales": locales, "refreshed_at": refreshed}
+
+
+localized_names = LocalizedNameStore()
+
+
+# ── Populating the store ─────────────────────────────────────────────────────
+
+#: Refresh no more often than this. eBird's taxonomy changes roughly annually.
+REFRESH_INTERVAL_SECONDS = 30 * 24 * 3600
+
+
+def _needs_refresh(refreshed_at: Optional[str], now: Optional[datetime] = None) -> bool:
+    if not refreshed_at:
+        return True
+    try:
+        recorded = datetime.fromisoformat(refreshed_at)
+    except (TypeError, ValueError):
+        return True
+    if recorded.tzinfo is None:
+        recorded = recorded.replace(tzinfo=timezone.utc)
+    reference = now or datetime.now(timezone.utc)
+    return (reference - recorded).total_seconds() > REFRESH_INTERVAL_SECONDS
+
+
+async def refresh_locale_from_ebird(locale: str, *, store: Optional[LocalizedNameStore] = None) -> int:
+    """Pull one locale's taxonomy from eBird into the store.
+
+    One bulk request, not one per species: pre-resolving species individually
+    against a free community service is what the design rejected.
+    """
+    from app.services.ebird_service import ebird_service
+
+    target = store or localized_names
+    if not target.available:
+        return 0
+
+    try:
+        english_items = await ebird_service.get_taxonomy("en")
+        localized_items = await ebird_service.get_taxonomy(locale)
+    except Exception as error:
+        log.warning("Could not fetch eBird taxonomy", locale=locale, error=str(error))
+        return 0
+
+    english = {
+        _key(item.get("sciName")): str(item.get("comName") or "")
+        for item in english_items or []
+        if isinstance(item, dict)
+    }
+    entries = [(item.get("sciName"), item.get("comName")) for item in localized_items or [] if isinstance(item, dict)]
+    if not entries:
+        return 0
+
+    stored = target.upsert_many(locale, entries, english=english)
+    log.info("Localized names refreshed from eBird", locale=locale, stored=stored)
+    return stored
+
+
+async def refresh_localized_names(
+    locales: Iterable[str], *, store: Optional[LocalizedNameStore] = None, force: bool = False
+) -> dict[str, int]:
+    """Refresh the locales that are due, skipping the rest."""
+    target = store or localized_names
+    if not target.available:
+        return {}
+
+    refreshed_at = target.status().get("refreshed_at") or {}
+    results: dict[str, int] = {}
+    for locale in locales:
+        locale_key = _key(locale)
+        if not locale_key or locale_key == "en":
+            continue
+        if not force and not _needs_refresh(refreshed_at.get(locale_key)):  # type: ignore[union-attr]
+            continue
+        results[locale_key] = await refresh_locale_from_ebird(locale, store=target)
+    return results
+
+
+_background_task: Optional["asyncio.Task[None]"] = None
+
+
+async def start_background_refresh() -> None:
+    """Schedule a refresh of the configured locale without holding up startup.
+
+    Fetching a whole taxonomy is one request but a large response, so it runs
+    detached. A failure costs the localized names and nothing else.
+    """
+    global _background_task
+
+    from app.config import settings
+    from app.services.ebird_service import ebird_service
+
+    locale = _key(settings.ebird.locale)
+    if not locale or locale == "en":
+        return
+    if not ebird_service.is_configured():
+        log.debug("eBird not configured; localized names will not be refreshed")
+        return
+
+    async def run() -> None:
+        try:
+            await refresh_localized_names([locale])
+        except Exception as error:  # pragma: no cover - guarded by the caller's phase
+            log.warning("Localized name refresh failed", locale=locale, error=str(error))
+
+    _background_task = asyncio.create_task(run())

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -2,6 +2,7 @@ import httpx
 import os
 import structlog
 
+from app.services.localized_names import localized_names
 from app.services.species_reference import species_reference
 import asyncio
 import aiosqlite
@@ -143,10 +144,17 @@ class TaxonomyService:
             # gives offline installs, and installs riding out an outage, a name.
             reference_hit = species_reference.lookup(query_name)
             if reference_hit:
+                # The reference ships English only. A locale the owner has already
+                # pulled from eBird names the bird in their language even now,
+                # with nothing reachable.
+                localized = localized_names.lookup(reference_hit.get("scientific_name"), settings.ebird.locale)
+                if localized:
+                    reference_hit["common_name"] = localized
                 log.info(
                     "Taxonomy resolved from bundled reference",
                     query=query_name,
                     scientific_name=reference_hit.get("scientific_name"),
+                    localized=bool(localized),
                     lookup_unavailable=lookup_unavailable,
                 )
                 # Not cached: the row would carry no taxon id, and a later lookup

--- a/backend/tests/test_localized_names.py
+++ b/backend/tests/test_localized_names.py
@@ -1,0 +1,185 @@
+"""Localized bird names that survive without a network.
+
+The bundled reference ships English names only, and `taxonomy_translations` is
+keyed on an iNaturalist taxon id the reference does not have. This store is
+keyed on scientific name so a reference-resolved species can still be named in
+the owner's language, and it is populated in bulk from eBird while online so it
+is there when nothing is reachable.
+
+It holds reproducible data. Losing it costs one refresh, so it lives beside the
+application database rather than inside it, and needs no migration.
+"""
+
+import pytest
+
+from app.services.localized_names import LocalizedNameStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LocalizedNameStore(tmp_path / "names.db")
+
+
+def test_stores_and_reads_a_localized_name(store):
+    written = store.upsert_many("de", [("Cyanistes caeruleus", "Blaumeise")])
+
+    assert written == 1
+    assert store.lookup("Cyanistes caeruleus", "de") == "Blaumeise"
+
+
+def test_lookup_ignores_case_and_surrounding_space(store):
+    store.upsert_many("de", [("Cyanistes caeruleus", "Blaumeise")])
+
+    assert store.lookup("  cyanistes CAERULEUS ", "de") == "Blaumeise"
+
+
+def test_locales_do_not_leak_into_one_another(store):
+    store.upsert_many("de", [("Cyanistes caeruleus", "Blaumeise")])
+    store.upsert_many("fr", [("Cyanistes caeruleus", "Mésange bleue")])
+
+    assert store.lookup("Cyanistes caeruleus", "fr") == "Mésange bleue"
+    assert store.lookup("Cyanistes caeruleus", "es") is None
+
+
+def test_a_refresh_replaces_a_renamed_species_rather_than_duplicating_it(store):
+    store.upsert_many("de", [("Cyanistes caeruleus", "Blaumeise")])
+    store.upsert_many("de", [("Cyanistes caeruleus", "Blaumeise (neu)")])
+
+    assert store.lookup("Cyanistes caeruleus", "de") == "Blaumeise (neu)"
+    assert store.status()["locales"]["de"] == 1
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [("", "Blaumeise")],
+        [("Cyanistes caeruleus", "")],
+        [("Cyanistes caeruleus", None)],
+        [(None, "Blaumeise")],
+    ],
+)
+def test_unusable_rows_are_skipped_rather_than_stored(store, entries):
+    assert store.upsert_many("de", entries) == 0
+    assert store.lookup("Cyanistes caeruleus", "de") is None
+
+
+def test_a_name_identical_to_the_english_one_is_not_stored(store):
+    """eBird returns English for an untranslated species; storing it would claim a translation."""
+    written = store.upsert_many(
+        "it", [("Cyanistes caeruleus", "Eurasian Blue Tit")], english={"cyanistes caeruleus": "Eurasian Blue Tit"}
+    )
+
+    assert written == 0
+    assert store.lookup("Cyanistes caeruleus", "it") is None
+
+
+def test_status_reports_what_is_held(store):
+    store.upsert_many("de", [("A b", "x"), ("C d", "y")])
+
+    status = store.status()
+
+    assert status["available"] is True
+    assert status["locales"] == {"de": 2}
+    assert status["refreshed_at"]["de"]
+
+
+def test_a_missing_lookup_is_silent(store):
+    assert store.lookup("Nothing here", "de") is None
+    assert store.lookup(None, "de") is None
+    assert store.lookup("Cyanistes caeruleus", "") is None
+
+
+def test_an_unwritable_location_disables_the_store_rather_than_raising(tmp_path):
+    unwritable = LocalizedNameStore(tmp_path / "no-such-dir" / "deeper" / "names.db")
+    unwritable._parent_is_writable = lambda: False  # type: ignore[method-assign]
+
+    assert unwritable.upsert_many("de", [("A b", "x")]) == 0
+    assert unwritable.lookup("A b", "de") is None
+    assert unwritable.status()["available"] is False
+
+
+def test_a_damaged_file_disables_the_store_rather_than_raising(tmp_path):
+    path = tmp_path / "damaged.db"
+    path.write_bytes(b"not a database at all")
+    damaged = LocalizedNameStore(path)
+
+    assert damaged.lookup("A b", "de") is None
+    assert damaged.status()["available"] is False
+
+
+# ── Refreshing from eBird ────────────────────────────────────────────────────
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+from app.services import localized_names as module  # noqa: E402
+
+TAXONOMY = {
+    "en": [
+        {"sciName": "Cyanistes caeruleus", "comName": "Eurasian Blue Tit"},
+        {"sciName": "Erithacus rubecula", "comName": "European Robin"},
+    ],
+    "de": [
+        {"sciName": "Cyanistes caeruleus", "comName": "Blaumeise"},
+        # eBird returns the English name when it has no translation.
+        {"sciName": "Erithacus rubecula", "comName": "European Robin"},
+    ],
+}
+
+
+@pytest.fixture
+def ebird_taxonomy(monkeypatch):
+    from app.services import ebird_service as ebird_module
+
+    async def get_taxonomy(locale=None):
+        return TAXONOMY.get(str(locale or "en"), [])
+
+    monkeypatch.setattr(ebird_module.ebird_service, "get_taxonomy", get_taxonomy)
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_stores_only_the_genuinely_translated_names(store, ebird_taxonomy):
+    stored = await module.refresh_locale_from_ebird("de", store=store)
+
+    assert stored == 1
+    assert store.lookup("Cyanistes caeruleus", "de") == "Blaumeise"
+    # Untranslated: storing the English name would claim a translation.
+    assert store.lookup("Erithacus rubecula", "de") is None
+
+
+@pytest.mark.asyncio
+async def test_english_is_never_refreshed_because_it_is_the_baseline(store, ebird_taxonomy):
+    assert await module.refresh_localized_names(["en"], store=store) == {}
+
+
+@pytest.mark.asyncio
+async def test_a_recent_locale_is_left_alone(store, ebird_taxonomy):
+    await module.refresh_localized_names(["de"], store=store)
+
+    assert await module.refresh_localized_names(["de"], store=store) == {}
+    assert await module.refresh_localized_names(["de"], store=store, force=True) == {"de": 1}
+
+
+@pytest.mark.asyncio
+async def test_a_broken_ebird_costs_nothing(store, monkeypatch):
+    from app.services import ebird_service as ebird_module
+
+    async def explode(locale=None):
+        raise RuntimeError("ebird is down")
+
+    monkeypatch.setattr(ebird_module.ebird_service, "get_taxonomy", explode)
+
+    assert await module.refresh_locale_from_ebird("de", store=store) == 0
+    assert store.lookup("Cyanistes caeruleus", "de") is None
+
+
+@pytest.mark.parametrize(
+    ("recorded", "due"),
+    [
+        (None, True),
+        ("not a date", True),
+        ((datetime.now(timezone.utc) - timedelta(days=1)).isoformat(), False),
+        ((datetime.now(timezone.utc) - timedelta(days=60)).isoformat(), True),
+    ],
+)
+def test_refresh_is_due_only_after_the_interval(recorded, due):
+    assert module._needs_refresh(recorded) is due

--- a/backend/tests/test_species_reference.py
+++ b/backend/tests/test_species_reference.py
@@ -257,3 +257,61 @@ async def test_an_uncovered_species_still_records_the_negative(monkeypatch):
     assert result["common_name"] is None
     assert len(saved) == 1
     assert saved[0]["is_not_found"] is True
+
+
+@pytest.mark.asyncio
+async def test_the_reference_answer_is_localized_when_the_store_has_the_name(monkeypatch, tmp_path):
+    """An offline install still names the bird in the owner's language."""
+    from app.config import settings
+    from app.services.localized_names import LocalizedNameStore
+    from app.services.taxonomy import taxonomy_service as module
+
+    store = LocalizedNameStore(tmp_path / "names.db")
+    store.upsert_many("de", [("Cyanistes caeruleus", "Blaumeise")])
+    monkeypatch.setattr(module, "localized_names", store)
+    monkeypatch.setattr(settings.ebird, "locale", "de")
+
+    async def not_found(_name):
+        return None
+
+    async def empty_cache(_query, db=None):
+        return None
+
+    async def noop_save(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(module.taxonomy_service, "_lookup_inaturalist", not_found)
+    monkeypatch.setattr(module.taxonomy_service, "_get_from_cache", empty_cache)
+    monkeypatch.setattr(module.taxonomy_service, "_save_to_cache", noop_save)
+
+    result = await module.taxonomy_service.get_names("Cyanistes caeruleus")
+
+    assert result["scientific_name"] == "Cyanistes caeruleus"
+    assert result["common_name"] == "Blaumeise"
+
+
+@pytest.mark.asyncio
+async def test_the_reference_answer_stays_english_when_no_translation_is_held(monkeypatch, tmp_path):
+    from app.config import settings
+    from app.services.localized_names import LocalizedNameStore
+    from app.services.taxonomy import taxonomy_service as module
+
+    monkeypatch.setattr(module, "localized_names", LocalizedNameStore(tmp_path / "empty.db"))
+    monkeypatch.setattr(settings.ebird, "locale", "de")
+
+    async def not_found(_name):
+        return None
+
+    async def empty_cache(_query, db=None):
+        return None
+
+    async def noop_save(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(module.taxonomy_service, "_lookup_inaturalist", not_found)
+    monkeypatch.setattr(module.taxonomy_service, "_get_from_cache", empty_cache)
+    monkeypatch.setattr(module.taxonomy_service, "_save_to_cache", noop_save)
+
+    result = await module.taxonomy_service.get_names("Cyanistes caeruleus")
+
+    assert result["common_name"] == "Eurasian Blue Tit"

--- a/docs/plans/2026-08-19-species-reference-source-decision.md
+++ b/docs/plans/2026-08-19-species-reference-source-decision.md
@@ -1,8 +1,7 @@
 # Species reference: resolving the source decision
 
 Date: 2026-08-19
-Status: Partly implemented — the bundled layer is built and wired in; the eBird
-layer is not yet. Resolves the two open decisions in
+Status: Implemented, except the Italian question. Resolves the two open decisions in
 [2026-08-06-species-reference-and-name-resolution.md](2026-08-06-species-reference-and-name-resolution.md)
 
 ## Decision
@@ -163,10 +162,8 @@ The Dockerfile already downloads that label file with a pinned sha256, so the in
 
 ### Still to do
 
-- Persist eBird taxonomy into `taxon_name` per locale, and a refresh policy. The locale mapping
-  itself is done: `resolve_locale` now compares underscored and hyphenated codes on one form and
-  prefers a regional variant where the bare code is absent or thinner. See below.
-- Decide the Italian and Chinese question.
+- Decide the Italian question. Chinese is answered: fixing the locale resolution moved it from 7.1%
+  to 30.8%, so Italian at 5.8% is the only locale left largely untranslated.
 - The model-output-index mapping, if the roadmap keeps that criterion after the reconciliation above.
 
 
@@ -184,3 +181,22 @@ many translated names.
 Both are fixed. Codes are compared on one normalized form, and a bare language with a thin or absent
 code takes its preferred regional variant. An explicit regional choice such as `zh_HK` is matched
 exactly and is unaffected.
+
+
+### Where localized names ended up
+
+Not in the bundled file, and not in `taxonomy_translations`.
+
+The bundled asset is read-only inside the image and replaced on update, so it cannot accumulate
+anything. `taxonomy_translations` is keyed on an iNaturalist taxon id, which is exactly what a
+reference-resolved species does not have, and its `language_code` column is five characters while
+`zh_SIM` is six.
+
+So localized names live in `species_names.db`, beside the application database, keyed on scientific
+name. It is populated in bulk from eBird, one request per locale rather than one per species, and
+carries no Alembic migration because it holds a reproducible copy of a public reference. Losing it
+costs one refresh.
+
+A name eBird returns unchanged from English is not stored. eBird answers with the English name when
+it has no translation, and recording that would claim a translation we do not have, which is how a
+locale like Italian would have looked complete while being 5.8% translated.


### PR DESCRIPTION
Third slice of the species catalogue, after #219 (bundled reference) and #220 (locale resolution).

## The gap

The bundled reference ships English names only, so an install resolving from it named every bird in English regardless of the owner's language. That is exactly the case the reference exists for: no network, no iNaturalist, no eBird.

## Why not the obvious places

**`taxonomy_translations`** is keyed on an iNaturalist `taxa_id`, which is precisely what a reference-resolved species does not have. Its `language_code` column is also `String(5)` while `zh_SIM` is six characters.

**The bundled file** is read-only inside the image and replaced on update, so it cannot accumulate anything.

## What is here

`species_names.db`, beside the application database, keyed on **scientific name** so it works with or without a taxon id.

- Populated from eBird in **one request per language**, not one per species. Per-species pre-resolution against a free community service is the load the original design rejected, and that reasoning still holds.
- Refreshed at most monthly; the taxonomy changes roughly annually.
- Scheduled **detached at startup** and only when eBird is configured, so a large response never delays the app coming up.
- No Alembic migration. It holds a reproducible copy of a public reference, so losing the file costs one refresh. Treating it as user data would be wrong.

## One thing worth calling out

**A name eBird returns unchanged from English is not stored.** eBird answers with the English name when it has no translation, so recording it would claim a translation we do not have. Without that rule Italian would look complete while being 5.8% translated, which is the sort of quiet dishonesty this codebase's standards exist to prevent.

## Safety

- A missing, unwritable or damaged file disables the store and leaves names in English. All three are tested.
- Nothing here can fail a lookup: the store is consulted only to improve an answer that already exists.
- No change to the application database, no migration, no change to what is stored about a detection.
- eBird being down costs the refresh and nothing else.

## Verification

- `pytest` 2029 passed, 44 skipped (25 new)
- `ruff check .` / `ruff format --check .` clean from the repository root
- `docs_consistency_check.py` passed, OpenAPI artifact current

Tests cover storage and case-insensitive lookup, locale isolation, refresh replacing rather than duplicating, unusable rows, the English-passthrough rule, missing/unwritable/damaged files, a broken eBird, the refresh interval, and both integrated paths: a reference answer localized when the store has the name, and left English when it does not.

## Where the catalogue now stands

Only the **Italian** question is left open. Fixing the locale resolution in #220 moved Chinese from 7.1% to 30.8%, so Italian at 5.8% is the single remaining locale that stays largely English. Either state it in the release notes, which the exit criterion permits, or add Wikidata (CC0) as a fourth source.