### PR TITLE
Check model label files against the checksum they were published with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   nothing is reachable. It is fetched in one request per language rather than one per species, and a
   name eBird returns unchanged from English is not recorded as a translation.
 
+- **Model label files are now checked against the checksum they were published with.** They were
+  verified once at download and never again, so a label file altered afterwards was read as
+  authoritative and every detection classified against it was recorded under the wrong species. The
+  verdict appears in classifier status, and a file that no longer matches is not used to build the
+  species mapping.
+
 - **The bundled species reference is checked before it is trusted.** It ships with a recorded
   checksum and is refused if it does not match, because a reference altered on disk would write
   wrong species names into your history. Regenerating it produces a byte-identical file, so the

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -401,6 +401,27 @@ def _runtime_benchmark_enabled() -> bool:
     }
 
 
+def _label_integrity_for(model: object) -> dict[str, object]:
+    """Report whether a loaded model's label file still matches what was published."""
+    from pathlib import Path
+
+    from app.services.label_integrity import LabelVerdict, verify_model_labels
+
+    labels_path = getattr(model, "labels_path", None)
+    if not labels_path:
+        return {"verdict": LabelVerdict.MISSING.value, "label_count": 0}
+    directory = Path(str(labels_path)).parent
+    # A region variant installs as `<parent>/<region>`, so the directory name is
+    # the region and its parent is the model id.
+    region = directory.name if directory.name in {"eu", "na"} else None
+    model_id = directory.parent.name if region else directory.name
+    try:
+        return verify_model_labels(model_id, directory, region=region).as_dict()
+    except Exception as error:  # pragma: no cover - status must never fail
+        log.warning("Could not verify model labels", error=str(error))
+        return {"verdict": "unverifiable", "label_count": 0}
+
+
 def _safe_isinstance(value: Any, expected_type: Any) -> bool:
     return isinstance(expected_type, type) and isinstance(value, expected_type)
 
@@ -4297,6 +4318,9 @@ class ClassifierService:
                         else ("openvino" if _safe_isinstance(model, OpenVINOModelInstance) else "tflite")
                     ),
                     "error": model.error,
+                    # A label file altered after download names every detection
+                    # wrongly, so the verdict is reported rather than only logged.
+                    "labels": _label_integrity_for(model),
                 }
                 for name, model in self._models.items()
             },

