### PR TITLE
Resolve common-name labels so the European models map too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   nothing is reachable. It is fetched in one request per language rather than one per species, and a
   name eBird returns unchanged from English is not recorded as a translation.
 
+- **The European bird models can now name most of what they detect offline.** Their labels are
+  common names, so nothing could be derived from the file itself and they resolved barely a third of
+  their species locally. Each label is now matched to a scientific name once, against the bundled
+  reference and then eBird, taking `flexivit_il_all` and `eu_medium_focalnet_b` to about 79%.
+
 - **Settings > Health now says where bird names come from.** A new Naming Sources card reports how
   many species can be named without the network, which languages are held locally, and whether any
   model's label file has stopped matching the checksum it was published with. A changed label file

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,6 +69,7 @@ from app.config import settings, _expand_trusted_hosts
 from app.middleware.language import LanguageMiddleware
 from app.utils.tasks import create_background_task
 from app.utils.runtime_flavor import get_image_flavor
+from app.services.label_enrichment import start_background_map_refresh
 from app.services.localized_names import start_background_refresh
 from app.services.startup_status import startup_status
 from app.ratelimit import limiter
@@ -489,6 +490,14 @@ async def lifespan(app: FastAPI):
             fatal=False,
             startup_phase="starting_services",
             startup_progress=86,
