### PR TITLE
Harden the species reference against real model label sets

### DIFF
--- a/backend/app/services/localized_names.py
+++ b/backend/app/services/localized_names.py
@@ -60,6 +60,9 @@ class LocalizedNameStore:
         self._path = Path(path) if path is not None else default_store_path()
         self._connection: Optional[sqlite3.Connection] = None
         self._lock = threading.Lock()
+        # sqlite3 connections are not safe for concurrent use, and this one is
+        # shared: read from the event path, written by the refresh task.
+        self._access = threading.Lock()
         self._disabled = False
 
     def _parent_is_writable(self) -> bool:
@@ -129,17 +132,18 @@ class LocalizedNameStore:
             return 0
 
         try:
-            connection.executemany(
-                "INSERT INTO species_name (scientific_name, locale, common_name) VALUES (?, ?, ?)"
-                " ON CONFLICT (scientific_name, locale) DO UPDATE SET common_name = excluded.common_name",
-                rows,
-            )
-            connection.execute(
-                "INSERT INTO locale_refresh (locale, refreshed_at) VALUES (?, ?)"
-                " ON CONFLICT (locale) DO UPDATE SET refreshed_at = excluded.refreshed_at",
-                (locale_key, datetime.now(timezone.utc).isoformat()),
-            )
-            connection.commit()
+            with self._access:
+                connection.executemany(
+                    "INSERT INTO species_name (scientific_name, locale, common_name) VALUES (?, ?, ?)"
+                    " ON CONFLICT (scientific_name, locale) DO UPDATE SET common_name = excluded.common_name",
+                    rows,
+                )
+                connection.execute(
+                    "INSERT INTO locale_refresh (locale, refreshed_at) VALUES (?, ?)"
+                    " ON CONFLICT (locale) DO UPDATE SET refreshed_at = excluded.refreshed_at",
+                    (locale_key, datetime.now(timezone.utc).isoformat()),
+                )
+                connection.commit()
         except sqlite3.Error as error:
             log.warning("Could not store localized names", locale=locale_key, error=str(error))
             return 0
@@ -154,10 +158,11 @@ class LocalizedNameStore:
         if connection is None:
             return None
         try:
-            row = connection.execute(
-                "SELECT common_name FROM species_name WHERE scientific_name = ? AND locale = ?",
-                (scientific_key, locale_key),
-            ).fetchone()
+            with self._access:
+                row = connection.execute(
+                    "SELECT common_name FROM species_name WHERE scientific_name = ? AND locale = ?",
+                    (scientific_key, locale_key),
+                ).fetchone()
         except sqlite3.Error as error:
             log.warning("Localized name lookup failed", error=str(error))
             return None
@@ -168,16 +173,17 @@ class LocalizedNameStore:
         if connection is None:
             return {"available": False, "locales": {}, "refreshed_at": {}}
         try:
-            locales = {
-                row["locale"]: row["count"]
-                for row in connection.execute(
-                    "SELECT locale, COUNT(*) AS count FROM species_name GROUP BY locale"
-                ).fetchall()
-            }
-            refreshed = {
-                row["locale"]: row["refreshed_at"]
-                for row in connection.execute("SELECT locale, refreshed_at FROM locale_refresh").fetchall()
-            }
+            with self._access:
+                locales = {
+                    row["locale"]: row["count"]
+                    for row in connection.execute(
+                        "SELECT locale, COUNT(*) AS count FROM species_name GROUP BY locale"
+                    ).fetchall()
+                }
+                refreshed = {
+                    row["locale"]: row["refreshed_at"]
+                    for row in connection.execute("SELECT locale, refreshed_at FROM locale_refresh").fetchall()
+                }
         except sqlite3.Error:
             return {"available": False, "locales": {}, "refreshed_at": {}}
         return {"available": True, "locales": locales, "refreshed_at": refreshed}