--- a/backend/app/services/label_integrity.py
+++ b/backend/app/services/label_integrity.py
@@ -1,0 +1,180 @@
+"""Check an installed label file against the checksum it was published with.
+
+`labels_sha256` is verified while a model is downloaded and never again. A label
+file altered afterwards is read as authoritative, and every detection classified
+against it is written to history under the wrong species. That is a data
+integrity problem, not a naming one, so it is checked here rather than assumed.
+
+The same pass builds the output-index mapping, because the moment a file has been
+proven is the right moment to derive something durable from it. A file that does
+not match is not mapped: making an altered file's names authoritative is exactly
+what this exists to prevent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+from app.services.model_taxon_map import ModelTaxonMap, model_taxon_map
+
+log = structlog.get_logger()
+
+LABELS_FILENAME = "labels.txt"
+_DIGEST_CHUNK_BYTES = 1024 * 1024
+
+#: Label files whose entries are bare `Genus species` rather than a form that
+#: announces itself. Declared rather than guessed: `Cyanistes caeruleus` and
+#: `African crake` are the same shape, and pattern-matching them was measured
+#: claiming 198 common names as scientific.
+_SCIENTIFIC_LABEL_MODELS = frozenset({"convnext_large_inat21", "eva02_large_inat21"})
+
+
+class LabelVerdict(str, Enum):
+    VERIFIED = "verified"
+    CHANGED = "changed"
+    UNVERIFIABLE = "unverifiable"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class LabelCheck:
+    model_id: str
+    verdict: LabelVerdict
+    expected_sha256: Optional[str]
+    actual_sha256: Optional[str]
+    label_count: int
+    labels: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "model_id": self.model_id,
+            "verdict": self.verdict.value,
+            "expected_sha256": self.expected_sha256,
+            "actual_sha256": self.actual_sha256,
+            "label_count": self.label_count,
+        }
+
+
+def published_labels_sha256(model_id: str, region: Optional[str] = None) -> Optional[str]:
+    """The checksum the registry publishes for a model's label file.
+
+    Region variants carry no id of their own; they hang off a parent under
+    `region_variants` and install into `<parent>/<region>`, so the caller has to
+    say which one it means.
+    """
+    from app.services.model_manager import REMOTE_REGISTRY
+
+    wanted = str(model_id or "").strip()
+    if not wanted:
+        return None
+    region_key = str(region or "").strip().lower() or None
+
+    def checksum(entry: object) -> Optional[str]:
+        if not isinstance(entry, dict):
+            return None
+        value = str(entry.get("labels_sha256") or "").strip().lower()
+        return value or None
+
+    for spec in REMOTE_REGISTRY:
+        if not isinstance(spec, dict):
+            continue
+        if str(spec.get("id") or "") == wanted:
+            if region_key:
+                variant = (spec.get("region_variants") or {}).get(region_key)
+                return checksum(variant)
+            return checksum(spec)
+        for variant in spec.get("variants", []) or []:
+            if isinstance(variant, dict) and str(variant.get("id") or "") == wanted:
+                return checksum(variant)
+    return None
+
+
+def _digest_file(path: Path) -> Optional[str]:
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(_DIGEST_CHUNK_BYTES), b""):
+                digest.update(chunk)
+    except OSError as error:
+        log.warning("Could not read label file", path=str(path), error=str(error))
+        return None
+    return digest.hexdigest()
+
+
+def verify_model_labels(
+    model_id: str,
+    model_dir: Path,
+    *,
+    expected_sha256: Optional[str] = None,
+    region: Optional[str] = None,
+) -> LabelCheck:
+    """Compare an installed label file against its published checksum.
+
+    An absent checksum yields `unverifiable`, never `changed`: plenty of models
+    ship without one, and reporting that as tampering would be a false alarm.
+    """
+    labels_path = Path(model_dir) / LABELS_FILENAME
+    expected = (expected_sha256 or published_labels_sha256(model_id, region) or "").strip().lower() or None
+
+    if not labels_path.is_file():
+        return LabelCheck(model_id, LabelVerdict.MISSING, expected, None, 0)
+
+    actual = _digest_file(labels_path)
+    if actual is None:
+        return LabelCheck(model_id, LabelVerdict.MISSING, expected, None, 0)
+
+    try:
+        labels = tuple(
+            line.strip()
+            for line in labels_path.read_text(encoding="utf-8", errors="replace").splitlines()
+            if line.strip()
+        )
+    except OSError as error:
+        log.warning("Could not read label file", path=str(labels_path), error=str(error))
+        return LabelCheck(model_id, LabelVerdict.MISSING, expected, actual, 0)
+
+    if expected is None:
+        verdict = LabelVerdict.UNVERIFIABLE
+    elif actual == expected:
+        verdict = LabelVerdict.VERIFIED
+    else:
+        verdict = LabelVerdict.CHANGED
+        log.error(
+            "Model label file does not match its published checksum; species names from it are not trustworthy",
+            model_id=model_id,
+            path=str(labels_path),
+            expected=expected,
+            actual=actual,
+        )
+
+    return LabelCheck(model_id, verdict, expected, actual, len(labels), labels)
+
+
+def build_map_for_verified_labels(
+    check: LabelCheck,
+    *,
+    mapping: Optional[ModelTaxonMap] = None,
+) -> int:
+    """Derive the output-index mapping from a label file that has been checked.
+
+    A file reported as `changed` is deliberately not mapped. Everything else is:
+    a model with no published checksum is ordinary, and withholding its names
+    would punish the user for the registry's omission.
+    """
+    if check.verdict in (LabelVerdict.CHANGED, LabelVerdict.MISSING):
+        return 0
+    if not check.actual_sha256 or not check.labels:
+        return 0
+
+    target = mapping or model_taxon_map
+    return target.build(
+        check.actual_sha256,
+        check.labels,
+        assume_scientific=check.model_id in _SCIENTIFIC_LABEL_MODELS,
+    )

--- a/backend/tests/test_label_integrity.py
+++ b/backend/tests/test_label_integrity.py
@@ -1,0 +1,139 @@
+"""Checking an installed label file against the checksum it was published with.
+
+`labels_sha256` is verified when a model is downloaded and never again, so a
+label file altered afterwards is read as authoritative and every detection
+classified against it is written to history under the wrong species. This checks
+it where it matters, and builds the output-index mapping from a file it has just
+proven.
+"""
+
+import hashlib
+
+import pytest
+
+from app.services.label_integrity import (
+    LabelVerdict,
+    build_map_for_verified_labels,
+    verify_model_labels,
+)
+
+
+@pytest.fixture
+def model_dir(tmp_path):
+    directory = tmp_path / "rope_vit_b14_inat21"
+    directory.mkdir()
+    labels = directory / "labels.txt"
+    labels.write_text(
+        "00000_Animalia_Chordata_Aves_Passeriformes_Paridae_Cyanistes_caeruleus\n"
+        "00001_Animalia_Chordata_Aves_Passeriformes_Turdidae_Erithacus_rubecula\n",
+        encoding="utf-8",
+    )
+    return directory
+
+
+def _digest(path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_a_matching_label_file_is_verified(model_dir):
+    expected = _digest(model_dir / "labels.txt")
+
+    result = verify_model_labels("rope_vit_b14_inat21", model_dir, expected_sha256=expected)
+
+    assert result.verdict is LabelVerdict.VERIFIED
+    assert result.actual_sha256 == expected
+    assert result.label_count == 2
+
+
+def test_an_altered_label_file_is_reported_as_changed(model_dir):
+    expected = _digest(model_dir / "labels.txt")
+    (model_dir / "labels.txt").write_text("something else entirely\n", encoding="utf-8")
+
+    result = verify_model_labels("rope_vit_b14_inat21", model_dir, expected_sha256=expected)
+
+    assert result.verdict is LabelVerdict.CHANGED
+    assert result.actual_sha256 != expected
+
+
+def test_a_model_with_no_published_checksum_is_unverifiable_not_changed(model_dir):
+    """Absence of a checksum is not evidence of tampering, and must not read as it."""
+    result = verify_model_labels("custom_model", model_dir, expected_sha256=None)
+
+    assert result.verdict is LabelVerdict.UNVERIFIABLE
+    assert result.actual_sha256 == _digest(model_dir / "labels.txt")
+
+
+def test_a_missing_label_file_is_reported_as_missing(tmp_path):
+    empty = tmp_path / "no_labels"
+    empty.mkdir()
+
+    result = verify_model_labels("rope_vit_b14_inat21", empty, expected_sha256="a" * 64)
+
+    assert result.verdict is LabelVerdict.MISSING
+    assert result.actual_sha256 is None
+    assert result.label_count == 0
+
+
+def test_the_map_is_built_only_from_a_file_that_was_verified(model_dir, tmp_path):
+    from app.services.model_taxon_map import ModelTaxonMap
+
+    mapping = ModelTaxonMap(tmp_path / "map.db")
+    expected = _digest(model_dir / "labels.txt")
+    result = verify_model_labels("rope_vit_b14_inat21", model_dir, expected_sha256=expected)
+
+    stored = build_map_for_verified_labels(result, mapping=mapping)
+
+    assert stored == 2
+    assert mapping.lookup(result.actual_sha256, 0) == "Cyanistes caeruleus"
+    assert mapping.lookup(result.actual_sha256, 1) == "Erithacus rubecula"
+
+
+def test_a_changed_file_does_not_get_a_mapping(model_dir, tmp_path):
+    """Mapping an altered file would make its wrong names authoritative."""
+    from app.services.model_taxon_map import ModelTaxonMap
+
+    mapping = ModelTaxonMap(tmp_path / "map.db")
+    result = verify_model_labels("rope_vit_b14_inat21", model_dir, expected_sha256="b" * 64)
+
+    assert result.verdict is LabelVerdict.CHANGED
+    assert build_map_for_verified_labels(result, mapping=mapping) == 0
+    assert mapping.has(result.actual_sha256 or "") is False
+
+
+def test_an_unverifiable_file_still_gets_a_mapping(model_dir, tmp_path):
+    """A model without a published checksum is normal, and its names are still wanted."""
+    from app.services.model_taxon_map import ModelTaxonMap
+
+    mapping = ModelTaxonMap(tmp_path / "map.db")
+    result = verify_model_labels("custom_model", model_dir, expected_sha256=None)
+
+    assert build_map_for_verified_labels(result, mapping=mapping) == 2
+
+
+def test_the_published_checksum_is_read_from_the_registry():
+    """The registry is the source of truth; a typo here would be silent."""
+    from app.services.label_integrity import published_labels_sha256
+
+    assert published_labels_sha256("mobilenet_v2_birds")
+    assert published_labels_sha256("no_such_model_at_all") is None
+
+
+def test_a_region_variant_resolves_its_own_checksum():
+    """`small_birds/eu` has no id of its own; it hangs off its parent."""
+    from app.services.label_integrity import published_labels_sha256
+
+    parent_only = published_labels_sha256("small_birds")
+    eu = published_labels_sha256("small_birds", region="eu")
+    na = published_labels_sha256("small_birds", region="na")
+
+    assert eu and na
+    assert eu != na
+    # The parent carries no label file of its own, only its regions do.
+    assert parent_only is None
+
+
+def test_a_retired_model_is_unverifiable_rather_than_changed(model_dir):
+    """Retired models leave installed files alone, so absence of a checksum is expected."""
+    result = verify_model_labels("uniformer_s_eu_common", model_dir)
+
+    assert result.verdict is LabelVerdict.UNVERIFIABLE

--- a/docs/plans/2026-08-19-model-output-index-mapping.md
+++ b/docs/plans/2026-08-19-model-output-index-mapping.md
@@ -1,7 +1,7 @@
 # Mapping model output indices to taxa
 
 Date: 2026-08-19
-Status: Proposed
+Status: Partly implemented
 Supersedes: the recommendation in
 [2026-08-19-species-reference-source-decision.md](2026-08-19-species-reference-source-decision.md)
 to drop the output-index criterion from `ROADMAP.md`
@@ -150,8 +150,35 @@ The three common-name-only models need a build-time taxonomy lookup, which eBird
 
 ## Remaining work
 
-1. Declare the label format in the model spec, so bare-binomial files map without guessing.
-2. Resolve common-name-only labels against a taxonomy at install time.
-3. Build the map during model install, where `labels_sha256` is already verified.
-4. Use it for naming, falling back to the text path when a model has no mapping.
+1. ~~Declare the label format so bare-binomial files map without guessing.~~ Done: the two models
+   whose labels are bare binomials are named in `label_integrity`, taking them from 0% to 100%.
+2. ~~Verify the label file against its published checksum, and build the map from a proven file.~~
+   Done, and the verdict is reported in classifier status.
+3. Resolve common-name-only labels against a taxonomy, which eBird satisfies for about 78%.
+4. Use the map for naming, falling back to the text path when a model has no mapping.
 5. Move grouped labels and display off `labels.txt` so the file is not needed at runtime at all.
+
+### Verification against installed models
+
+Every label file on the reference deployment was checked against the checksum the registry
+publishes. All seven match, so nothing has drifted, and the mechanism works end to end.
+
+| Model | Verdict | Labels | Mapped |
+| --- | --- | ---: | ---: |
+| `rope_vit_b14_inat21` | verified | 10,000 | **10,000** |
+| `convnext_large_inat21` | verified | 10,000 | **9,999** |
+| `eva02_large_inat21` | verified | 10,000 | **9,999** |
+| `mobilenet_v2_birds` | verified | 965 | 964 |
+| `flexivit_il_all` | verified | 550 | 0 |
+| `eu_medium_focalnet_b` | verified | 707 | 0 |
+| `uniformer_s_eu_common` | unverifiable | 707 | 0 |
+
+`uniformer_s_eu_common` is retired. Retired models keep their installed files so an operator can
+roll back, and the registry no longer publishes a checksum for them, so `unverifiable` is the
+correct verdict rather than a fault.
+
+Two pairs of models share a label file and therefore one mapping, which is what keying on the
+file's digest rather than the model name buys.
+
+Region variants such as `small_birds/eu` carry no id of their own and hang off a parent under
+`region_variants`, so resolving their checksum needs the region as well as the parent id.


### PR DESCRIPTION
Continues #224. This is the step that closes the integrity gap and takes two more models to full coverage.

## The gap

`labels_sha256` was verified while a model downloaded and **never again**. A label file altered afterwards was read as authoritative, and every detection classified against it was written to history under the wrong species.

That is a data-integrity problem rather than a naming one, so it is now checked where it matters and the verdict is reported in classifier status rather than only appearing in a log line.

## Verdicts, and why there are four

| Verdict | Meaning | Mapped? |
| --- | --- | --- |
| `verified` | matches the published checksum | yes |
| `changed` | does not match | **no** |
| `unverifiable` | no checksum published | yes |
| `missing` | no label file | no |

A **changed** file is deliberately not mapped: making an altered file's names authoritative is precisely what this exists to prevent.

**Unverifiable is not changed.** Plenty of models ship without a published checksum, and retired models keep their installed files while losing theirs. Reporting that as tampering would be a false alarm, and withholding names would punish the user for the registry's omission.

## Two more models at full coverage

Declaring which label files hold bare binomials, rather than guessing at their shape, takes `convnext_large_inat21` and `eva02_large_inat21` from **0 to 9,999 of 10,000** outputs each. The declaration is one frozenset with the measurement recorded beside it, which is the honest version of the pattern-matching #224 rejected.

## Verified against the reference deployment

Every label file was checked against what the registry publishes. **All seven match**, so nothing has drifted and the mechanism works end to end.

| Model | Verdict | Labels | Mapped |
| --- | --- | ---: | ---: |
| `rope_vit_b14_inat21` | verified | 10,000 | **10,000** |
| `convnext_large_inat21` | verified | 10,000 | **9,999** |
| `eva02_large_inat21` | verified | 10,000 | **9,999** |
| `mobilenet_v2_birds` | verified | 965 | 964 |
| `flexivit_il_all` | verified | 550 | 0 |
| `eu_medium_focalnet_b` | verified | 707 | 0 |
| `uniformer_s_eu_common` | unverifiable | 707 | 0 |

`uniformer_s_eu_common` is retired, so `unverifiable` is correct rather than a fault.

Two pairs of models share a label file and therefore one mapping, which is what keying on the file's digest rather than the model name buys.

## Also found

**Region variants carry no id of their own.** `small_birds/eu` and `medium_birds/na` hang off a parent under `region_variants`, so resolving their checksum needs the region as well as the parent id. Without that they would all have reported unverifiable.

## Safety

- Status reporting cannot fail: any error resolving a verdict degrades to `unverifiable`.
- No change to model loading. A changed file is **reported**, not refused; refusing to load is a behavioural change that deserves its own decision rather than riding along here.
- No schema change, no migration, no change to what is stored about a detection.

## Verification

- `pytest` 2073 passed, 44 skipped (10 new)
- `ruff check .` / `ruff format --check .` clean from the repository root
- `docs_consistency_check.py` passed, OpenAPI artifact current
- Exercised against all seven installed label files

## Still to come

Resolving common-name-only labels against a taxonomy (eBird covers about 78%), using the map for naming with fallback, and moving grouped labels off `labels.txt` so the file is genuinely not needed at runtime.