### PR TITLE
Give the species catalogue database its own versioned schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
           python -m alembic downgrade -1
           python -m alembic upgrade head
 
+      - name: Species catalogue migration smoke test
+        run: |
+          cd backend
+          export SPECIES_CATALOG_PATH=/tmp/yawamf-ci-species-catalog.db
+          rm -f "$SPECIES_CATALOG_PATH"
+          python -m alembic -c alembic_catalog.ini upgrade head
+          python -m alembic -c alembic_catalog.ini downgrade -1
+          python -m alembic -c alembic_catalog.ini upgrade head
+
       - name: Migration path matrix
         run: |
           cd backend
@@ -71,12 +80,13 @@ jobs:
           from alembic.config import Config
           from alembic.script import ScriptDirectory
 
-          script = ScriptDirectory.from_config(Config("alembic.ini"))
-          heads = script.get_heads()
-          if len(heads) != 1:
-              print(f"Expected 1 Alembic head, found {len(heads)}: {heads}")
-              sys.exit(1)
-          print(f"Alembic head OK: {heads[0]}")
+          for ini in ("alembic.ini", "alembic_catalog.ini"):
+              script = ScriptDirectory.from_config(Config(ini))
+              heads = script.get_heads()
+              if len(heads) != 1:
+                  print(f"{ini}: expected 1 Alembic head, found {len(heads)}: {heads}")
+                  sys.exit(1)
+              print(f"{ini}: Alembic head OK: {heads[0]}")
           PY
 
       - name: OpenAPI artifact up to date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- **The species catalogue database now has its own versioned schema.** Phase 1 groundwork for the
+  versioned species catalogue: a dedicated, single-head Alembic stream
+  (`backend/alembic_catalog.ini`, `backend/migrations_catalog/`) creates `/data/species_catalog.db`
+  with the full designed schema — opaque species identity with synonym links, provider taxon
+  concepts, RFC 5646 translated names, fail-closed aliases, checksum-keyed model artifacts, the
+  output-index mapping with declared class kinds, transactional release records (at most one
+  active), and owner name overrides that survive refreshes. Constraints live in the schema, the
+  stream is reversible and idempotent, and CI now smokes it and enforces one head per stream
+  alongside the detections database.
+
 - **The species catalogue's sources are now a frozen, machine-checked contract.** Phase 0 of the
   versioned species catalogue: `backend/app/assets/species_sources.json` pins every source species
   data may come from — the IOC World Bird List 14.2 already bundled, Catalogue of Life COL26.7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,16 @@ pass before any commit. "It builds" is not "it works".
   committed runtime code, and there must not be one.
 - **Every schema change ships a migration in the same commit.** Never edit an
   already-released migration; add a new one.
-- **Single head, reversible, idempotent.** There is exactly one Alembic head. Each
-  migration has a working `downgrade`; `upgrade → downgrade → upgrade` is a no-op
-  against an up-to-date database. CI enforces all three (see §9).
+- **Single head, reversible, idempotent.** There is exactly one Alembic head per
+  migration stream. Each migration has a working `downgrade`;
+  `upgrade → downgrade → upgrade` is a no-op against an up-to-date database. CI
+  enforces all three (see §9).
+- **Two independent migration streams.** `backend/migrations/` versions
+  `/data/speciesid.db` (detection history) via `alembic.ini`;
+  `backend/migrations_catalog/` versions `/data/species_catalog.db` (the species
+  catalogue) via `alembic_catalog.ini`. Neither stream may reference the other's
+  revisions, and no runtime code may hold cross-database foreign keys — the shared
+  value is an opaque `species_id`.
 - **Constraints belong in the schema**: `UNIQUE` (e.g. `frigate_event`), indexes,
   required columns, enum handling. Do not rely on application code to enforce what
   the database can enforce.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,7 +153,7 @@ consumers of the current mapping**: anything taught to trust that key has to be 
 | Phase | State |
 | --- | --- |
 | 0. Freeze the contract and provenance gate | 🔄 mostly delivered ([freeze note](docs/plans/2026-08-19-species-catalogue-phase0-freeze.md)): pinned sources (IOC 14.2, CoL COL26.7 by DOI, eBird 2025) in a machine-checked manifest with a licence/redistribution gate; per-artifact label grammar declared in the registry; 100%-coverage artifact [inventory](docs/reviews/2026-08-19-species-catalogue-phase0-inventory.md) held current by a regression test. Remaining: the synonym/split-lump mapping report, which needs Phase 1's CoL import |