@@ -227,9 +233,16 @@ async def refresh_locale_from_ebird(locale: str, *, store: Optional[LocalizedNam
     english = {
         _key(item.get("sciName")): str(item.get("comName") or "")
         for item in english_items or []
-        if isinstance(item, dict)
+        if isinstance(item, dict) and str(item.get("category") or "species") == "species"
     }
-    entries = [(item.get("sciName"), item.get("comName")) for item in localized_items or [] if isinstance(item, dict)]
+    # get_taxonomy also requests issf, spuh and slash forms. A subspecies, a
+    # "duck sp." or an "A/B" pair is not a species, and storing one would offer a
+    # name for something the classifier can never emit.
+    entries = [
+        (item.get("sciName"), item.get("comName"))
+        for item in localized_items or []
+        if isinstance(item, dict) and str(item.get("category") or "species") == "species"
+    ]
     if not entries:
         return 0
 

--- a/backend/app/services/species_reference.py
+++ b/backend/app/services/species_reference.py
@@ -53,6 +53,9 @@ class SpeciesReference:
         self._path = path
         self._connection: Optional[sqlite3.Connection] = None
         self._lock = threading.Lock()
+        # sqlite3 connections are not safe for concurrent use, and this one is
+        # shared by every caller resolving a name.
+        self._access = threading.Lock()
         self._disabled = False
 
     @property
@@ -113,12 +116,13 @@ class SpeciesReference:
 
         try:
             for candidate in self._candidates(query_name):
-                row = connection.execute(
-                    "SELECT scientific_name, common_name FROM taxon"
-                    " WHERE scientific_name = ? COLLATE NOCASE"
-                    " OR common_name = ? COLLATE NOCASE LIMIT 1",
-                    (candidate, candidate),
-                ).fetchone()
+                with self._access:
+                    row = connection.execute(
+                        "SELECT scientific_name, common_name FROM taxon"
+                        " WHERE scientific_name = ? COLLATE NOCASE"
+                        " OR common_name = ? COLLATE NOCASE LIMIT 1",
+                        (candidate, candidate),
+                    ).fetchone()
                 if row:
                     return {
                         "scientific_name": row["scientific_name"],
@@ -138,10 +142,11 @@ class SpeciesReference:
         if connection is None:
             return {"available": False, "taxon_count": 0, "schema_version": None, "source": None}
         try:
-            meta = {
-                row["key"]: row["value"]
-                for row in connection.execute("SELECT key, value FROM reference_meta").fetchall()
-            }
+            with self._access:
+                meta = {
+                    row["key"]: row["value"]
+                    for row in connection.execute("SELECT key, value FROM reference_meta").fetchall()
+                }
         except sqlite3.Error:
             meta = {}
         try:

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -1,11 +1,12 @@
-import httpx
+import asyncio
 import os
+
+import aiosqlite
+import httpx
 import structlog
 
 from app.services.localized_names import localized_names
 from app.services.species_reference import species_reference
-import asyncio
-import aiosqlite
 from typing import Any, Optional, Dict
 from datetime import datetime
 from app.database import get_db
@@ -142,7 +143,8 @@ class TaxonomyService:
             # taxon id, so resolving from it first would cost enrichment the id it
             # needs for every covered species. Placed here it costs nothing and
             # gives offline installs, and installs riding out an outage, a name.
-            reference_hit = species_reference.lookup(query_name)
+            # Local SQLite reads, so off the event loop (CLAUDE.md 4).
+            reference_hit = await asyncio.to_thread(species_reference.lookup, query_name)
             if reference_hit:
                 # The reference ships English only. A locale the owner has already
                 # pulled from eBird names the bird in their language even now,

--- a/backend/tests/test_localized_names.py
+++ b/backend/tests/test_localized_names.py
@@ -183,3 +183,81 @@ async def test_a_broken_ebird_costs_nothing(store, monkeypatch):
 )
 def test_refresh_is_due_only_after_the_interval(recorded, due):
     assert module._needs_refresh(recorded) is due
+
+
+# ── Hardening ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_only_real_species_are_stored(store, monkeypatch):
+    """get_taxonomy asks for issf, spuh and slash forms too; those are not species."""
+    from app.services import ebird_service as ebird_module
+
+    async def get_taxonomy(locale=None):
+        if str(locale or "en") == "en":
+            return [
+                {"sciName": "Anas platyrhynchos", "comName": "Mallard", "category": "species"},
+                {"sciName": "Anas platyrhynchos/rubripes", "comName": "Mallard/Black Duck", "category": "slash"},
+                {"sciName": "Anas sp.", "comName": "duck sp.", "category": "spuh"},
+                {"sciName": "Anas platyrhynchos domesticus", "comName": "Domestic Mallard", "category": "issf"},
+            ]
+        return [
+            {"sciName": "Anas platyrhynchos", "comName": "Stockente", "category": "species"},
+            {"sciName": "Anas platyrhynchos/rubripes", "comName": "Stockente/Dunkelente", "category": "slash"},
+            {"sciName": "Anas sp.", "comName": "Ente sp.", "category": "spuh"},
+            {"sciName": "Anas platyrhynchos domesticus", "comName": "Hausente", "category": "issf"},
+        ]
+
+    monkeypatch.setattr(ebird_module.ebird_service, "get_taxonomy", get_taxonomy)
+
+    stored = await module.refresh_locale_from_ebird("de", store=store)
+
+    assert stored == 1
+    assert store.lookup("Anas platyrhynchos", "de") == "Stockente"
+    assert store.lookup("Anas platyrhynchos/rubripes", "de") is None
+    assert store.lookup("Anas sp.", "de") is None
+
+
+@pytest.mark.asyncio
+async def test_an_entry_with_no_category_is_still_accepted(store, monkeypatch):
+    """Not every caller or fixture carries the field; absence must not empty the store."""
+    from app.services import ebird_service as ebird_module
+
+    async def get_taxonomy(locale=None):
+        name = "Blaumeise" if str(locale or "en") != "en" else "Eurasian Blue Tit"
+        return [{"sciName": "Cyanistes caeruleus", "comName": name}]
+
+    monkeypatch.setattr(ebird_module.ebird_service, "get_taxonomy", get_taxonomy)
+
+    assert await module.refresh_locale_from_ebird("de", store=store) == 1
+
+
+def test_concurrent_readers_and_writers_do_not_trip_over_the_connection(store):
+    """One connection is shared, so access has to be serialized."""
+    import threading
+
+    store.upsert_many("de", [(f"Genus species{i}", f"Name {i}") for i in range(50)])
+    errors: list[BaseException] = []
+
+    def read() -> None:
+        try:
+            for i in range(200):
+                store.lookup(f"Genus species{i % 50}", "de")
+        except BaseException as error:  # noqa: BLE001 - recorded for the assertion
+            errors.append(error)
+
+    def write() -> None:
+        try:
+            for i in range(50):
+                store.upsert_many("fr", [(f"Genus species{i}", f"Nom {i}")])
+        except BaseException as error:  # noqa: BLE001
+            errors.append(error)
+
+    threads = [threading.Thread(target=read) for _ in range(4)] + [threading.Thread(target=write) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert store.lookup("Genus species7", "fr") == "Nom 7"

--- a/backend/tests/test_species_reference.py
+++ b/backend/tests/test_species_reference.py
@@ -315,3 +315,29 @@ async def test_the_reference_answer_stays_english_when_no_translation_is_held(mo
     result = await module.taxonomy_service.get_names("Cyanistes caeruleus")
 
     assert result["common_name"] == "Eurasian Blue Tit"
+
+
+def test_concurrent_lookups_share_one_connection_safely():
+    """The reference is read from the event path; a shared connection needs serializing."""
+    import threading
+
+    if not species_reference.available:
+        pytest.skip("bundled reference not present in this checkout")
+
+    errors: list[BaseException] = []
+
+    def read() -> None:
+        try:
+            for _ in range(200):
+                species_reference.lookup("Haemorhous cassinii")
+                species_reference.lookup("Nothing at all")
+        except BaseException as error:  # noqa: BLE001
+            errors.append(error)
+
+    threads = [threading.Thread(target=read) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []

--- a/docs/plans/2026-08-19-species-reference-source-decision.md
+++ b/docs/plans/2026-08-19-species-reference-source-decision.md
@@ -200,3 +200,39 @@ costs one refresh.
 A name eBird returns unchanged from English is not stored. eBird answers with the English name when
 it has no translation, and recording that would claim a translation we do not have, which is how a
 locale like Italian would have looked complete while being 5.8% translated.
+
+
+## What the bundled reference does and does not do
+
+**It does not replace model label files.** The classifier loads `labels.txt` and indexes into it to
+turn an output index into label text; the reference takes that text and resolves names from it. Both
+are needed, and the reference cannot remove the label file while it keys on text.
+
+That matters for the 3.0 exit criterion, which asks for names "without requiring model label text
+files at runtime". Meeting it as written needs the output-index mapping this document recommends
+dropping. The two positions are still unreconciled in `ROADMAP.md`, and that is a release-scope call.
+
+### Measured resolution per model
+
+Against the committed reference, using label files from a live deployment:
+
+| Model | Labels | Resolved | Rate |
+| --- | ---: | ---: | ---: |
+| `rope_vit_b14_inat21` | 10,000 | 860 | 8.6% of all, 57.9% of its 1,486 birds |
+| `convnext_large_inat21` | 10,000 | 860 | as above |
+| `eva02_large_inat21` | 10,000 | 860 | as above |
+| `mobilenet_v2_birds` | 965 | 964 | 99.9% |
+| `flexivit_il_all` | 550 | 178 | 32.4% |
+| `eu_medium_focalnet_b` | 707 | 234 | 33.1% |
+| `uniformer_s_eu_common` | 707 | 234 | 33.1% |
+
+**The European models get the least from it.** The bundled source is Google Coral's bird set, which
+leans North American, so labels like `African blue tit`, `Algerian nuthatch` and `Arabian babbler`
+are simply absent. Those installs depend on eBird and iNaturalist as before. This is a property of
+the only permissively licensed source available, not of the matching.
+
+### Correctness checks
+
+- No duplicate common names in the reference, so a common-name match cannot resolve ambiguously.
+- All 8,514 non-bird labels in the iNat model were checked against the reference: **none** resolves
+  to a bird. A moth cannot be named a finch.


### PR DESCRIPTION
Review of #219 and #221 against every installed model's real label file, rather than fixtures.

## Does this replace model label files?

**No, and it cannot while it keys on label text.** The classifier loads `labels.txt` and indexes into it to turn output index 4815 into label text; the reference takes that text and resolves names. Both are needed.

That matters, because the 3.0 exit criterion asks for names "without requiring model label text files at runtime". Meeting it as written needs the **output-index mapping** that #218 recommended dropping. Those two positions are still unreconciled in `ROADMAP.md`. It is a release-scope call, so I have not made it.

## Measured resolution, per model

| Model | Labels | Resolved | Rate |
| --- | ---: | ---: | ---: |
| `rope_vit_b14_inat21` | 10,000 | 860 | 8.6% overall, **57.9% of its 1,486 birds** |
| `convnext_large_inat21` / `eva02_large_inat21` | 10,000 | 860 | as above |
| `mobilenet_v2_birds` | 965 | 964 | 99.9% |
| `flexivit_il_all` | 550 | 178 | **32.4%** |
| `eu_medium_focalnet_b` / `uniformer_s_eu_common` | 707 | 234 | **33.1%** |

**The European models get the least from it.** The misses are `African blue tit`, `Algerian nuthatch`, `Arabian babbler` and similar: genuinely absent from Google Coral's North-America-leaning set, not a matching failure. Those installs depend on eBird and iNaturalist exactly as before. That is a property of the only permissively licensed source and now says so in the design note instead of being a surprise.

## Fixed

**The refresh stored things that are not species.** `get_taxonomy` requests `species,issf,spuh,slash` for its own callers, so the importer was storing subspecies, `duck sp.` and `Anas platyrhynchos/rubripes` as if a classifier could emit them. It now keeps only real species, while tolerating an absent `category` field.

**One sqlite connection was shared across threads without serialization.** The reference is read from the event path; the name store is written by the refresh task while being read. sqlite connections are not safe for concurrent use, so every statement is now serialized. Both are covered by concurrency tests running readers and writers together.

**Two local sqlite reads were running on the event loop.** Rare, but CLAUDE.md §4 is not conditional, so they run off it.

## Checked and clean

- **No duplicate common names** in the reference, so a common-name match cannot resolve ambiguously.
- **None of the 8,514 non-bird labels** in the iNat model resolves to a bird. A moth cannot be named a finch. Both now have tests.

## Verification

- `pytest` 2033 passed, 44 skipped (5 new)
- `ruff check .` / `ruff format --check .` clean from the repository root
- `docs_consistency_check.py` passed

Measurements were taken against label files and the eBird API of a live deployment; no running instance was modified.

## Still open

- The **Italian** locale at 5.8%.
- The **output-index criterion** in `ROADMAP.md`, per the top of this description.
- Nothing surfaces the reference or the name store in the UI yet: no indication of which locales are held, when they were refreshed, or a way to trigger one.