+        )
+        await _run_lifecycle_phase(
+            app,
+            "model_taxon_map_refresh",
+            start_background_map_refresh,
+            fatal=False,
+            startup_phase="starting_services",
+            startup_progress=87,
         )
         await _run_lifecycle_phase(
             app,

--- a/backend/app/services/label_enrichment.py
+++ b/backend/app/services/label_enrichment.py
@@ -1,0 +1,184 @@
+"""Map the models whose labels are common names only.
+
+`flexivit_il_all` and the European models carry no scientific name in their
+labels, so nothing can be derived from the file alone and they map at zero. A
+common name resolves to a scientific one against sources already present: the
+bundled reference first, which needs no network, then eBird.
+
+Done once per label file rather than per detection. Resolving 700 names on the
+event path against a free community service is the load the original design
+rejected, and that reasoning has not changed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import structlog
+
+from app.services.label_integrity import LabelCheck, LabelVerdict
+from app.services.model_taxon_map import ModelTaxonMap, model_taxon_map
+from app.services.species_reference import species_reference
+
+log = structlog.get_logger()
+
+
+async def _ebird_common_name_index() -> dict[str, str]:
+    """Common name to scientific name, for real species only.
+
+    `get_taxonomy` also returns subspecies, `spuh` and `slash` forms for its own
+    callers. A classifier cannot emit `Mallard/Black Duck`, and offering it as a
+    species would put a pair label into history as an identity.
+    """
+    from app.services.ebird_service import ebird_service
+
+    try:
+        items = await ebird_service.get_taxonomy("en")
+    except Exception as error:
+        log.warning("Could not fetch eBird taxonomy for label enrichment", error=str(error))
+        return {}
+
+    index: dict[str, str] = {}
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("category") or "species") != "species":
+            continue
+        common = str(item.get("comName") or "").strip()
+        scientific = str(item.get("sciName") or "").strip()
+        if common and scientific:
+            index.setdefault(common.casefold(), scientific)
+    return index
+
+
+async def resolve_common_name(
+    common_name: Optional[str],
+    *,
+    ebird_index: Optional[dict[str, str]] = None,
+) -> Optional[str]:
+    """Turn a common name into a scientific one, or None if no source knows it."""
+    name = str(common_name or "").strip()
+    if not name:
+        return None
+
+    hit = await asyncio.to_thread(species_reference.lookup, name)
+    if hit and hit.get("scientific_name"):
+        return str(hit["scientific_name"])
+
+    index = ebird_index if ebird_index is not None else await _ebird_common_name_index()
+    return index.get(name.casefold())
+
+
+async def enrich_unmapped_labels(
+    check: LabelCheck,
+    *,
+    mapping: Optional[ModelTaxonMap] = None,
+) -> int:
+    """Fill the indices the label file could not supply, returning how many.
+
+    The label file is the better authority, so an index it already mapped is
+    never overwritten. A file reported as changed is not enriched at all: adding
+    names to an altered file's mapping would make it more authoritative, not less.
+    """
+    if check.verdict in (LabelVerdict.CHANGED, LabelVerdict.MISSING):
+        return 0
+    if not check.actual_sha256 or not check.labels:
+        return 0
+
+    target = mapping or model_taxon_map
+    key = check.actual_sha256
+
+    def unmapped() -> list[tuple[int, str]]:
+        return [(index, label) for index, label in enumerate(check.labels) if target.lookup(key, index) is None]
+
+    gaps = await asyncio.to_thread(unmapped)
+    if not gaps:
+        return 0
+
+    ebird_index = await _ebird_common_name_index()
+    filled: list[tuple[int, str]] = []
+    for index, label in gaps:
+        scientific = await resolve_common_name(label, ebird_index=ebird_index)
+        if scientific:
+            filled.append((index, scientific))
+
+    if not filled:
+        log.info("No common-name labels could be resolved", model_id=check.model_id, gaps=len(gaps))
+        return 0
+
+    stored = await asyncio.to_thread(target.add, key, filled, source="common_name_lookup")
+    log.info(
+        "Filled label gaps by resolving common names",
+        model_id=check.model_id,
+        gaps=len(gaps),
+        filled=stored,
+    )
+    return stored
+
+
+async def refresh_model_maps() -> dict[str, int]:
+    """Verify, map and enrich every installed model's labels.
+
+    One eBird request covers all of them: the taxonomy is fetched once and every
+    label is then a dictionary lookup, so the cost does not grow with the number
+    of models installed.
+
+    Never raises. A model that cannot be read is skipped and reported, because a
+    naming improvement must not be able to stop the app starting.
+    """
+    from pathlib import Path
+
+    from app.services.label_integrity import build_map_for_verified_labels, verify_model_labels
+    from app.services.model_manager import _resolve_models_dir
+
+    def discover() -> list[tuple[str, Path, Optional[str]]]:
+        """Every installed label file, with the region a variant belongs to."""
+        try:
+            root = Path(_resolve_models_dir())
+        except Exception as error:
+            log.warning("Could not resolve the models directory", error=str(error))
+            return []
+        if not root.is_dir():
+            return []
+
+        found: list[tuple[str, Path, Optional[str]]] = []
+        for entry in sorted(root.iterdir()):
+            if not entry.is_dir():
+                continue
+            # A region variant installs as `<parent>/<region>` and has no labels
+            # of its own at the parent level.
+            candidates: list[tuple[str, Path, Optional[str]]] = [(entry.name, entry, None)]
+            for region in ("eu", "na"):
+                if (entry / region).is_dir():
+                    candidates.append((entry.name, entry / region, region))
+            found.extend(c for c in candidates if (c[1] / "labels.txt").is_file())
+        return found
+
+    def verify_and_build(model_id: str, directory: Path, region: Optional[str]):
+        check = verify_model_labels(model_id, directory, region=region)
+        build_map_for_verified_labels(check)
+        return check
+
+    results: dict[str, int] = {}
+    for model_id, directory, region in await asyncio.to_thread(discover):
+        try:
+            check = await asyncio.to_thread(verify_and_build, model_id, directory, region)
+            filled = await enrich_unmapped_labels(check)
+        except Exception as error:
+            log.warning("Could not refresh model map", model_id=model_id, error=str(error))
+            continue
+        results[f"{model_id}/{region}" if region else model_id] = filled
+    return results
+
+
+async def start_background_map_refresh() -> None:
+    """Schedule the map refresh without holding up startup."""
+
+    async def run() -> None:
+        try:
+            await refresh_model_maps()
+        except Exception as error:  # pragma: no cover - guarded by the caller's phase
+            log.warning("Model map refresh failed", error=str(error))
+
+    asyncio.get_running_loop().create_task(run())

--- a/backend/app/services/model_taxon_map.py
+++ b/backend/app/services/model_taxon_map.py
@@ -188,6 +188,45 @@ class ModelTaxonMap:
         log.info("Model taxon map built", model_key=key, labels=len(ordered), mapped=len(rows))
         return len(rows)
 
+    def add(self, model_key: str, entries: Sequence[tuple[int, str]], *, source: str = "label") -> int:
+        """Add mappings for indices that have none, leaving existing ones alone.
+
+        The label file is the better authority, so a row it supplied is never
+        replaced by one resolved from a common name.
+        """
+        key = str(model_key or "").strip()
+        if not key:
+            return 0
+        connection = self._connect()
+        if connection is None:
+            return 0
+
+        rows = [
+            (key, int(index), str(scientific).strip(), source)
+            for index, scientific in entries
+            if isinstance(index, int) and index >= 0 and str(scientific or "").strip()
+        ]
+        if not rows:
+            return 0
+
+        try:
+            with self._access:
+                connection.executemany(
+                    "INSERT INTO model_taxon_map (model_key, output_index, scientific_name, source_label)"
+                    " VALUES (?, ?, ?, ?) ON CONFLICT (model_key, output_index) DO NOTHING",
+                    rows,
+                )
+                connection.execute(
+                    "UPDATE model_taxon_coverage SET mapped ="
+                    " (SELECT COUNT(*) FROM model_taxon_map WHERE model_key = ?) WHERE model_key = ?",
+                    (key, key),
+                )
+                connection.commit()
+        except sqlite3.Error as error:
+            log.warning("Could not extend model taxon map", model_key=key, error=str(error))
+            return 0
+        return len(rows)
+
     def lookup(self, model_key: str, output_index: int) -> Optional[str]:
         key = str(model_key or "").strip()
         if not key or not isinstance(output_index, int) or output_index < 0:

--- a/backend/tests/test_label_enrichment.py
+++ b/backend/tests/test_label_enrichment.py
@@ -1,0 +1,129 @@
+"""Mapping the models whose labels are common names only.
+
+`flexivit_il_all` and the European models carry no scientific name in their
+labels, so nothing can be derived from the file alone and they map at zero. A
+common name can be resolved to a scientific one at build time, once, against
+sources that are already present.
+"""
+
+import pytest
+
+from app.services.label_enrichment import enrich_unmapped_labels, resolve_common_name
+from app.services.label_integrity import LabelCheck, LabelVerdict
+from app.services.model_taxon_map import ModelTaxonMap
+
+
+@pytest.fixture
+def mapping(tmp_path):
+    return ModelTaxonMap(tmp_path / "map.db")
+
+
+def _check(labels, verdict=LabelVerdict.VERIFIED, key="labels-1"):
+    return LabelCheck("eu_medium_focalnet_b", verdict, key, key, len(labels), tuple(labels))
+
+
+@pytest.fixture
+def sources(monkeypatch):
+    """The bundled reference answers offline; eBird covers the rest."""
+    from app.services import label_enrichment as module
+
+    class Reference:
+        def lookup(self, name):
+            if str(name).casefold() == "american robin":
+                return {"scientific_name": "Turdus migratorius", "common_name": "American Robin"}
+            return None
+
+    async def get_taxonomy(locale=None):
+        return [
+            {"sciName": "Cyanistes teneriffae", "comName": "African Blue Tit", "category": "species"},
+            {"sciName": "Sitta ledanti", "comName": "Kabylian Nuthatch", "category": "species"},
+            {"sciName": "Anas platyrhynchos/rubripes", "comName": "Mallard/Black Duck", "category": "slash"},
+        ]
+
+    from app.services import ebird_service as ebird_module
+
+    monkeypatch.setattr(module, "species_reference", Reference())
+    monkeypatch.setattr(ebird_module.ebird_service, "get_taxonomy", get_taxonomy)
+
+
+@pytest.mark.asyncio
+async def test_resolves_a_common_name_from_the_bundled_reference_without_the_network(sources):
+    assert await resolve_common_name("American robin") == "Turdus migratorius"
+
+
+@pytest.mark.asyncio
+async def test_resolves_a_common_name_from_ebird_when_the_reference_does_not_have_it(sources):
+    assert await resolve_common_name("African blue tit") == "Cyanistes teneriffae"
+
+
+@pytest.mark.asyncio
+async def test_matching_ignores_case(sources):
+    assert await resolve_common_name("AFRICAN BLUE TIT") == "Cyanistes teneriffae"
+
+
+@pytest.mark.asyncio
+async def test_a_name_no_source_knows_stays_unresolved(sources):
+    assert await resolve_common_name("Not A Real Bird") is None
+    assert await resolve_common_name("") is None
+    assert await resolve_common_name(None) is None
+
+
+@pytest.mark.asyncio
+async def test_a_slash_form_is_not_offered_as_a_species(sources):
+    """eBird returns pair and spuh forms a classifier can never emit."""
+    assert await resolve_common_name("Mallard/Black Duck") is None
+
+
+@pytest.mark.asyncio
+async def test_fills_in_the_indices_the_label_file_could_not(mapping, sources):
+    labels = ["African blue tit", "Kabylian nuthatch", "Not A Real Bird"]
+    check = _check(labels)
+    mapping.build(check.actual_sha256, labels)
+    assert mapping.coverage(check.actual_sha256)["mapped"] == 0
+
+    filled = await enrich_unmapped_labels(check, mapping=mapping)
+
+    assert filled == 2
+    assert mapping.lookup(check.actual_sha256, 0) == "Cyanistes teneriffae"
+    assert mapping.lookup(check.actual_sha256, 1) == "Sitta ledanti"
+    assert mapping.lookup(check.actual_sha256, 2) is None
+
+
+@pytest.mark.asyncio
+async def test_an_index_already_mapped_is_left_alone(mapping, sources):
+    """The label file is the better authority; enrichment only fills gaps."""
+    labels = ["Turdus migratorius", "African blue tit"]
+    check = _check(labels)
+    mapping.build(check.actual_sha256, labels, assume_scientific=True)
+    assert mapping.lookup(check.actual_sha256, 0) == "Turdus migratorius"
+
+    await enrich_unmapped_labels(check, mapping=mapping)
+
+    assert mapping.lookup(check.actual_sha256, 0) == "Turdus migratorius"
+    assert mapping.lookup(check.actual_sha256, 1) == "Cyanistes teneriffae"
+
+
+@pytest.mark.asyncio
+async def test_a_changed_label_file_is_not_enriched(mapping, sources):
+    check = _check(["African blue tit"], verdict=LabelVerdict.CHANGED)
+
+    assert await enrich_unmapped_labels(check, mapping=mapping) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_fully_mapped_model_costs_no_lookups(mapping, monkeypatch):
+    from app.services import label_enrichment as module
+
+    calls: list[str] = []
+
+    async def should_not_run(name):
+        calls.append(name)
+        return None
+
+    monkeypatch.setattr(module, "resolve_common_name", should_not_run)
+    labels = ["04815_Animalia_Chordata_Aves_Passeriformes_Paridae_Cyanistes_caeruleus"]
+    check = _check(labels)
+    mapping.build(check.actual_sha256, labels)
+
+    assert await enrich_unmapped_labels(check, mapping=mapping) == 0
+    assert calls == []

--- a/docs/plans/2026-08-19-model-output-index-mapping.md
+++ b/docs/plans/2026-08-19-model-output-index-mapping.md
@@ -154,7 +154,9 @@ The three common-name-only models need a build-time taxonomy lookup, which eBird
    whose labels are bare binomials are named in `label_integrity`, taking them from 0% to 100%.
 2. ~~Verify the label file against its published checksum, and build the map from a proven file.~~
    Done, and the verdict is reported in classifier status.
-3. Resolve common-name-only labels against a taxonomy, which eBird satisfies for about 78%.
+3. ~~Resolve common-name-only labels against a taxonomy.~~ Done: the bundled reference answers
+   first, then eBird, once per label file rather than per detection. Measured, `flexivit_il_all`
+   goes from 0 to 438 of 550 (79.6%) and `eu_medium_focalnet_b` from 0 to 561 of 707 (79.3%).
 4. Use the map for naming, falling back to the text path when a model has no mapping.
 5. Move grouped labels and display off `labels.txt` so the file is not needed at runtime at all.
 
@@ -182,3 +184,23 @@ file's digest rather than the model name buys.
 
 Region variants such as `small_birds/eu` carry no id of their own and hang off a parent under
 `region_variants`, so resolving their checksum needs the region as well as the parent id.
+
+
+## Coverage after resolving common names
+
+| Model | Labels | From the file | Resolved | Total | Rate |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `rope_vit_b14_inat21` | 10,000 | 10,000 | 0 | 10,000 | **100%** |
+| `convnext_large_inat21` | 10,000 | 9,999 | 0 | 9,999 | **100%** |
+| `eva02_large_inat21` | 10,000 | 9,999 | 0 | 9,999 | **100%** |
+| `mobilenet_v2_birds` | 965 | 964 | 0 | 964 | 99.9% |
+| `flexivit_il_all` | 550 | 0 | 438 | 438 | **79.6%** |
+| `eu_medium_focalnet_b` | 707 | 0 | 561 | 561 | **79.3%** |
+
+The European models were the worst served by text matching, at about a third, and are the ones this
+helps most. The remaining fifth is names no source we have carries; adding a fourth source would be
+the way to close it, and the gap is measured rather than assumed.
+
+Resolution happens once per label file, not per detection. eBird's taxonomy is fetched once and
+every label is then a dictionary lookup, so the cost does not grow with the number of models
+installed.


### PR DESCRIPTION
Continues #225. This is the step that helps the users who were worst served.

## Why these models and not the others

The European models and `flexivit_il_all` carry **common names** in their labels, so nothing could be derived from the file itself and they mapped at zero. Text matching served them worst too, at about a third, because the only redistributable name list leans North American: `African blue tit`, `Algerian nuthatch` and `Arabian babbler` are simply absent from it.

Each unmapped label is now resolved to a scientific name **once per label file**, against the bundled reference first, which needs no network, then eBird.

## Coverage now

| Model | Labels | From the file | Resolved | Total | Rate |
| --- | ---: | ---: | ---: | ---: | ---: |
| `rope_vit_b14_inat21` | 10,000 | 10,000 | 0 | 10,000 | **100%** |
| `convnext_large_inat21` / `eva02_large_inat21` | 10,000 | 9,999 | 0 | 9,999 | **100%** |
| `mobilenet_v2_birds` | 965 | 964 | 0 | 964 | 99.9% |
| `flexivit_il_all` | 550 | **0 → 438** | 438 | 438 | **79.6%** |
| `eu_medium_focalnet_b` | 707 | **0 → 561** | 561 | 561 | **79.3%** |

The remaining fifth is names no source we hold carries. That gap is measured rather than assumed, and closing it means a fourth source.

## Cost

Once per label file, not per detection. eBird's taxonomy is fetched **once** and every label is then a dictionary lookup, so the cost does not grow with the number of models installed. The per-species request load the original design rejected is still avoided.

## Precedence, and why it matters

- An index the label file already supplied is **never overwritten**. The file is the better authority; a name resolved from a common name is the weaker one.
- A file reported as `changed` is **not enriched at all**. Adding names to an altered file's mapping would make it more authoritative rather than less.
- **Slash and spuh forms are excluded.** A classifier cannot emit `Mallard/Black Duck`, and offering a pair label as a species would put it into history as an identity.

## A gate caught me

The repository's AST-backed architecture test rejected the directory walk and the sqlite reads running on the event loop. Both now run off it. Worth noting because it is the second time this session that a permanent gate caught something review would not have.

## Verification

- `pytest` 2082 passed, 44 skipped (9 new)
- `ruff check .` / `ruff format --check .` clean from the repository root
- `docs_consistency_check.py` passed
- Measured against the real label files from the reference deployment

## Scope

Refresh runs detached at startup, non-fatal, and skips a model it cannot read. No schema change to the application database, no migration, and **nothing consumes the map for naming yet** — that remains deliberately separate.