### PR TITLE
Adopt the catalogue design and record what has to be reworked

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,9 +54,10 @@ delivered → release-defining initiatives → non-blocking backlog → breaking
 
 - [ ] The UI simplification pass has made Settings and the primary owner/guest journeys coherent,
   responsive, keyboard-operable, and honest about loading, empty, error, and destructive states.
-- [ ] A separately versioned SQLite species catalogue maps every supported model output index to
-  a canonical taxon and supplies common, scientific, and translated names without requiring model
-  label text files at runtime; migration from existing taxonomy data is lossless and reversible.
+- [ ] The dedicated, versioned SQLite species catalogue is authoritative for model-output identity
+  and translated species names; every supported model checksum has a complete output-index mapping,
+  label text files are no longer runtime truth, and upgraded detections preserve their history and
+  owner overrides.
 - [ ] Native editorial review is complete for locales presented as fully supported, or any residual
   language-quality limitations are labelled honestly in the release notes.
 - [x] Stable installation and recovery docs match the shipped Compose defaults and first-run auth
@@ -113,99 +114,62 @@ All four recommendations from the
 The headline work that makes `3.0` a major version: a guided first run, a cleaner product
 surface, a codebase reviewed to the gold standard, and complete translations.
 
-#### Versioned species catalogue and model mapping 🐦
-**Priority:** P1 | **Effort:** M remaining (was L) | **Status:** 🔄 In progress — the catalogue, the
-bundled data and the index mapping are delivered; what remains is making `labels.txt` unnecessary at
-runtime
+#### Versioned species catalogue and model-output identity 🗂️
+**Priority:** P1 | **Effort:** XL | **Status:** 🔄 Phases 1 and 2 partly delivered
 
-Design and measurements:
-[`docs/plans/2026-08-19-species-reference-source-decision.md`](docs/plans/2026-08-19-species-reference-source-decision.md)
-and
-[`docs/plans/2026-08-19-model-output-index-mapping.md`](docs/plans/2026-08-19-model-output-index-mapping.md).
+Design: [`docs/plans/2026-08-12-versioned-species-catalogue-design.md`](docs/plans/2026-08-12-versioned-species-catalogue-design.md).
+What is already built, what it is worth and what has to be reworked:
+[`docs/plans/2026-08-19-species-catalogue-reconciliation.md`](docs/plans/2026-08-19-species-catalogue-reconciliation.md).
+Source measurements: [`docs/plans/2026-08-19-species-reference-source-decision.md`](docs/plans/2026-08-19-species-reference-source-decision.md).
 
-##### ✅ Delivered
+Make a dedicated `/data/species_catalog.db` authoritative for species identity instead of relying on
+raw model-label text and whichever name a provider returned at detection time. It stays separate
+from the detections database so the catalogue can be enriched, versioned, validated and rolled back
+without rewriting detection history. It holds the complete taxon set emitted by supported models,
+accepted scientific names, source identifiers, synonyms, RFC 5646 translated common names,
+provenance, and owner overrides. Every exact model artifact checksum and output index maps to a
+canonical YA-WAMF species identity or an explicit non-species class.
 
-- **A bundled species reference**, `backend/app/assets/species_reference.db`, 3.87 MB, generated
-  from the IOC World Bird List (CC BY 3.0, attribution in `species_reference.NOTICE.md`). 11,276
-  species, 87,656 localized names covering all eight non-English locales. Refused at runtime if it
-  does not match `species_reference.db.sha256`; the build is reproducible so that digest is
-  checkable. Regenerate with `backend/scripts/build_species_reference.py --ioc <file>`.
-- **No API key is required** for local naming. eBird is an enhancement for species the list does not
-  carry, checked after it.
-- **Model label files are verified** against the checksum the registry publishes, with the verdict
-  reported in classifier status and on the Health page. A changed file is reported, not refused,
-  because customising labels is legitimate.
-- **An output-index mapping**, `model_taxon_map.db`, keyed on the label file's digest so a
-  republished model is a distinct artifact. Coverage measured on the installed models:
-  `rope_vit_b14_inat21` 100%, `convnext_large_inat21` and `eva02_large_inat21` 100%,
-  `mobilenet_v2_birds` 99.9%, `flexivit_il_all` 90.2%, `eu_medium_focalnet_b` 88.1%.
-- **Rebuilt when a model installs or the eBird settings change**, so a fresh install does not wait
-  for a restart.
-- **User renames stay in `taxonomy_cache.manual_common_name`** and outrank every source. They must
-  never move into the reference or the maps: those are rebuilt from their sources, and the reference
-  is refused outright if its digest changes.
+This does not pretend classifiers can work without an ordered output mapping. It replaces standalone
+label files as runtime truth with a checksum-bound mapping imported into SQLite.
 
-##### ☐ Next, in order
+##### Delivered so far
 
