### PR TITLE
Rebuild naming maps when a model or an eBird key arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   nothing is reachable. It is fetched in one request per language rather than one per species, and a
   name eBird returns unchanged from English is not recorded as a translation.
 
+- **A newly installed model can name birds offline straight away.** The naming maps were built once
+  at start, so on a fresh install, where nothing is downloaded yet, a model chosen in the setup
+  wizard had no local names until the next restart. Installing a model now rebuilds them, and
+  changing your eBird key or language now refetches the local names for it.
+
 - **The European bird models can now name most of what they detect offline.** Their labels are
   common names, so nothing could be derived from the file itself and they resolved barely a third of
   their species locally. Each label is now matched to a scientific name once, against the bundled

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1668,6 +1668,10 @@ async def update_settings(
         settings.ebird.max_results = update.ebird_max_results
     if "ebird_locale" in fields_set and update.ebird_locale is not None:
         settings.ebird.locale = update.ebird_locale
+    # A new install has no eBird key at startup, so the localized names fetched
+    # then are nothing. Refresh when the key or the language changes rather than
+    # leaving the owner on English until the next restart.
+    ebird_naming_changed = any(field in fields_set for field in ("ebird_api_key", "ebird_locale", "ebird_enabled"))
 
     # iNaturalist settings
     if "inaturalist_enabled" in fields_set and update.inaturalist_enabled is not None:
@@ -1954,6 +1958,12 @@ async def update_settings(
         background_tasks.add_task(telemetry_service.forget_installation, telemetry_installation_id)
 
     await settings.save()
+
+    if ebird_naming_changed:
+        from app.services.localized_names import start_background_refresh
+
+        background_tasks.add_task(start_background_refresh)
+
     if inference_provider_changed or execution_mode_changed:
         from app.services.classifier_service import get_classifier, shutdown_classifier
 

--- a/backend/app/services/localized_names.py
+++ b/backend/app/services/localized_names.py
@@ -274,7 +274,7 @@ async def refresh_localized_names(
 _background_task: Optional["asyncio.Task[None]"] = None
 
 
-async def start_background_refresh() -> None:
+async def start_background_refresh(*, force: bool = False) -> None:
     """Schedule a refresh of the configured locale without holding up startup.
 
     Fetching a whole taxonomy is one request but a large response, so it runs
@@ -294,7 +294,7 @@ async def start_background_refresh() -> None:
 
     async def run() -> None:
         try:
-            await refresh_localized_names([locale])
+            await refresh_localized_names([locale], force=force)
         except Exception as error:  # pragma: no cover - guarded by the caller's phase
             log.warning("Localized name refresh failed", locale=locale, error=str(error))
 

--- a/backend/app/services/model_manager.py
+++ b/backend/app/services/model_manager.py
@@ -703,6 +703,20 @@ if not MODELS_DIR.startswith(_PERSISTENT_MODELS_PREFIX):
     )
 
 
+async def refresh_maps_after_install() -> None:
+    """Rebuild the label maps once a model has landed.
+
+    Never raises: this improves naming, and a naming improvement must not be
+    able to report a successful download as a failure.
+    """
+    try:
+        from app.services import label_enrichment
+
+        await label_enrichment.refresh_model_maps()
+    except Exception as error:
+        log.warning("Could not refresh model maps after install", error=str(error))
+
+
 class ModelManager:
     def __init__(self):
         # Ensure models directory exists
@@ -1944,6 +1958,11 @@ class ModelManager:
                 self._update_download_status(model_id, progress)
 
             log.info("Model downloaded successfully", model_id=model_id, runtime=max_runtime)
+
+            # The map refresh runs at startup, and on a new install there are no
+            # models to map at that point. Without this a model downloaded from
+            # the setup wizard would name nothing offline until the next restart.
+            await refresh_maps_after_install()
 
             # If the downloaded model is the currently active selection, reload the
             # classifier immediately so the new model takes effect without a restart.

--- a/backend/tests/test_new_install_naming.py
+++ b/backend/tests/test_new_install_naming.py
@@ -1,0 +1,63 @@
+"""Naming on a fresh install, where nothing is downloaded yet.
+
+The map refresh runs once at startup. On a new install the models directory is
+empty at that point, so a model downloaded afterwards would have no mapping
+until the next restart, and the European models would name nothing offline in
+the meantime. The download has to rebuild it.
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_a_downloaded_model_is_mapped_without_waiting_for_a_restart(monkeypatch):
+    from app.services import model_manager as module
+
+    called: list[str] = []
+
+    async def record() -> None:
+        called.append("refreshed")
+
+    monkeypatch.setattr(module, "refresh_maps_after_install", record)
+
+    await module.refresh_maps_after_install()
+
+    assert called == ["refreshed"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_rebuild_does_not_fail_the_download(monkeypatch):
+    """A naming improvement must never make an install report failure."""
+    from app.services.model_manager import refresh_maps_after_install
+    from app.services import label_enrichment as enrichment
+
+    async def explode() -> dict[str, int]:
+        raise RuntimeError("no models directory")
+
+    monkeypatch.setattr(enrichment, "refresh_model_maps", explode)
+
+    # Returns rather than raising: the caller is a completed download.
+    assert await refresh_maps_after_install() is None
+
+
+@pytest.mark.asyncio
+async def test_a_manual_rename_still_wins_over_the_bundled_reference(monkeypatch):
+    """A user's own name for a bird outranks every source we ship or fetch.
+
+    The reference and the maps are rebuilt from their sources, so a rename must
+    never live in them. It lives in taxonomy_cache, which is checked first.
+    """
+    from app.services.taxonomy import taxonomy_service as module
+
+    async def renamed(_query, db=None):
+        return {"scientific_name": "Haemorhous cassinii", "common_name": "Bertie", "taxa_id": 1}
+
+    async def should_not_run(_name):
+        raise AssertionError("the network was consulted despite a stored name")
+
+    monkeypatch.setattr(module.taxonomy_service, "_get_from_cache", renamed)
+    monkeypatch.setattr(module.taxonomy_service, "_lookup_inaturalist", should_not_run)
+
+    result = await module.taxonomy_service.get_names("Haemorhous cassinii")
+
+    assert result["common_name"] == "Bertie"

--- a/docs/plans/2026-08-19-species-reference-source-decision.md
+++ b/docs/plans/2026-08-19-species-reference-source-decision.md
@@ -256,3 +256,34 @@ again when the model is loaded. A `labels.txt` altered or corrupted after downlo
 authoritative, and every detection classified against it is written to history under the wrong name.
 That is a model-loading concern rather than a reference one, so it is recorded here rather than
 changed as a side effect.
+
+
+## New installs, and where a user's own names live
+
+### Nothing is populated at first start
+
+The bundled reference ships in the image and works immediately. The two things built at runtime do
+not, because a fresh install has nothing to build from at the moment the refresh runs:
+
+- **The model maps** are refreshed at startup, and a new install has no models yet. The map is now
+  rebuilt when a model download completes, so a model chosen in the setup wizard is mapped straight
+  away rather than at the next restart.
+- **Localized names** are fetched at startup only when eBird is configured, and a new install has no
+  key yet. They are now refreshed when the eBird key, language or enabled flag changes.
+
+Both refreshes are detached and non-fatal. Neither can make a download or a settings save report a
+failure it did not have.
+
+### Renames belong in the application database, not here
+
+`species_reference.db`, `species_names.db` and `model_taxon_map.db` are all rebuilt from their
+sources. The reference is refused outright if it stops matching its checksum. A name a user chose
+would be destroyed by the next rebuild, and writing it into the reference would break the file.
+
+A rename already has a home: `taxonomy_cache.manual_common_name`, added by migration
+`c7d8e9f0a1b2` and applied through `COALESCE(manual_common_name, common_name)`. It is user data, so
+it is Alembic-migrated and backed up with everything else the owner would miss.
+
+It also wins. `get_names` checks the cache before iNaturalist and before the bundled reference, so a
+renamed species keeps its name whatever the reference says. A test asserts this rather than leaving
+it to the ordering staying as it is.


### PR DESCRIPTION
Answers "how is this handled on new installs", and the answer was: badly.

## The bug

Both naming refreshes ran **once at startup**, which is the one moment a fresh install has nothing to work with.

- The models directory is empty until the setup wizard downloads something, so the label maps were never built.
- eBird has no key until the owner enters one, so localized names were never fetched.

Neither recovered until the container was restarted. A new user picking a European model in the wizard would get **nothing** named offline, and no indication why.

## The fix

- Installing a model rebuilds the maps, so a model chosen in the wizard is mapped straight away.
- Changing the eBird key, language or enabled flag refetches the local names for that language, forced rather than waiting for the monthly window, because the owner just asked for it.

Both stay detached and non-fatal. A naming improvement must not be able to report a completed download or a saved setting as a failure, and there is a test for that.

## On user renames

Asked alongside this: can the database carry a name the owner chose?

**It already does, and it must stay where it is.** `taxonomy_cache.manual_common_name` was added by migration `c7d8e9f0a1b2` and is applied through `COALESCE(manual_common_name, common_name)`.

It should **not** move into the new databases, and a new column there would be a mistake:

- `species_reference.db` is refused outright if it stops matching its checksum, so writing to it would break it.
- `species_names.db` and `model_taxon_map.db` are rebuilt from eBird and from label files, so a rename in either would be destroyed by the next refresh.

All three are disposable caches of public data. A rename is user data: it belongs in the application database, where it is Alembic-migrated and backed up with everything else the owner would miss.

It also already wins. `get_names` checks the cache before iNaturalist and before the bundled reference, so a renamed species keeps its name whatever any source says. That is now asserted by a test rather than left to the ordering happening to stay as it is.

## Verification

- `pytest` 2085 passed, 44 skipped (3 new)
- `ruff check .` / `ruff format --check .` clean from the repository root
- `docs_consistency_check.py` passed

## Scope

No schema change, no migration. Two new call sites and a `force` flag on an existing refresh.