-| 1. Catalogue schema and deterministic builder | 🔄 seed and builder exist; schema, Catalogue of Life import for non-bird classes, seed-then-copy into `/data`, and the dedicated Alembic stream remain |
+| 1. Catalogue schema and deterministic builder | 🔄 the dedicated Alembic stream and full catalogue schema are delivered (single-head, reversible, CI-smoked, constraints in-schema); the IOC seed and its builder exist. Remaining: the transactional staging importer, the Catalogue of Life import for non-bird classes, and seed-then-copy into `/data` |
 | 2. Checksum-bound model mappings | 🔄 label verification exists; `model_artifacts` keyed on the model checksum and `model_output_taxa` with class kinds remain |
 | 3. Shadow resolution and historical backfill | ☐ |
 | 4. Make catalogue identity authoritative | ☐ retires the scientific-name key |

--- a/backend/alembic_catalog.ini
+++ b/backend/alembic_catalog.ini
@@ -1,0 +1,47 @@
+# The species catalogue's own migration stream.
+#
+# /data/species_catalog.db is versioned independently of /data/speciesid.db so
+# taxonomy can be enriched, validated, and rolled back without touching
+# detection history. Same bar as the main stream: one head, reversible,
+# idempotent (see CLAUDE.md §3 and the catalogue design under docs/plans/).
+
+[alembic]
+script_location = migrations_catalog
+prepend_sys_path = .
+path_separator = os
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/app/services/species_catalog_migrations.py
+++ b/backend/app/services/species_catalog_migrations.py
@@ -1,0 +1,50 @@
+"""Programmatic access to the species catalogue's migration stream.
+
+The catalogue database has its own single-head Alembic environment
+(`alembic_catalog.ini` / `migrations_catalog/`), deliberately separate from the
+main `speciesid.db` stream: taxonomy can be migrated, enriched, and rolled back
+without holding any lock over detection history, and neither stream can depend
+on the other's revisions.
+
+These helpers are synchronous because Alembic is; callers on the event loop
+dispatch them through a worker thread.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+CATALOG_INI = _BACKEND_DIR / "alembic_catalog.ini"
+
+
+def default_catalog_path() -> Path:
+    configured = os.environ.get("SPECIES_CATALOG_PATH")
+    if configured:
+        return Path(configured)
+    return Path("/data/species_catalog.db")
+
+
+def catalog_alembic_config(db_path: Path | None = None) -> Config:
+    config = Config(str(CATALOG_INI))
+    config.set_main_option("script_location", str(_BACKEND_DIR / "migrations_catalog"))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path or default_catalog_path()}")
+    return config
+
+
+def catalog_migration_heads() -> list[str]:
+    script = ScriptDirectory.from_config(catalog_alembic_config(Path(":memory:")))
+    return list(script.get_heads())
+
+
+def upgrade_catalog(db_path: Path | None = None, revision: str = "head") -> None:
+    command.upgrade(catalog_alembic_config(db_path), revision)
+
+
+def downgrade_catalog(db_path: Path | None = None, revision: str = "-1") -> None:
+    command.downgrade(catalog_alembic_config(db_path), revision)

--- a/backend/migrations_catalog/env.py
+++ b/backend/migrations_catalog/env.py
@@ -1,0 +1,67 @@
+"""Alembic environment for the species catalogue database.
+
+A separate stream from the main `speciesid.db` environment on purpose: the
+catalogue can be enriched, validated, and rolled back without holding a
+migration lock over detection history, and neither stream can ever depend on
+the other's revisions.
+"""
+
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(os.getcwd())
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# The catalogue schema is defined in its migrations, not in model metadata.
+target_metadata = None
+
+
+def get_url() -> str:
+    configured = config.get_main_option("sqlalchemy.url")
+    if configured:
+        return configured
+    db_path = os.environ.get("SPECIES_CATALOG_PATH", "/data/species_catalog.db")
+    return f"sqlite:///{db_path}"
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=get_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = get_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, render_as_batch=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations_catalog/script.py.mako
+++ b/backend/migrations_catalog/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations_catalog/versions/b7c2f4a91e00_species_catalogue_schema.py
+++ b/backend/migrations_catalog/versions/b7c2f4a91e00_species_catalogue_schema.py
@@ -1,0 +1,207 @@
+"""species catalogue schema
+
+The initial schema for /data/species_catalog.db, from the catalogue design
+(docs/plans/2026-08-12-versioned-species-catalogue-design.md): opaque species
+identity with synonym links, provider concepts, RFC 5646 named translations,
+aliases that fail closed, checksum-keyed model artifacts, and the
+output-index mapping with declared class kinds. Constraints live here, not in
+application code.
+
+Revision ID: b7c2f4a91e00
+Revises:
+Create Date: 2026-08-19 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c2f4a91e00"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLES = (
+    "species_name_overrides",
+    "model_output_taxa",
+    "model_artifacts",
+    "species_aliases",
+    "species_names",
+    "species_concepts",
+    "species",
+    "catalogue_releases",
+)
+
+
+def _has_table(inspector: sa.Inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _has_table(inspector, "catalogue_releases"):
+        op.create_table(
+            "catalogue_releases",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("schema_version", sa.Integer(), nullable=False),
+            sa.Column("source_manifest", sa.Text(), nullable=False),
+            sa.Column("content_sha256", sa.String(), nullable=False),
+            sa.Column("generated_at", sa.String(), nullable=False),
+            sa.Column("state", sa.String(), nullable=False),
+            sa.Column("activated_at", sa.String(), nullable=True),
+            sa.CheckConstraint("state IN ('staged', 'active', 'retired')", name="ck_catalogue_releases_state"),
+            sa.UniqueConstraint("content_sha256", name="uq_catalogue_releases_content"),
+        )
+        op.create_index(
+            "uq_catalogue_releases_one_active",
+            "catalogue_releases",
+            ["state"],
+            unique=True,
+            sqlite_where=sa.text("state = 'active'"),
+        )
+
+    if not _has_table(inspector, "species"):
+        op.create_table(
+            "species",
+            sa.Column("species_id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("rank", sa.String(), nullable=False, server_default="species"),
+            sa.Column("status", sa.String(), nullable=False, server_default="accepted"),
+            sa.Column("accepted_species_id", sa.Integer(), nullable=True),
+            sa.CheckConstraint("status IN ('accepted', 'deprecated')", name="ck_species_status"),
+            sa.ForeignKeyConstraint(["accepted_species_id"], ["species.species_id"], name="fk_species_accepted"),
+            sqlite_autoincrement=True,
+        )
+
+    if not _has_table(inspector, "species_concepts"):
+        op.create_table(
+            "species_concepts",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("species_id", sa.Integer(), nullable=False),
+            sa.Column("provider", sa.String(), nullable=False),
+            sa.Column("provider_taxon_id", sa.String(), nullable=False),
+            sa.Column("source_release", sa.String(), nullable=False),
+            sa.Column("scientific_name", sa.String(), nullable=False),
+            sa.Column("authorship", sa.String(), nullable=True),
+            sa.Column("accepted_name_usage", sa.String(), nullable=True),
+            sa.Column("status", sa.String(), nullable=True),
+            sa.ForeignKeyConstraint(["species_id"], ["species.species_id"], name="fk_species_concepts_species"),
+            sa.UniqueConstraint(
+                "provider", "source_release", "provider_taxon_id", name="uq_species_concepts_provider_concept"
+            ),
+        )
+        op.create_index("idx_species_concepts_species", "species_concepts", ["species_id"])
+        op.create_index(
+            "idx_species_concepts_scientific",
+            "species_concepts",
+            [sa.text("scientific_name COLLATE NOCASE")],
+        )
+
+    if not _has_table(inspector, "species_names"):
+        op.create_table(
+            "species_names",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("species_id", sa.Integer(), nullable=False),
+            sa.Column("language_tag", sa.String(), nullable=False),
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("name_kind", sa.String(), nullable=False, server_default="vernacular"),
+            sa.Column("preferred", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("region", sa.String(), nullable=True),
+            sa.Column("provider", sa.String(), nullable=False),
+            sa.Column("source_release", sa.String(), nullable=False),
+            sa.ForeignKeyConstraint(["species_id"], ["species.species_id"], name="fk_species_names_species"),
+            sa.UniqueConstraint(
+                "species_id",
+                "language_tag",
+                "provider",
+                "source_release",
+                "name",
+                name="uq_species_names_provider_name",
+            ),
+        )
+        op.create_index("idx_species_names_species_language", "species_names", ["species_id", "language_tag"])
+
+    if not _has_table(inspector, "species_aliases"):
+        op.create_table(
+            "species_aliases",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("alias", sa.String(), nullable=False),
+            sa.Column("alias_kind", sa.String(), nullable=False),
+            sa.Column("species_id", sa.Integer(), nullable=True),
+            sa.Column("resolution", sa.String(), nullable=False, server_default="resolved"),
+            sa.Column("source", sa.String(), nullable=False),
+            sa.Column("confidence", sa.Float(), nullable=True),
+            sa.CheckConstraint(
+                "resolution IN ('resolved', 'candidate', 'unresolved')", name="ck_species_aliases_resolution"
+            ),
+            sa.ForeignKeyConstraint(["species_id"], ["species.species_id"], name="fk_species_aliases_species"),
+            sa.UniqueConstraint("alias", "alias_kind", "species_id", "source", name="uq_species_aliases_row"),
+        )
+        op.create_index("idx_species_aliases_alias", "species_aliases", [sa.text("alias COLLATE NOCASE")])
+
+    if not _has_table(inspector, "model_artifacts"):
+        op.create_table(
+            "model_artifacts",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("registry_id", sa.String(), nullable=False),
+            sa.Column("model_sha256", sa.String(), nullable=False),
+            sa.Column("mapping_set_sha256", sa.String(), nullable=True),
+            sa.Column("output_width", sa.Integer(), nullable=False),
+            sa.Column("runtime", sa.String(), nullable=False),
+            sa.Column("model_version", sa.String(), nullable=True),
+            sa.Column("state", sa.String(), nullable=False, server_default="registered"),
+            sa.CheckConstraint("state IN ('registered', 'installed', 'retired')", name="ck_model_artifacts_state"),
+            sa.CheckConstraint("output_width > 0", name="ck_model_artifacts_output_width"),
+            sa.UniqueConstraint("model_sha256", name="uq_model_artifacts_checksum"),
+        )
+        op.create_index("idx_model_artifacts_registry", "model_artifacts", ["registry_id"])
+
+    if not _has_table(inspector, "model_output_taxa"):
+        op.create_table(
+            "model_output_taxa",
+            sa.Column("model_artifact_id", sa.Integer(), nullable=False),
+            sa.Column("output_index", sa.Integer(), nullable=False),
+            sa.Column("class_kind", sa.String(), nullable=False),
+            sa.Column("species_id", sa.Integer(), nullable=True),
+            sa.Column("source_label", sa.String(), nullable=False),
+            sa.PrimaryKeyConstraint("model_artifact_id", "output_index", name="pk_model_output_taxa"),
+            sa.CheckConstraint("output_index >= 0", name="ck_model_output_taxa_index"),
+            sa.CheckConstraint(
+                "class_kind IN ('species', 'hybrid', 'aggregate', 'background', 'unknown')",
+                name="ck_model_output_taxa_kind",
+            ),
+            sa.CheckConstraint(
+                "class_kind != 'species' OR species_id IS NOT NULL", name="ck_model_output_taxa_species_identity"
+            ),
+            sa.ForeignKeyConstraint(
+                ["model_artifact_id"], ["model_artifacts.id"], name="fk_model_output_taxa_artifact", ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(["species_id"], ["species.species_id"], name="fk_model_output_taxa_species"),
+        )
+        op.create_index("idx_model_output_taxa_species", "model_output_taxa", ["species_id"])
+
+    if not _has_table(inspector, "species_name_overrides"):
+        op.create_table(
+            "species_name_overrides",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("species_id", sa.Integer(), nullable=False),
+            # '' means every language; NULL would make the unique constraint
+            # unenforceable because SQLite treats NULLs as distinct.
+            sa.Column("language_tag", sa.String(), nullable=False, server_default=""),
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False, server_default=sa.text("(CURRENT_TIMESTAMP)")),
+            sa.ForeignKeyConstraint(["species_id"], ["species.species_id"], name="fk_species_name_overrides_species"),
+            sa.UniqueConstraint("species_id", "language_tag", name="uq_species_name_overrides_scope"),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    for table_name in _TABLES:
+        if _has_table(inspector, table_name):
+            op.drop_table(table_name)

--- a/backend/tests/test_species_catalog_migrations.py
+++ b/backend/tests/test_species_catalog_migrations.py
@@ -1,0 +1,286 @@
+"""The dedicated migration stream for the species catalogue database.
+
+`species_catalog.db` lives beside `speciesid.db` but is versioned by its own
+single-head Alembic environment, so taxonomy and translations can be enriched,
+validated, and rolled back without ever holding a migration lock over detection
+history. The same §3 bar applies: reversible, idempotent, one head, and
+constraints in the schema rather than in application code.
+"""
+
+import sqlite3
+
+import pytest
+
+from app.services.species_catalog_migrations import (
+    catalog_alembic_config,
+    catalog_migration_heads,
+    downgrade_catalog,
+    upgrade_catalog,
+)
+
+EXPECTED_TABLES = {
+    "catalogue_releases",
+    "species",
+    "species_concepts",
+    "species_names",
+    "species_aliases",
+    "model_artifacts",
+    "model_output_taxa",
+    "species_name_overrides",
+}
+
+
+@pytest.fixture
+def catalog_path(tmp_path):
+    return tmp_path / "species_catalog.db"
+
+
+def _tables(path) -> set[str]:
+    connection = sqlite3.connect(path)
+    try:
+        rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    finally:
+        connection.close()
+    return {row[0] for row in rows if not row[0].startswith("sqlite_")}
+
+
+def _schema_dump(path) -> str:
+    connection = sqlite3.connect(path)
+    try:
+        rows = connection.execute(
+            "SELECT COALESCE(sql, '') FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+    finally:
+        connection.close()
+    return "\n".join(row[0] for row in rows)
+
+
+def _connect(path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def test_the_catalogue_stream_has_exactly_one_head():
+    assert len(catalog_migration_heads()) == 1
+
+
+def test_a_fresh_upgrade_creates_the_full_catalogue_schema(catalog_path):
+    upgrade_catalog(catalog_path)
+
+    assert EXPECTED_TABLES <= _tables(catalog_path)
+    assert "alembic_version" in _tables(catalog_path)
+
+
+def test_upgrade_downgrade_upgrade_is_a_no_op(catalog_path):
+    upgrade_catalog(catalog_path)
+    first = _schema_dump(catalog_path)
+
+    downgrade_catalog(catalog_path, "base")
+    assert not (EXPECTED_TABLES & _tables(catalog_path)), "downgrade must remove the catalogue schema"
+
+    upgrade_catalog(catalog_path)
+    assert _schema_dump(catalog_path) == first
+
+
+def test_rerunning_the_upgrade_changes_nothing(catalog_path):
+    upgrade_catalog(catalog_path)
+    first = _schema_dump(catalog_path)
+
+    upgrade_catalog(catalog_path)
+
+    assert _schema_dump(catalog_path) == first
+
+
+def test_the_config_points_at_the_requested_database(catalog_path):
+    config = catalog_alembic_config(catalog_path)
+
+    assert str(catalog_path) in (config.get_main_option("sqlalchemy.url") or "")
+
+
+class TestSchemaConstraints:
+    """§3: what the database can enforce, the database enforces."""
+
+    @pytest.fixture(autouse=True)
+    def _migrated(self, catalog_path):
+        upgrade_catalog(catalog_path)
+        self.path = catalog_path
+
+    def _seed_release_species_artifact(self, connection) -> None:
+        connection.execute(
+            "INSERT INTO catalogue_releases (schema_version, source_manifest, content_sha256, generated_at, state)"
+            " VALUES (1, '{}', 'seed-sha', '2026-08-19T00:00:00Z', 'active')"
+        )
+        connection.execute("INSERT INTO species (species_id, rank, status) VALUES (1, 'species', 'accepted')")
+        connection.execute(
+            "INSERT INTO model_artifacts (id, registry_id, model_sha256, output_width, runtime)"
+            " VALUES (1, 'rope_vit_b14_inat21', 'deadbeef', 10000, 'onnx')"
+        )
+
+    def test_at_most_one_release_can_be_active(self):
+        connection = _connect(self.path)
+        try:
+            connection.execute(
+                "INSERT INTO catalogue_releases (schema_version, source_manifest, content_sha256, generated_at, state)"
+                " VALUES (1, '{}', 'aaa', '2026-08-19T00:00:00Z', 'active')"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO catalogue_releases (schema_version, source_manifest, content_sha256, generated_at, state)"
+                    " VALUES (1, '{}', 'bbb', '2026-08-19T00:00:00Z', 'active')"
+                )
+            # A second staged or retired release is fine.
+            connection.execute(
+                "INSERT INTO catalogue_releases (schema_version, source_manifest, content_sha256, generated_at, state)"
+                " VALUES (1, '{}', 'ccc', '2026-08-19T00:00:00Z', 'staged')"
+            )
+        finally:
+            connection.close()
+
+    def test_an_unknown_release_state_is_rejected(self):
+        connection = _connect(self.path)
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO catalogue_releases (schema_version, source_manifest, content_sha256, generated_at, state)"
+                    " VALUES (1, '{}', 'ddd', '2026-08-19T00:00:00Z', 'probably_fine')"
+                )
+        finally:
+            connection.close()
+
+    def test_a_model_artifact_checksum_is_unique(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO model_artifacts (registry_id, model_sha256, output_width, runtime)"
+                    " VALUES ('a_republished_model', 'deadbeef', 707, 'onnx')"
+                )
+        finally:
+            connection.close()
+
+    def test_an_output_index_maps_exactly_once_per_artifact(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            connection.execute(
+                "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                " VALUES (1, 0, 'species', 1, 'Cyanistes caeruleus')"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                    " VALUES (1, 0, 'species', 1, 'a second meaning for index 0')"
+                )
+        finally:
+            connection.close()
+
+    def test_a_species_class_must_name_a_species(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                    " VALUES (1, 1, 'species', NULL, 'a species with no identity')"
+                )
+            # A background class deliberately has no species.
+            connection.execute(
+                "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                " VALUES (1, 1, 'background', NULL, 'background')"
+            )
+        finally:
+            connection.close()
+
+    def test_an_unknown_class_kind_is_rejected(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                    " VALUES (1, 2, 'mystery', NULL, 'x')"
+                )
+        finally:
+            connection.close()
+
+    def test_a_mapping_row_cannot_point_at_a_missing_artifact_or_species(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                    " VALUES (99, 0, 'species', 1, 'orphaned artifact')"
+                )
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                    " VALUES (1, 3, 'species', 99, 'orphaned species')"
+                )
+        finally:
+            connection.close()
+
+    def test_a_provider_concept_is_unique_per_release(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            connection.execute(
+                "INSERT INTO species_concepts (species_id, provider, provider_taxon_id, source_release, scientific_name)"
+                " VALUES (1, 'catalogue-of-life', 'COL123', 'COL26.7', 'Cyanistes caeruleus')"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO species_concepts (species_id, provider, provider_taxon_id, source_release, scientific_name)"
+                    " VALUES (1, 'catalogue-of-life', 'COL123', 'COL26.7', 'a second reading of the same concept')"
+                )
+        finally:
+            connection.close()
+
+    def test_language_tags_wider_than_five_characters_fit(self):
+        """RFC 5646 tags such as `zh-Hant` and `pt-BR` are the reason the old
+        five-character column could not be reused."""
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            connection.execute(
+                "INSERT INTO species_names (species_id, language_tag, name, name_kind, provider, source_release)"
+                " VALUES (1, 'zh-Hant', '青山雀', 'vernacular', 'ioc-world-bird-list', '14.2')"
+            )
+        finally:
+            connection.close()
+
+    def test_one_owner_override_per_species_and_language(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            connection.execute(
+                "INSERT INTO species_name_overrides (species_id, language_tag, name) VALUES (1, '', 'My blue tit')"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO species_name_overrides (species_id, language_tag, name) VALUES (1, '', 'Another name')"
+                )
+            # A per-language override coexists with the all-languages one.
+            connection.execute(
+                "INSERT INTO species_name_overrides (species_id, language_tag, name) VALUES (1, 'de', 'Meine Meise')"
+            )
+        finally:
+            connection.close()
+
+    def test_a_synonym_can_point_at_its_accepted_species(self):
+        connection = _connect(self.path)
+        try:
+            self._seed_release_species_artifact(connection)
+            connection.execute(
+                "INSERT INTO species (species_id, rank, status, accepted_species_id)"
+                " VALUES (2, 'species', 'deprecated', 1)"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO species (species_id, rank, status, accepted_species_id)"
+                    " VALUES (3, 'species', 'deprecated', 99)"
+                )
+        finally:
+            connection.close()


### PR DESCRIPTION
## Outcome

Phase 1 groundwork for the versioned species catalogue ([design](docs/plans/2026-08-12-versioned-species-catalogue-design.md)): `/data/species_catalog.db` now has a dedicated, single-head Alembic migration stream creating the full designed schema, with constraints in the schema rather than application code.

Stacked on #233; the base retargets to `dev` when that merges.

## Included

- **`backend/alembic_catalog.ini` + `backend/migrations_catalog/`** — the catalogue's own migration environment. URL comes from `SPECIES_CATALOG_PATH` (default `/data/species_catalog.db`); neither stream references the other's revisions, and no cross-database foreign keys exist — the shared value is the opaque `species_id`.
- **The initial schema migration** — `catalogue_releases` (transactional release records; a partial unique index allows at most one `active`), `species` (opaque identity, synonym/successor links, accepted/deprecated status), `species_concepts` (unique per provider + release + provider taxon id), `species_names` (RFC 5646 tags — `zh-Hant` fits, which the old 5-char column could not), `species_aliases` (resolution fails closed: `resolved`/`candidate`/`unresolved`), `model_artifacts` (unique model checksum owns the mapping), `model_output_taxa` (one meaning per artifact + output index; `class_kind` closed set; a `species` class must name a species), and `species_name_overrides` (owner data, unique per species + language).
- **Programmatic helpers** (`app/services/species_catalog_migrations.py`) used by tests and by the upcoming seed-then-copy startup wiring.
- **CI** ([ci.yml](.github/workflows/ci.yml)): a catalogue migration smoke (`upgrade → downgrade → upgrade`) and the single-head check now covers both streams — kept in lock-step with the local commands per §9.
- **CLAUDE.md §3** records the two-stream rule.

## Excluded

- The transactional staging importer, the Catalogue of Life non-bird import, and seed-then-copy into `/data` — the next Phase 1 slices, tracked in the roadmap.
- No changes to `speciesid.db`, its migrations, or any runtime read/write path; nothing opens the catalogue at runtime yet.

## Verification

- 16 new tests: fresh upgrade creates the full schema; `upgrade → downgrade → upgrade` is byte-identical (schema dump compared); re-running upgrade changes nothing; single head; and constraint proofs — duplicate artifact checksum rejected, duplicate output index rejected, species class without identity rejected, unknown class kind/release state rejected, second active release rejected, orphaned FK rows rejected, one owner override per species+language, synonym links validated.
- Full backend suite: 2,136 passed, 44 skipped. Repo-root ruff lint/format clean; docs consistency check passes.
- The exact CI smoke commands were run locally against both streams.

## Risk

None at runtime: nothing reads or writes the catalogue database yet. The migration stream is additive infrastructure; the detections database and its migration path are untouched.