-1. **Use the mapping for naming.** `detection_service` resolves names from `classification["label"]`.
-   Attach the mapped scientific name at the classifier boundary, where the output index and the
-   model are both known, and prefer it as the lookup key. `_build_classification_results` in
-   `classifier_service.py` is the one shared builder, with three callers. Only the ungrouped path
-   carries a real output index; the grouped path aggregates several indices into one row and must
-   keep using label text. Fall back to the text path whenever a model has no mapping.
-2. **Move grouped labels and display off `labels.txt`.** This is the step that satisfies the exit
-   criterion, and it is a refactor of the path every detection takes, so it belongs on its own
-   branch. `ModelInstance.load()` reads the file into `self.labels` and `self.grouped_labels`; both
-   need to come from the mapping instead, and `build_grouped_classifier_labels` needs a source of
-   grouping that is not the raw file.
-3. **Close the last coverage gap.** About 10% of the European models' labels resolve to no
-   scientific name in any source we hold. Measure what they are before choosing a fourth source;
-   they may be regional or non-bird labels that do not warrant one.
-4. **Explain limits on the Health page.** The Naming Sources card reports numbers but not why they
-   are what they are. Nielsen's heuristics and §5 ask for the reason, not just the state.
+A seed catalogue built from the IOC World Bird List (11,276 species, 87,656 localized names,
+CC BY 3.0, reproducible build, digest-verified at runtime), the source measurements behind choosing
+it, label-file verification against the registry checksum with the verdict surfaced on the Health
+page, and a first output-index mapping.
 
-##### Where things live
+##### Known defect in the delivered layer
 
-| File | Where | Rebuilt from | Committed |
-| --- | --- | --- | --- |
-| `species_reference.db` | `backend/app/assets/` | IOC workbook, via the generator | yes, with a `.sha256` |
-| `model_taxon_map.db` | beside the application DB | label files, at install and startup | no |
-| `species_names.db` | beside the application DB | eBird, per locale | no |
+It keys identity on the **scientific name**. Those change when taxa are split, lumped or
+synonymised, so `Parus caeruleus` and `Cyanistes caeruleus` become two different birds to anything
+keying on the text, and history divides silently. The design's opaque `species_id` with
+`accepted_species_id` is the fix, and it lands in Phase 4. **Until then, do not add further
+consumers of the current mapping**: anything taught to trust that key has to be undone.
 
-The last two hold reproducible copies of public data, so they carry no Alembic migration and losing
-them costs one refresh. Anything a user chose belongs in the application database instead.
+##### Phases
 
-##### Reproducing the measurements
+| Phase | State |
+| --- | --- |
+| 0. Freeze the contract and provenance gate | ☐ |
+| 1. Catalogue schema and deterministic builder | 🔄 seed and builder exist; schema, Catalogue of Life import for non-bird classes, seed-then-copy into `/data`, and the dedicated Alembic stream remain |
+| 2. Checksum-bound model mappings | 🔄 label verification exists; `model_artifacts` keyed on the model checksum and `model_output_taxa` with class kinds remain |
+| 3. Shadow resolution and historical backfill | ☐ |
+| 4. Make catalogue identity authoritative | ☐ retires the scientific-name key |
+| 5. Remove label-file authority before `3.0` | ☐ |
 
-The figures above were taken from label files on a live deployment, not from fixtures. To repeat
-them, copy the label files out of a running container:
+##### Cheap, independent of the phases
 
-```bash
-docker exec <container> sh -lc 'cat /data/models/<model>/labels.txt'
-```
+- Explain naming limits on the Health page rather than only reporting numbers (§5).
+- Measure the ~10% of European model labels that resolve to no scientific name in any held source,
+  before deciding whether a further source is warranted.
 
-The models with useful label formats are `rope_vit_b14_inat21` (iNaturalist hierarchy),
-`mobilenet_v2_birds` (paired), `convnext_large_inat21` (bare binomial) and `eu_medium_focalnet_b`
-(common name only). Guessing whether a bare two-word label is a scientific name does not work and
-should not be attempted again: a word list claimed 198 common names as scientific, and a statistical
-discriminator separated the files by only a factor of two. The format is declared in
-`label_integrity._SCIENTIFIC_LABEL_MODELS` instead.
-
-##### Amendments to the exit criteria
-
-- The criterion's "without requiring model label text files at runtime" is **not yet met**. Steps 1
-  and 2 above are what meet it.
-- Index binding is kept, not dropped. An earlier recommendation to drop it was wrong: it measured
-  resolution only and missed that binding raises the flagship model from 57.9% to 100% and removes
-  an unverified runtime input.
-- "Supplies translated names" is met for the eight bundled locales, at 90.5% for Italian and 100%
-  for Chinese, so no release-note limitation is needed for language coverage.
-
-**Acceptance:** every shipped classifier has complete, checksum-bound index coverage; missing or
-ambiguous mappings fail closed; common/scientific/locale switches do not change filtering or
-analytics identity; existing `taxonomy_cache` and translation rows migrate without loss;
-backup/restore and rollback are exercised; and tests prove two models with different label orders
-resolve the same bird to the same taxon (already covered in `test_model_taxon_map.py`).
+**3.0 gate:** all supported models and regional variants have complete mappings; normal inference
+and reads work offline; locale changes affect display only; catalogue refresh is transactional and
+reversible; backup/restore includes both databases; and real upgraded databases prove that
+detections, unresolved legacy rows, provider identifiers, and manual names survive without
+reinterpretation or loss.
 
 #### First-run setup wizard 🧭
 **Priority:** P1 | **Effort:** L | **Status:** ✅ Shipped on `dev` — multi-part, hardware-validating, re-runnable from the Settings navigation ([design](docs/plans/2026-07-12-first-run-setup-wizard-design.md))

--- a/docs/plans/2026-08-06-species-reference-and-name-resolution.md
+++ b/docs/plans/2026-08-06-species-reference-and-name-resolution.md
@@ -1,7 +1,9 @@
 # Species reference and name resolution
 
 Date: 2026-08-06
-Status: Superseded in part — the open decisions are resolved in
+Status: Superseded by
+[2026-08-12-versioned-species-catalogue-design.md](2026-08-12-versioned-species-catalogue-design.md),
+which is the accepted design. Kept for the measurements and the option analysis. Superseded in part — the open decisions are resolved in
 [2026-08-19-species-reference-source-decision.md](2026-08-19-species-reference-source-decision.md),
 which measures the coverage this document assumed
 

--- a/docs/plans/2026-08-12-versioned-species-catalogue-design.md
+++ b/docs/plans/2026-08-12-versioned-species-catalogue-design.md
@@ -1,0 +1,353 @@
+# Versioned species catalogue and model-output identity
+
+**Roadmap item:** [The Road to 3.0 §1.2, Versioned species catalogue and model-output identity](../../ROADMAP.md#versioned-species-catalogue-and-model-output-identity-%EF%B8%8F)
+**Status:** Proposed, required before `3.0`
+**Scope:** Replace label-text identity with a dedicated, versioned, enrichable SQLite species catalogue that owns scientific names, source identifiers, synonyms, translated common names, and the exact output-index mapping for every supported classifier artifact.
+
+## Outcome
+
+Every class that a supported YA-WAMF model can emit resolves locally and deterministically to one
+catalogue taxon. Inference records the model artifact, output index, and canonical species identity;
+the UI, filters, notifications, exports, and integrations resolve names from that identity instead
+of treating a model label or translated common name as a key.
+
+The catalogue lives in `/data/species_catalog.db`, separate from the detection-history database at
+`/data/speciesid.db`. The separation is deliberate: YA-WAMF can enrich, version, validate, and roll
+back taxonomy and translations without rewriting the user's detection history. Both files are user
+data and both are included in backup, restore, integrity checks, and upgrade testing.
+
+The current `taxonomy_cache` and `taxonomy_translations` data is migrated conservatively into the
+catalogue. During the compatibility window it remains readable in `speciesid.db`; it is not dropped
+until the separate catalogue has been proven complete on upgraded installations.
+
+## Why this is needed
+
+YA-WAMF currently has three overlapping sources of species identity:
+
+- model output position plus `labels.txt`;
+- detection snapshots in `display_name`, `scientific_name`, `common_name`, and the iNaturalist
+  `taxa_id`;
+- provider-backed rows in `taxonomy_cache` and `taxonomy_translations`.
+
+That is why an old detection can know enough to show the right Species Details view while a
+different query still has only a scientific name. It also makes a translated common name look like
+a different species unless every read path performs the same recovery logic.
+
+Common names cannot safely be identifiers. They are not unique, they vary by locale and region,
+and owners may override them. Scientific names are the best interchange value but also change when
+taxonomies split, lump, or synonymise a taxon. The durable identity therefore needs to be an opaque
+YA-WAMF key with explicit, versioned links to provider taxon concepts.
+
+## Research findings
+
+- Darwin Core deliberately separates `taxonID`, `scientificNameID`,
+  `acceptedNameUsageID`, `scientificName`, and `vernacularName`. YA-WAMF should mirror that
+  separation instead of making one provider ID or display string carry every meaning.
+- The Catalogue of Life publishes pinned monthly and annual releases. Its Base Release prioritises
+  scrutinised sources, while its Extended Release maximises coverage. The Base Release is the
+  conservative starting point for accepted scientific names and synonym relationships.
+- eBird publishes a versioned taxonomy annually and supports more than 115 alternate common-name
+  sets. It is useful as a bird-specific crosswalk and name source, but bundled redistribution must
+  remain behind a documented licence/attribution check.
+- GBIF's species API works with name usages from multiple checklists, exposes vernacular names and
+  synonyms, and supports identifier-first matching. It is suitable for crosswalk validation, not
+  as an unversioned runtime identity.
+- LiteRT formally maps an output tensor axis to a label associated file. ONNX offers optional
+  model metadata but does not define a universal species-label contract. A classifier therefore
+  always needs an ordered output mapping, even when there is no standalone `labels.txt` at
+  runtime.
+- RFC 5646 language tags can include language, script, region, and variants. The existing
+  five-character `language_code` limit is too narrow for values such as `zh-Hant` or `pt-BR`.
+
+## Boundaries
+
+### In scope
+
+- Every species, aggregate, hybrid, background, and unknown class emitted by every model in the
+  supported YA-WAMF registry.
+- Accepted scientific names, synonyms, provider identifiers, translated common names, provenance,
+  source release, and owner overrides.
+- Exact mapping from `(model artifact SHA-256, output index)` to catalogue identity or a deliberate
+  non-species class.
+- Offline runtime resolution after the model and catalogue are installed.
+- Compatibility and lossless backfill for existing detections and installed models.
+
+### Out of scope for the `3.0` gate
+
+- Bundling every known taxon in every kingdom. The first catalogue covers the complete YA-WAMF
+  model-output universe and its aliases, not millions of unrelated taxa.
+- Translating application UI copy. Species vernacular names and UI localisation remain separate
+  datasets and review processes.
+- Automatically merging ambiguous homonyms or silently rewriting historical classifications after
+  a taxonomic split or lump.
+- Requiring a live taxonomy provider during inference or ordinary read paths.
+
+## Data model
+
+Names are illustrative; the implementation design review may refine them before the first
+migration.
+
+| Table | Purpose and required constraints |
+|---|---|
+| `catalogue_releases` | One row per imported catalogue build: schema version, source release identifiers, generated time, content SHA-256, licence/citation manifest, and activation state. A new release becomes active only after a complete transactional import and validation. |
+| `species` | Opaque YA-WAMF `species_id`, rank, accepted/deprecated state, and optional `accepted_species_id` for synonym or successor relationships. No common name is stored as identity. |
+| `species_concepts` | Source-specific taxon concept: `species_id`, provider, provider taxon ID, source release, accepted-name usage, canonical scientific name, authorship, and status. Unique on provider + release + provider ID. |
+| `species_names` | `species_id`, RFC 5646 language tag, name, name kind, preferred flag, region where applicable, provider, source release, and provenance. Unique provider records coexist; deterministic precedence chooses one display value. |
+| `species_aliases` | Normalised legacy label, former scientific name, provider synonym, or curated alias mapped to `species_id`, with source and confidence. Ambiguous aliases are stored as unresolved candidates, never guessed. |
+| `model_artifacts` | Registry model/variant ID, model SHA-256, mapping-set SHA-256, output width, runtime, model version, and installation state. The artifact checksum, not the friendly model ID, owns the mapping. |
+| `model_output_taxa` | `model_artifact_id`, zero-based output index, class kind (`species`, `hybrid`, `aggregate`, `background`, `unknown`), optional `species_id`, and original source label for audit. Unique on artifact + output index. |
+| `species_name_overrides` | Owner-owned display names, separate from provider data, so catalogue refreshes never overwrite them. Scope is species + optional RFC 5646 language tag. |
+
+Detections gain nullable `species_id`, `model_artifact_id`, and `model_output_index` columns. Existing
+scientific/common/display fields remain as historical snapshots and compatibility fields through the
+transition. Existing iNaturalist `taxa_id` becomes one external identifier rather than the canonical
+key.
+
+## Database and lifecycle boundary
+
+- **Separate connections:** repositories open `speciesid.db` and `species_catalog.db` independently.
+  Runtime code does not rely on a permanent SQLite `ATTACH`, cross-database foreign keys, or a
+  distributed transaction. The shared value is an opaque, immutable `species_id`.
+- **Detection writes stay autonomous:** classification resolves the model output from the catalogue
+  before it writes a detection. The detection transaction stores `species_id`, artifact/index
+  provenance, and name snapshots, but never mutates catalogue tables.
+- **Enrichment stays autonomous:** taxonomy sync, translations, synonyms, provider identifiers, and
+  owner naming overrides write only to `species_catalog.db`. A failed enrichment cannot roll back or
+  corrupt a detection write.
+- **Independent migration stream:** `species_catalog.db` has a dedicated Alembic environment with
+  one linear head. CI applies fresh, upgrade, downgrade, upgrade, idempotency, and path-matrix checks
+  to both databases. No runtime `create_all` or implicit schema repair path is permitted.
+- **First installation:** the image carries a checksum-pinned seed catalogue. YA-WAMF validates and
+  atomically copies it into `/data` only when no catalogue has ever been initialised. It never
+  mistakes a later missing file for a fresh install.
+- **Missing or corrupt catalogue:** YA-WAMF fails closed for new species classification, preserves
+  incoming event recoverability, and serves existing detections from their stored name snapshots
+  with an owner-visible degraded-state warning. It does not silently replace a database that may
+  contain owner enrichments or overrides.
+- **Reads and cache:** the checksum-verified active model mapping can be held in an immutable
+  in-memory cache after startup. Catalogue release activation atomically replaces that cache only
+  after validation; partially imported data is never visible.
+- **Backup and restore:** a supported backup is one coordinated bundle containing
+  `speciesid.db`, `species_catalog.db`, catalogue/version metadata, and configuration. Restore
+  validates both SQLite files and their recorded catalogue IDs before making either live.
+
+## Source and precedence policy
+
+1. **Canonical taxonomy:** import a pinned Catalogue of Life Base Release for the taxa required by
+   supported model mappings. Record its DOI/release, checksum, licence, and source citations.
+2. **Bird-specific crosswalk:** validate scientific names, eBird species codes, hybrids, and
+   aggregates against one pinned eBird taxonomy release. A taxonomy disagreement remains explicit;
+   import tooling does not silently choose a fuzzy match.
+3. **Common names:** store each name with language tag, provider, release, and region. Import or
+   redistribute only when the source licence permits it. Existing iNaturalist/eBird calls may enrich
+   an installation's local catalogue on demand, but provider failure cannot block inference.
+4. **Owner override:** an owner's name wins for display and survives every provider refresh. It does
+   not change canonical identity, exports that require provider names, or another locale.
+5. **Fallback:** requested locale + region, requested base language, configured English provider
+   name, scientific name. The API should expose provenance so the UI never presents a fallback as a
+   verified translation.
+
+The build pipeline fails when a source has no explicit compatible licence/citation record. It never
+scrapes names from arbitrary web pages.
+
+## Model contract
+
+Species classifiers do not emit names. ONNX and OpenVINO models normally return a floating-point
+tensor shaped `[1, N]`, with one logit per trained class; YA-WAMF applies softmax. TFLite returns
+the same class-axis shape as probabilities, logits, or quantised integers; YA-WAMF dequantises and
+normalises it. In every case the semantic result is an output position and score, for example
+`index=2, score=0.84`. Only the mapping gives index `2` a species meaning.
+
+The versioned SQLite catalogue directly stores the complete mapping for each supported classifier
+artifact. Model installation performs a lookup by model SHA-256; it does not download or read a
+label or mapping sidecar at runtime.
+
+Release tooling may consume embedded LiteRT metadata, ONNX metadata, or a reviewed legacy label
+file as build input. It normalises that evidence into `model_artifacts` and `model_output_taxa`
+rows before the catalogue is published. A machine-readable intermediate record can look like this:
+
+```json
+{
+  "schema_version": 1,
+  "model_sha256": "...",
+  "output_count": 1486,
+  "taxonomy_release": "...",
+  "outputs": [
+    {
+      "index": 0,
+      "kind": "species",
+      "source": "catalogue-of-life",
+      "source_taxon_id": "...",
+      "scientific_name": "Passer domesticus"
+    }
+  ]
+}
+```
+
+That intermediate file is reproducibility evidence for the catalogue builder, not a runtime model
+dependency. The catalogue release stores its resulting mapping-set checksum and source provenance.
+
+Installation is fail-closed. YA-WAMF verifies the model checksum, finds exactly one matching
+database mapping, checks its mapping-set checksum, contiguous indices, output count against the
+model tensor, unique source identifiers, and complete resolution of every species class before
+activation. Non-species outputs must be declared rather than hidden in special label strings.
+
+At inference time the winning tensor index resolves through `model_output_taxa`. Several indices
+may deliberately resolve to the same `species_id`; their probabilities are aggregated according to
+the stored mapping policy, replacing today's label-text grouping. Supported models no longer parse
+a text label to discover identity. `labels.txt` remains only as an import adapter for legacy or
+owner-supplied models until their mapping has been imported and verified; it is not the runtime
+source of truth.
+
+The separate crop detector is outside this species mapping. Its raw outputs are bounding boxes,
+numeric detector class IDs, and confidence values (or a YOLOX tensor containing those values). Its
+single target `bird` class stays in checksum-bound detector configuration rather than being treated
+as a taxonomic species.
+
+## Delivery plan
+
+### Phase 0: freeze the contract and provenance gate
+
+- Inventory every current registry model/region variant, output width, model SHA-256, label
+  checksum, label grammar, non-species class, and training taxonomy.
+- Decide and document the pinned Catalogue of Life and eBird releases used for the first build.
+- Add a machine-readable source manifest with URL, release, checksum, licence, attribution, and
+  redistribution decision.
+- Produce a report of exact, synonym, split/lump, aggregate, hybrid, and unresolved mappings. No
+  fuzzy result may enter a release without review.
+
+**Evidence:** the inventory covers 100% of supported artifact checksums; rebuilding from pinned
+inputs produces the same catalogue checksum; the licence gate rejects an unknown source.
+
+### Phase 1: catalogue schema and deterministic builder
+
+- Add a dedicated, single-head Alembic migration environment for `species_catalog.db`, with
+  reversible and idempotent migrations for the catalogue tables and RFC 5646 language tags. Do not
+  drop or repurpose `taxonomy_cache` or `taxonomy_translations` in `speciesid.db` yet.
+- Add a repository-owned importer that validates a release in staging tables and activates it in
+  one transaction. Interrupted imports leave the previous release active.
+- Build only the complete model-output taxon set plus aliases and supported-locale names. Keep the
+  source artifact outside migration code so migrations remain small and deterministic.
+- Add repository methods for identity lookup, locale fallback, alias search, and provenance.
+
+**Evidence:** fresh install, upgrade, downgrade, upgrade, interrupted import, repeat import,
+catalogue rollback, missing/corrupt catalogue, and coordinated backup/restore tests all preserve
+detection history and owner overrides.
+
+### Phase 2: checksum-bound model mappings
+
+- Compile reviewed mapping rows into the catalogue for every supported artifact and regional
+  variant. Keep source manifests only as deterministic build inputs and review evidence.
+- During model installation and activation, resolve the model SHA-256 directly against SQLite and
+  verify output tensor width before a model becomes selectable. Do not download a runtime mapping
+  sidecar.
+- Add diagnostics that report mapping coverage, catalogue release, source mismatch, and unresolved
+  classes without exposing raw provider credentials.
+- Reject a same-name model whose checksum differs from the registered mapping.
+
+**Evidence:** every supported model has exactly one mapping for every output index; swapped,
+truncated, duplicated, or wrong-checksum mappings fail activation; hardware smoke tests resolve the
+same top outputs on every runtime flavour.
+
+### Phase 3: shadow resolution and historical backfill
+
+- Resolve inference through both the current label path and the new catalogue path, persist only
+  when they agree, and surface mismatches in owner diagnostics.
+- Backfill `species_id` conservatively from existing iNaturalist IDs, exact scientific names, and
+  unambiguous aliases. Keep unresolved rows unchanged and report counts; never guess from a common
+  name shared by multiple taxa.
+- Copy existing provider taxonomy, translations, and manual overrides into the separate catalogue
+  with provenance. Re-running the migration is a no-op and never deletes the source rows.
+- Record model artifact and output index on new detections while retaining name snapshots.
+- Update audio correlation, manual observations, backfill, and video reclassification to use the
+  same resolver.
+
+**Evidence:** a copy of a real upgraded database produces identical detection counts, grouping,
+filters, notification decisions, and exports; every unresolved row remains readable and repairable.
+
+### Phase 4: make catalogue identity authoritative
+
+- Move leaderboard, Events, Species Details, search, filters, notifications, BirdNET correlation,
+  eBird export, and external integrations to `species_id` joins through repositories.
+- Resolve translated display names at read time with one shared precedence function. Do not write a
+  locale-dependent name back into canonical detection identity.
+- Preserve API compatibility fields while adding canonical identity and name provenance to typed
+  response models and generated frontend types.
+- Make taxonomy provider sync an explicit catalogue enrichment job with visible status, version,
+  errors, and rollback rather than scattered read-time network lookups.
+
+**Evidence:** changing locale changes display only; every affected surface shows the same species;
+provider outage tests prove normal inference and reads remain local; query benchmarks meet or beat
+the current taxonomy joins.
+
+### Phase 5: remove label-file authority before `3.0`
+
+- Stop requiring standalone `labels.txt` or another mapping sidecar for registry-supported models.
+  Prefer embedded model metadata as build evidence where available, but always compile it into the
+  catalogue mapping tables before release.
+- Keep a documented compatibility importer for owner-supplied/pre-3.0 models. It must produce an
+  explicit unresolved mapping report before activation.
+- Retire duplicated name-recovery SQL after `taxonomy_cache` and `taxonomy_translations` data has
+  migrated into the separate catalogue without loss. Keep a bounded compatibility reader through
+  the pre-3.0 upgrade window rather than attempting cross-database compatibility views.
+- Document catalogue version, model mapping status, source citations, update/rollback behaviour,
+  and backup implications in owner diagnostics and upgrade notes.
+
+**Evidence:** a clean install and an upgraded install run all supported models without runtime
+label-file reads; all model flavours pass image smoke tests; the full Definition of Done and `3.0`
+migration evidence are green.
+
+## Safety and second-order effects
+
+- **Taxonomic change is not historical correction.** A later split or lump must not silently
+  rewrite what an older model predicted. Detection evidence stays bound to the model artifact and
+  output mapping used at the time; current accepted names are a separate presentation layer.
+- **Model names are not model identity.** Region variants and replaced artifacts may share a
+  friendly ID while changing output order. Only SHA-256-bound mappings may activate.
+- **Translations are not keys.** Locale changes must never alter filters, notification policy,
+  deduplication, audio correlation, or exports.
+- **Manual overrides are user data.** Catalogue import, provider refresh, rollback, and migration
+  must preserve them exactly.
+- **Ambiguity fails closed.** Homonyms, fuzzy matches, missing taxa, and source disagreements remain
+  unresolved until reviewed. The system keeps the raw output and remains operable.
+- **Source updates are explicit.** A new upstream taxonomy is a reviewed catalogue release with a
+  diff and rollback, not an automatic mutable dependency at startup.
+- **Storage and backup remain bounded.** Scope the bundled catalogue to taxa YA-WAMF can emit;
+  measure database growth and coordinated two-database backup/restore time before widening it.
+- **No cross-database foreign keys.** `speciesid.db` retains an opaque `species_id` and historical
+  name snapshots. Integrity diagnostics report orphaned identifiers, while catalogue rollback keeps
+  previously referenced identities available or explicitly deprecated rather than deleting them.
+- **Search indexes are derived.** If SQLite FTS5 is introduced, rebuild it from catalogue tables and
+  integrity-check it; never make the index the only copy of a name.
+
+## Acceptance criteria for `3.0`
+
+- Every supported model artifact and regional variant has complete, checksum-bound output mapping.
+- New visual, video, manual, and audio-correlated detections persist canonical `species_id`; model
+  detections also persist artifact and output-index provenance.
+- All primary species surfaces and policies join by canonical identity, not common-name or raw-label
+  equality.
+- Supported UI locales can resolve available species names locally with documented provenance and
+  deterministic fallback.
+- Existing detections, manual overrides, and external IDs survive a tested upgrade and rollback;
+  unresolved legacy rows remain visible.
+- A supported backup and restore round trip preserves and validates both SQLite files; a missing or
+  corrupt catalogue degrades safely without modifying `speciesid.db`.
+- Registry-supported inference no longer depends on standalone label files at runtime.
+- Catalogue refresh is transactional, versioned, observable, reversible, and never required for
+  startup or inference.
+- Source licences, versions, citations, and content checksums are present in the shipped catalogue
+  manifest and owner diagnostics.
+
+## References
+
+- [Darwin Core taxon and language terms](https://dwc.tdwg.org/terms/)
+- [Catalogue of Life downloads and version archive](https://www.catalogueoflife.org/data/download)
+- [Catalogue of Life release metadata](https://www.catalogueoflife.org/data/metadata)
+- [eBird taxonomy and release model](https://science.ebird.org/en/use-ebird-data/the-ebird-taxonomy)
+- [GBIF Species API](https://techdocs.gbif.org/en/openapi/v1/species)
+- [GBIF taxonomy interpretation and identifier matching](https://techdocs.gbif.org/en/data-processing/taxonomy-interpretation)
+- [RFC 5646 language tags](https://www.rfc-editor.org/rfc/rfc5646)
+- [LiteRT model metadata and tensor-axis labels](https://developers.google.com/edge/litert/conversion/tensorflow/metadata)
+- [ONNX intermediate representation and model metadata](https://onnx.ai/onnx/repo-docs/IR.html)
+- [SQLite FTS5 integrity considerations](https://www.sqlite.org/fts5.html)

--- a/docs/plans/2026-08-19-species-catalogue-reconciliation.md
+++ b/docs/plans/2026-08-19-species-catalogue-reconciliation.md
@@ -1,0 +1,128 @@
+# Species catalogue: reconciling what shipped with the design
+
+Date: 2026-08-19
+Status: Accepted plan
+Spine: [2026-08-12-versioned-species-catalogue-design.md](2026-08-12-versioned-species-catalogue-design.md)
+
+## What happened
+
+The catalogue design of 2026-08-12 sat uncommitted in a worktree. Work in mid-August proceeded from
+the older note of 2026-08-06 instead, and shipped a naming layer that is roughly Phase 1 of the
+design, built early and keyed wrongly.
+
+**The 2026-08-12 design is the spine.** This document records what already exists, what it is worth,
+what has to be reworked, and the order to do it in. Where the two disagree, the design wins except
+on the two points called out under *Refinements*, which are backed by measurements taken since.
+
+## What shipped, and where it belongs
+
+| Delivered | Status against the design |
+| --- | --- |
+| `species_reference.db`: IOC World Bird List, 11,276 species, 87,656 localized names, CC BY 3.0, reproducible build, digest-verified | **Keep as the seed.** It is the design's checksum-pinned seed catalogue, minus the copy-into-`/data` step. |
+| Source measurements: IOC vs eBird vs Coral coverage, per-locale completeness, the GBIF ambiguity finding | **Keep.** This is the evidence Phase 1's source selection needs, and it is expensive to reproduce. |
+| Label-file verification against the registry checksum, verdict surfaced in status and on the Health page | **Keep.** It is the design's artifact-checksum ownership, arriving early. |
+| `model_taxon_map.db`: `(label digest, output index) → scientific name` | **Replace** with `model_artifacts` + `model_output_taxa`. It has no class kind and keys on the label file rather than the model artifact. |
+| `species_names.db` and the eBird localized-name store | **Replace** with `species_names`. Provider, release and region belong on each name; a separate store cannot express precedence. |
+| Common-name resolution for the European models | **Fold into** `species_aliases`, which already specifies that an ambiguous alias is stored as an unresolved candidate rather than guessed. |
+| Renames in `taxonomy_cache.manual_common_name` | **Migrate** to `species_name_overrides`, scoped to species plus language. |
+
+## The defect worth naming
+
+The shipped layer keys identity on the **scientific name**. The design keys it on an opaque
+`species_id` with `accepted_species_id` for synonyms and successors, and it is right to.
+
+A scientific name is not stable. When a taxon is split, lumped or synonymised, `Parus caeruleus` and
+`Cyanistes caeruleus` become two different birds to anything that keys on the text: leaderboards
+divide, filters miss history, and a species page shows half its sightings. Nothing warns anyone.
+
+This is not a refactor for tidiness. It is the reason the design exists, and it should be fixed
+before more read paths are taught to trust the current key.
+
+## Refinements to the design
+
+Both are backed by measurements taken while building the shipped layer.
+
+### 1. Two canonical sources, not one
+
+The design names a pinned Catalogue of Life release as canonical taxonomy and eBird as the bird
+crosswalk. That is right for identity, and it must stay: the 10,000-class models emit **8,514
+non-bird classes**, which no bird list covers.
+
+But Catalogue of Life is the wrong source for *vernacular* names. Measured on 2026-08-19, its
+aggregated names offer several candidates per language with nothing to choose between them: for
+`Cyanistes caeruleus` GBIF returns both `Cinciarella` and `Cinciallegra` as Italian, and the second
+is the name of a different species. Shipping that is worse than shipping English, because the reader
+cannot tell it is wrong.
+
+The IOC World Bird List carries one curated name per species per language and is CC BY 3.0.
+Measured against the alternatives:
+
+| | Coral | eBird | **IOC** |
+| --- | ---: | ---: | ---: |
+| Birds the flagship model emits | 57.9% | 94.9% | **95.2%** |
+| `flexivit_il_all` labels | 32.4% | 78.2% | **90.2%** |
+| `eu_medium_focalnet_b` labels | 33.1% | 77.9% | **88.1%** |
+| Italian | n/a | **5.8%** | **90.5%** |
+| Chinese | n/a | **30.8%** | **100%** |
+| Requires an API key | no | **yes** | no |
+
+So the precedence policy becomes: **Catalogue of Life for taxonomy and identity across all
+kingdoms, eBird as the bird crosswalk, IOC for bird vernacular names, iNaturalist and eBird for
+on-demand enrichment.** Each still carries its release, checksum, licence and citation.
+
+This also removes an API key as a requirement for names in the owner's language, which the current
+runtime-eBird arrangement makes necessary.
+
+### 2. Do not guess a label's format
+
+The design says an ambiguous alias is stored as an unresolved candidate, never guessed. Two attempts
+to do otherwise were made and abandoned, and the results belong on the record so a third is not
+attempted:
+
+- A list of adjectives that cannot begin a genus claimed **198 common names as scientific** on
+  `eu_medium_focalnet_b`. Those would have entered history as identities.
+- A statistical discriminator, the ratio of distinct second words, separated scientific from
+  common-name label files by only 0.65 against 0.31.
+
+A bare `Genus species` is indistinguishable from `African crake` by shape. The format is declared per
+model artifact, and anything undeclared resolves by lookup or stays unresolved.
+
+## Plan
+
+Phases follow the design. The delivered work moves Phase 1 substantially forward and gives Phase 2 a
+worked example, but neither is complete against the schema.
+
+| Phase | State | What remains |
+| --- | --- | --- |
+| 0. Freeze the contract and provenance gate | ☐ | Unchanged from the design. Pin the Catalogue of Life and eBird releases, and record IOC's release and citation alongside them. |
+| 1. Catalogue schema and deterministic builder | 🔄 | The IOC seed, its reproducible build and its digest verification exist. Needed: the full schema, the Catalogue of Life import for non-bird classes, seed-then-copy into `/data`, and the dedicated Alembic stream. |
+| 2. Checksum-bound model mappings | 🔄 | Label-file verification exists. Needed: `model_artifacts` keyed on the model checksum rather than the label digest, and `model_output_taxa` with class kinds for hybrid, aggregate, background and unknown. |
+| 3. Shadow resolution and historical backfill | ☐ | Unchanged. |
+| 4. Make catalogue identity authoritative | ☐ | Unchanged, and this is where the scientific-name key is retired. |
+| 5. Remove label-file authority before `3.0` | ☐ | Unchanged. |
+
+### Ordering note
+
+Phase 4 retires the scientific-name key. Until then, every read path taught to trust the current key
+is work that has to be undone, so **no further consumers of `model_taxon_map` should be added**. The
+naming fallback it feeds today is harmless because it only supplies a display name when the network
+cannot; making it authoritative is not.
+
+### Cheap and worth doing first
+
+Two items are small and independent of the phases:
+
+- Explain limits on the Health page. It reports naming coverage without saying why a number is what
+  it is, which §5 asks for.
+- Measure the ~10% of European model labels that resolve to no scientific name in any held source,
+  before deciding whether a further source is warranted. They may be regional or non-species
+  classes that `class_kind` handles instead.
+
+## What this costs
+
+Some of what merged between 2026-08-15 and 2026-08-19 is superseded: the model map, the localized
+name store, and the placement of owner overrides. The IOC seed, the measurements, the label
+verification and the refusal to guess all carry forward.
+
+That is the right outcome. The alternative is a second identity scheme accumulating read paths
+alongside the one the design specifies.

--- a/docs/plans/2026-08-19-species-reference-source-decision.md
+++ b/docs/plans/2026-08-19-species-reference-source-decision.md
@@ -1,6 +1,10 @@
 # Species reference: resolving the source decision
 
 Date: 2026-08-19
+Note: the accepted design is
+[2026-08-12-versioned-species-catalogue-design.md](2026-08-12-versioned-species-catalogue-design.md);
+this document supplies its source measurements. See
+[2026-08-19-species-catalogue-reconciliation.md](2026-08-19-species-catalogue-reconciliation.md).
 Status: Implemented, except the Italian question. Resolves the two open decisions in
 [2026-08-06-species-reference-and-name-resolution.md](2026-08-06-species-reference-and-name-resolution.md)
 


### PR DESCRIPTION
Documentation only, and a correction of course.

## What happened

The species catalogue design of **12 August** was sitting uncommitted and unpushed in `.worktrees/yawamf-species-catalog-roadmap`, along with a roadmap entry and an exit criterion. It was never seen. Work last week proceeded from the older note of **6 August**, which it supersedes, and shipped a naming layer that is roughly Phase 1 of that design, built early and keyed wrongly.

This commits the design unmodified and makes it the spine. The roadmap entry is now **its** entry, including its exit criterion, which is more precise than the one written without it: it names identity, says label text stops being runtime truth, and requires owner overrides to survive an upgrade.

## The defect, named rather than left to be found

The delivered layer keys identity on the **scientific name**. Those change when taxa are split, lumped or synonymised, so `Parus caeruleus` and `Cyanistes caeruleus` become two different birds to anything keying on the text: leaderboards divide, filters miss history, a species page shows half its sightings, and nothing warns anyone.

The design's opaque `species_id` with `accepted_species_id` is the fix, and it lands in Phase 4. **Until then nothing further should be taught to trust the current key** — anything that is has to be undone. The existing fallback is harmless because it only supplies a display name when the network cannot answer; making it authoritative is not.

## What carries forward, and what does not

| Delivered | Verdict |
| --- | --- |
| IOC seed: 11,276 species, 87,656 localized names, CC BY 3.0, reproducible, digest-verified | **Keep** as the design's checksum-pinned seed |
| Source measurements and the GBIF ambiguity finding | **Keep** — expensive to reproduce, and Phase 1 needs them |
| Label-file verification with the verdict surfaced | **Keep** — artifact-checksum ownership, arriving early |
| `model_taxon_map.db` | **Replace** with `model_artifacts` + `model_output_taxa`; no class kind, keys on the label file not the artifact |
| `species_names.db` and the eBird store | **Replace** with `species_names`; provider, release and region belong on each name |
| Renames in `taxonomy_cache.manual_common_name` | **Migrate** to `species_name_overrides` |

## Two refinements to the design, both measured

**Catalogue of Life stays canonical for identity.** The 10,000-class models emit **8,514 non-bird classes** that no bird list covers, so a bird-only source cannot be the taxonomy.

**But it is the wrong source for vernacular names.** Its aggregated names offer several candidates per language with nothing to choose between them: for `Cyanistes caeruleus`, GBIF returns both `Cinciarella` and `Cinciallegra` as Italian, and the second is a different species. Shipping that is worse than shipping English, because the reader cannot tell it is wrong.

IOC is curated, one name per species per language, CC BY 3.0, and takes Italian from **5.8% to 90.5%** and Chinese to **100%** with no API key. So the precedence becomes Catalogue of Life for identity, eBird as the bird crosswalk, IOC for bird vernaculars, iNaturalist and eBird for on-demand enrichment.

**And the record of two abandoned attempts to guess a label's format is kept**, so a third is not made: a word list claimed 198 common names as scientific, and a statistical discriminator separated the files by only 0.65 against 0.31.

## Scope

No code. Four documents and the roadmap entry. `docs_consistency_check.py` passes.

The older 6 August note is marked superseded and cross-linked, so nobody works from it again — which is how this happened.

## For whoever picks this up

Two items are cheap and independent of the phases: explain naming limits on the Health page rather than only reporting numbers, and measure the ~10% of European model labels that resolve nowhere before deciding whether another source is warranted. They may be classes `class_kind` handles instead.