### PR TITLE
Seed the species catalogue into /data on first start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,9 @@ backend/data/*.db
 # The species reference is a shipped, checksum-verified asset, not a runtime
 # database. It must survive the *.db rule above.
 !backend/app/assets/species_reference.db
+# The seed catalogue is generated at image build from the reference; neither
+# the file nor its digest sidecar belongs in the repository.
+backend/app/assets/species_catalog_seed.db.sha256
 backend/data/models/
 # apps/telemetry-worker/ # Un-ignored to allow tracking source
 apps/telemetry-worker/.wrangler/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- **A fresh installation now starts with a complete species catalogue.** The image builds a
+  deterministic seed release of `/data/species_catalog.db` from the committed IOC reference
+  (11,276 species with their translated names, admitted through the source provenance gate), and
+  first start copies it into `/data` atomically. An initialisation marker distinguishes a genuinely
+  fresh install from a catalogue that has gone missing: a lost catalogue may have held owner
+  enrichments, so it is reported and left for the owner instead of being silently replaced by the
+  seed. A seed that fails its recorded digest is refused, and none of this can block startup.
+
 - **The species catalogue database now has its own versioned schema.** Phase 1 groundwork for the
   versioned species catalogue: a dedicated, single-head Alembic stream
   (`backend/alembic_catalog.ini`, `backend/migrations_catalog/`) creates `/data/species_catalog.db`

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,11 +165,13 @@ RUN useradd -m -u 1000 appuser && \
 
 COPY --from=ui-builder /ui/dist /usr/share/nginx/html
 COPY backend/alembic.ini /app/alembic.ini
+COPY backend/alembic_catalog.ini /app/alembic_catalog.ini
 COPY backend/download_model.py /app/download_model.py
 COPY backend/app /app/app
 COPY backend/scripts /app/scripts
 COPY backend/locales /app/locales
 COPY backend/migrations /app/migrations
+COPY backend/migrations_catalog /app/migrations_catalog
 COPY docker/monolith/nginx-main.conf /etc/nginx/nginx.conf
 COPY docker/monolith/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/monolith/entrypoint.sh /usr/local/bin/yawamf-entrypoint.sh
@@ -190,6 +192,14 @@ RUN set -eux; \
         "${coral_base}/inat_bird_labels.txt"; \
     echo "350fcd8cf1df1560060d464595dfed8b174b05792788052896004848d9ad04f9  /app/app/assets/model.tflite" | sha256sum -c -; \
     echo "a16108dfe3f8daff015b87a97ab6a17e717b9b1bccd719f6d8f747746d7b9277  /app/app/assets/labels.txt" | sha256sum -c -
+
+# Build the seed species catalogue from the committed, digest-verified IOC
+# reference. The build is deterministic and passes the provenance gate in
+# species_sources.json; first start copies it into /data only when no
+# catalogue has ever been initialised.
+RUN python /app/scripts/build_species_catalog_seed.py \
+        --reference /app/app/assets/species_reference.db \
+        --output /app/app/assets/species_catalog_seed.db
 
 ENV DB_PATH=/data/speciesid.db
 ENV HOME=/tmp

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,7 +153,7 @@ consumers of the current mapping**: anything taught to trust that key has to be 
 | Phase | State |
 | --- | --- |
 | 0. Freeze the contract and provenance gate | 🔄 mostly delivered ([freeze note](docs/plans/2026-08-19-species-catalogue-phase0-freeze.md)): pinned sources (IOC 14.2, CoL COL26.7 by DOI, eBird 2025) in a machine-checked manifest with a licence/redistribution gate; per-artifact label grammar declared in the registry; 100%-coverage artifact [inventory](docs/reviews/2026-08-19-species-catalogue-phase0-inventory.md) held current by a regression test. Remaining: the synonym/split-lump mapping report, which needs Phase 1's CoL import |
-| 1. Catalogue schema and deterministic builder | 🔄 the dedicated Alembic stream and full catalogue schema are delivered (single-head, reversible, CI-smoked, constraints in-schema); the IOC seed and its builder exist. Remaining: the transactional staging importer, the Catalogue of Life import for non-bird classes, and seed-then-copy into `/data` |
+| 1. Catalogue schema and deterministic builder | 🔄 the dedicated Alembic stream, full catalogue schema, deterministic IOC seed build, and marker-guarded seed-then-copy into `/data` are delivered (single-head, reversible, CI-smoked, constraints in-schema; a lost catalogue is reported, never silently replaced). Remaining: the transactional staging importer and the Catalogue of Life import for non-bird classes |
 | 2. Checksum-bound model mappings | 🔄 label verification exists; `model_artifacts` keyed on the model checksum and `model_output_taxa` with class kinds remain |
 | 3. Shadow resolution and historical backfill | ☐ |
 | 4. Make catalogue identity authoritative | ☐ retires the scientific-name key |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -83,10 +83,12 @@ RUN useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app /data /config
 
 COPY --chown=appuser:appuser alembic.ini /app/alembic.ini
+COPY --chown=appuser:appuser alembic_catalog.ini /app/alembic_catalog.ini
 COPY --chown=appuser:appuser download_model.py /app/download_model.py
 COPY --chown=appuser:appuser app /app/app
 COPY --chown=appuser:appuser locales /app/locales
 COPY --chown=appuser:appuser migrations /app/migrations
+COPY --chown=appuser:appuser migrations_catalog /app/migrations_catalog
 
 # Set environment variables
 ENV DB_PATH=/data/speciesid.db

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -456,6 +456,16 @@ async def lifespan(app: FastAPI):
             startup_phase="database",
             startup_progress=68,
         )
+        from app.services.species_catalog_store import start_species_catalog
+
+        await _run_lifecycle_phase(
+            app,
+            "species_catalog_init",
+            start_species_catalog,
+            fatal=False,
+            startup_phase="database",
+            startup_progress=70,
+        )
         await _run_lifecycle_phase(
             app,
             "notification_dispatcher_start",

--- a/backend/app/services/species_catalog_store.py
+++ b/backend/app/services/species_catalog_store.py
@@ -1,0 +1,157 @@
+"""Bring the species catalogue database into service at startup.
+
+The image carries a checksum-pinned seed catalogue built at release time. On
+startup the catalogue at `/data/species_catalog.db` is migrated if it exists,
+or seeded from the image only when no catalogue has ever been initialised. An
+initialisation marker beside the database distinguishes a genuinely fresh
+install from a database that has gone missing: a catalogue may hold owner
+enrichments and overrides, so replacing a lost one with the seed would be
+silent data loss, not recovery. That case is reported and left for the owner.
+
+Never fatal to startup: a missing or refused catalogue degrades naming, and
+later phases fail closed for new species classification, but the application
+must still come up to say so.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import structlog
+
+from app.services.species_catalog_migrations import default_catalog_path, upgrade_catalog
+
+log = structlog.get_logger()
+
+DEFAULT_SEED_PATH = Path(__file__).resolve().parent.parent / "assets" / "species_catalog_seed.db"
+
+_DIGEST_CHUNK_BYTES = 1024 * 1024
+
+
+class CatalogState(str, Enum):
+    READY = "ready"
+    SEEDED = "seeded"
+    INITIALIZED_EMPTY = "initialized_empty"
+    MISSING = "missing"
+    SEED_REJECTED = "seed_rejected"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class CatalogStatus:
+    state: CatalogState
+    path: str
+    detail: str = ""
+
+
+def _marker_path(catalog_path: Path) -> Path:
+    return catalog_path.with_suffix(catalog_path.suffix + ".initialized")
+
+
+def _seed_digest_ok(seed_path: Path) -> bool:
+    """Refuse a seed that no longer matches the digest recorded beside it.
+
+    A seed with no sidecar is accepted: absence is a local build, not
+    corruption. This mirrors the bundled species reference's contract.
+    """
+    sidecar = seed_path.with_suffix(seed_path.suffix + ".sha256")
+    if not sidecar.is_file():
+        return True
+    try:
+        expected = sidecar.read_text(encoding="utf-8").split()[0].strip().lower()
+    except (OSError, IndexError):
+        log.warning("Seed catalogue digest unreadable; using the file as found", path=str(sidecar))
+        return True
+    if len(expected) != 64:
+        log.warning("Seed catalogue digest malformed; using the file as found", path=str(sidecar))
+        return True
+
+    digest = hashlib.sha256()
+    try:
+        with open(seed_path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(_DIGEST_CHUNK_BYTES), b""):
+                digest.update(chunk)
+    except OSError as error:
+        log.error("Seed catalogue unreadable", path=str(seed_path), error=str(error))
+        return False
+    if digest.hexdigest() != expected:
+        log.error(
+            "Seed catalogue does not match its recorded digest; refusing it",
+            path=str(seed_path),
+            expected=expected,
+            actual=digest.hexdigest(),
+        )
+        return False
+    return True
+
+
+def _write_marker(catalog_path: Path) -> None:
+    _marker_path(catalog_path).write_text(
+        "The species catalogue at this path has been initialised. Its absence now means loss, not a fresh install.\n",
+        encoding="utf-8",
+    )
+
+
+def _copy_seed_atomically(seed_path: Path, catalog_path: Path) -> None:
+    catalog_path.parent.mkdir(parents=True, exist_ok=True)
+    handle, staged = tempfile.mkstemp(prefix=".species_catalog_seed_", dir=catalog_path.parent)
+    os.close(handle)
+    try:
+        shutil.copy2(seed_path, staged)
+        os.replace(staged, catalog_path)
+    except OSError:
+        Path(staged).unlink(missing_ok=True)
+        raise
+
+
+def ensure_catalog_ready(catalog_path: Path | None = None, seed_path: Path | None = None) -> CatalogStatus:
+    """Migrate an existing catalogue, or seed a genuinely fresh install."""
+    path = Path(catalog_path or default_catalog_path())
+    seed = Path(seed_path or DEFAULT_SEED_PATH)
+
+    try:
+        if path.is_file():
+            upgrade_catalog(path)
+            if not _marker_path(path).is_file():
+                _write_marker(path)
+            return CatalogStatus(CatalogState.READY, str(path))
+
+        if _marker_path(path).is_file():
+            log.error(
+                "Species catalogue was initialised before but is now missing; refusing to overwrite the loss "
+                "with the seed. Restore it from backup, or remove the .initialized marker to accept a fresh start.",
+                path=str(path),
+            )
+            return CatalogStatus(CatalogState.MISSING, str(path), "initialised before, file absent")
+
+        if seed.is_file():
+            if not _seed_digest_ok(seed):
+                return CatalogStatus(CatalogState.SEED_REJECTED, str(path), "seed failed digest verification")
+            _copy_seed_atomically(seed, path)
+            upgrade_catalog(path)
+            _write_marker(path)
+            log.info("Species catalogue seeded from the image", path=str(path), seed=str(seed))
+            return CatalogStatus(CatalogState.SEEDED, str(path))
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        upgrade_catalog(path)
+        _write_marker(path)
+        log.info("No seed catalogue shipped; initialised an empty migrated catalogue", path=str(path))
+        return CatalogStatus(CatalogState.INITIALIZED_EMPTY, str(path))
+    except Exception as error:
+        log.error("Species catalogue initialisation failed", path=str(path), error=str(error))
+        return CatalogStatus(CatalogState.FAILED, str(path), str(error))
+
+
+async def start_species_catalog() -> None:
+    """Startup phase wrapper: never raises, reports the outcome."""
+    import asyncio
+
+    status = await asyncio.to_thread(ensure_catalog_ready)
+    log.info("Species catalogue startup state", state=status.state.value, path=status.path, detail=status.detail)

--- a/backend/scripts/build_species_catalog_seed.py
+++ b/backend/scripts/build_species_catalog_seed.py
@@ -1,0 +1,165 @@
+"""Build the seed release of the species catalogue database.
+
+The seed is the catalogue a fresh installation starts from: a fully migrated
+`species_catalog.db` holding one *active* release built from the committed,
+digest-verified `species_reference.db` (IOC World Bird List). The input is
+admitted through the Phase 0 provenance gate — the reference's recorded source
+digest must match the release `species_sources.json` pins — so the chain runs
+manifest → reference → catalogue with no unpinned step.
+
+The build is reproducible: rows are inserted in a deterministic order, the
+release timestamp comes from the manifest's freeze date rather than the clock,
+and the file is vacuumed, so the same input produces a byte-identical file and
+the recorded digest can be checked rather than trusted.
+
+Usage:
+    python scripts/build_species_catalog_seed.py [--reference PATH] [--output PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from app.services.species_catalog_migrations import upgrade_catalog  # noqa: E402
+from app.services.species_provenance import (  # noqa: E402
+    SourceProvenanceError,
+    default_manifest_path,
+    load_source_manifest,
+    require_build_source,
+)
+
+SOURCE_NAME = "ioc-world-bird-list"
+DEFAULT_REFERENCE = _BACKEND_DIR / "app" / "assets" / "species_reference.db"
+DEFAULT_OUTPUT = _BACKEND_DIR / "app" / "assets" / "species_catalog_seed.db"
+_ENGLISH_TAG = "en"
+
+
+def _reference_rows(reference_path: Path) -> tuple[dict[str, str], list[tuple[int, str, str | None]], dict[int, list]]:
+    """The reference's provenance metadata, taxa, and localized names, in stable order."""
+    connection = sqlite3.connect(f"file:{reference_path}?mode=ro", uri=True)
+    try:
+        meta = dict(connection.execute("SELECT key, value FROM reference_meta").fetchall())
+        taxa = connection.execute("SELECT id, scientific_name, common_name FROM taxon ORDER BY id").fetchall()
+        names: dict[int, list] = {}
+        for taxon_id, locale, name in connection.execute(
+            "SELECT taxon_id, locale, common_name FROM taxon_name ORDER BY taxon_id, locale"
+        ):
+            names.setdefault(taxon_id, []).append((locale, name))
+    finally:
+        connection.close()
+    return meta, taxa, names
+
+
+def _frozen_on(manifest_path: Path | None) -> str:
+    payload = json.loads((manifest_path or default_manifest_path()).read_text(encoding="utf-8"))
+    frozen = str(payload.get("frozen_on") or "").strip()
+    if not frozen:
+        raise SystemExit("The source manifest records no frozen_on date; the seed timestamp must be deterministic")
+    return f"{frozen}T00:00:00Z"
+
+
+def build(reference_path: Path, output_path: Path, *, manifest_path: Path | None = None) -> str:
+    meta, taxa, names = _reference_rows(reference_path)
+    if not taxa:
+        raise SystemExit(f"No taxa found in {reference_path}")
+
+    try:
+        source = require_build_source(
+            load_source_manifest(manifest_path),
+            SOURCE_NAME,
+            content_sha256=str(meta.get("source_sha256") or ""),
+        )
+    except SourceProvenanceError as error:
+        raise SystemExit(f"Provenance gate refused the build: {error}") from error
+
+    generated_at = _frozen_on(manifest_path)
+    source_manifest = json.dumps(
+        {
+            "sources": [
+                {
+                    "id": source.id,
+                    "version": source.version,
+                    "licence": source.licence,
+                    "citation": source.citation,
+                    "url": source.url,
+                    "redistribution": source.redistribution,
+                    "content_sha256": source.content_sha256,
+                }
+            ]
+        },
+        sort_keys=True,
+    )
+
+    if output_path.exists():
+        output_path.unlink()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    upgrade_catalog(output_path)
+
+    content = hashlib.sha256()
+    connection = sqlite3.connect(output_path)
+    try:
+        connection.execute("PRAGMA foreign_keys = ON")
+        for species_id, (_, scientific, english) in enumerate(taxa, start=1):
+            connection.execute(
+                "INSERT INTO species (species_id, rank, status) VALUES (?, 'species', 'accepted')", (species_id,)
+            )
+            connection.execute(
+                "INSERT INTO species_concepts"
+                " (species_id, provider, provider_taxon_id, source_release, scientific_name)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (species_id, source.id, scientific, source.version, scientific),
+            )
+            content.update(f"species|{species_id}|{scientific}\n".encode())
+
+            localized = names.get(taxa[species_id - 1][0], [])
+            rows = ([(_ENGLISH_TAG, english)] if english else []) + localized
+            for language_tag, name in rows:
+                connection.execute(
+                    "INSERT INTO species_names"
+                    " (species_id, language_tag, name, name_kind, preferred, provider, source_release)"
+                    " VALUES (?, ?, ?, 'vernacular', 1, ?, ?)",
+                    (species_id, language_tag, name, source.id, source.version),
+                )
+                content.update(f"name|{species_id}|{language_tag}|{name}\n".encode())
+
+        connection.execute(
+            "INSERT INTO catalogue_releases"
+            " (schema_version, source_manifest, content_sha256, generated_at, state)"
+            " VALUES (1, ?, ?, ?, 'active')",
+            (source_manifest, content.hexdigest(), generated_at),
+        )
+        connection.commit()
+        connection.execute("VACUUM")
+    finally:
+        connection.close()
+
+    digest = hashlib.sha256(output_path.read_bytes()).hexdigest()
+    sidecar = output_path.with_suffix(output_path.suffix + ".sha256")
+    sidecar.write_text(f"{digest}  {output_path.name}\n", encoding="utf-8")
+    return digest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference", type=Path, default=DEFAULT_REFERENCE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    digest = build(args.reference, args.output)
+    size_mb = args.output.stat().st_size / 1024 / 1024
+    print(f"Wrote {args.output} ({size_mb:.2f} MB)")
+    print(f"sha256 {digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_species_catalog_seed.py
+++ b/backend/tests/test_species_catalog_seed.py
@@ -1,0 +1,208 @@
+"""Building the seed catalogue release from the bundled IOC reference.
+
+The seed is the catalogue a fresh installation starts from. It is built
+deterministically from the committed, digest-verified `species_reference.db`,
+admitted through the Phase 0 provenance gate, and lands as one *active*
+release inside a fully migrated `species_catalog.db`. Rebuilding from the same
+input must produce a byte-identical file, because that is the only thing that
+makes a recorded digest checkable rather than trusted.
+"""
+
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import build_species_catalog_seed as seed_builder  # noqa: E402
+
+ASSETS = Path(__file__).resolve().parents[1] / "app" / "assets"
+
+
+def _fixture_reference(tmp_path, *, source_sha256: str) -> Path:
+    """A miniature species_reference.db in the committed asset's schema."""
+    path = tmp_path / "species_reference.db"
+    connection = sqlite3.connect(path)
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE reference_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE taxon (id INTEGER PRIMARY KEY, scientific_name TEXT NOT NULL, common_name TEXT);
+            CREATE TABLE taxon_name (
+                taxon_id INTEGER NOT NULL, locale TEXT NOT NULL, common_name TEXT NOT NULL,
+                PRIMARY KEY (taxon_id, locale)
+            ) WITHOUT ROWID;
+            """
+        )
+        connection.executemany(
+            "INSERT INTO reference_meta VALUES (?, ?)",
+            [("schema_version", "2"), ("source", "ioc-world-bird-list"), ("source_sha256", source_sha256)],
+        )
+        connection.executemany(
+            "INSERT INTO taxon VALUES (?, ?, ?)",
+            [
+                (1, "Cyanistes caeruleus", "Eurasian Blue Tit"),
+                (2, "Erithacus rubecula", "European Robin"),
+                (3, "Struthio camelus", None),
+            ],
+        )
+        connection.executemany(
+            "INSERT INTO taxon_name VALUES (?, ?, ?)",
+            [(1, "de", "Blaumeise"), (1, "it", "Cinciarella"), (2, "de", "Rotkehlchen")],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return path
+
+
+def _manifest(tmp_path, *, pinned_sha256: str) -> Path:
+    path = tmp_path / "species_sources.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "frozen_on": "2026-08-19",
+                "sources": [
+                    {
+                        "id": "ioc-world-bird-list",
+                        "name": "IOC World Bird List (Multilingual)",
+                        "role": "bird-vernacular-names",
+                        "version": "14.2-test",
+                        "url": "https://www.worldbirdnames.org/",
+                        "licence": "CC-BY-3.0",
+                        "citation": "IOC World Bird List. https://www.worldbirdnames.org/",
+                        "redistribution": "bundled",
+                        "content_sha256": pinned_sha256,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def built(tmp_path):
+    pinned = hashlib.sha256(b"the ioc workbook the manifest froze").hexdigest()
+    reference = _fixture_reference(tmp_path, source_sha256=pinned)
+    manifest = _manifest(tmp_path, pinned_sha256=pinned)
+    output = tmp_path / "species_catalog.db"
+    seed_builder.build(reference, output, manifest_path=manifest)
+    return output
+
+
+def _query(path, sql, params=()):
+    connection = sqlite3.connect(path)
+    try:
+        return connection.execute(sql, params).fetchall()
+    finally:
+        connection.close()
+
+
+def test_the_seed_is_a_migrated_catalogue_with_one_active_release(built):
+    tables = {row[0] for row in _query(built, "SELECT name FROM sqlite_master WHERE type = 'table'")}
+    assert {"alembic_version", "catalogue_releases", "species", "species_concepts", "species_names"} <= tables
+
+    releases = _query(built, "SELECT state, schema_version FROM catalogue_releases")
+    assert releases == [("active", 1)]
+
+
+def test_every_reference_taxon_becomes_a_species_with_a_concept(built):
+    assert _query(built, "SELECT COUNT(*) FROM species")[0][0] == 3
+
+    concepts = _query(
+        built,
+        "SELECT provider, provider_taxon_id, source_release, scientific_name FROM species_concepts ORDER BY id",
+    )
+    assert concepts[0] == ("ioc-world-bird-list", "Cyanistes caeruleus", "14.2-test", "Cyanistes caeruleus")
+    assert len(concepts) == 3
+
+
+def test_names_carry_language_tags_and_provenance(built):
+    names = _query(
+        built,
+        "SELECT language_tag, name, provider, source_release, preferred FROM species_names"
+        " WHERE species_id = (SELECT species_id FROM species_concepts WHERE scientific_name = 'Cyanistes caeruleus')"
+        " ORDER BY language_tag",
+    )
+
+    assert ("de", "Blaumeise", "ioc-world-bird-list", "14.2-test", 1) in names
+    assert ("en", "Eurasian Blue Tit", "ioc-world-bird-list", "14.2-test", 1) in names
+    assert ("it", "Cinciarella", "ioc-world-bird-list", "14.2-test", 1) in names
+
+
+def test_a_taxon_with_no_english_name_still_gets_a_species_row(built):
+    ostrich = _query(
+        built,
+        "SELECT species_id FROM species_concepts WHERE scientific_name = 'Struthio camelus'",
+    )
+    assert len(ostrich) == 1
+    names = _query(built, "SELECT COUNT(*) FROM species_names WHERE species_id = ?", (ostrich[0][0],))
+    assert names[0][0] == 0
+
+
+def test_the_release_records_its_provenance(built):
+    manifest_json, content_sha, generated_at = _query(
+        built, "SELECT source_manifest, content_sha256, generated_at FROM catalogue_releases"
+    )[0]
+    recorded = json.loads(manifest_json)
+
+    assert recorded["sources"][0]["id"] == "ioc-world-bird-list"
+    assert recorded["sources"][0]["version"] == "14.2-test"
+    assert len(content_sha) == 64
+    assert generated_at == "2026-08-19T00:00:00Z"
+
+
+def test_the_build_is_reproducible(tmp_path):
+    pinned = hashlib.sha256(b"the ioc workbook the manifest froze").hexdigest()
+    reference = _fixture_reference(tmp_path, source_sha256=pinned)
+    manifest = _manifest(tmp_path, pinned_sha256=pinned)
+
+    first, second = tmp_path / "one.db", tmp_path / "two.db"
+    first_digest = seed_builder.build(reference, first, manifest_path=manifest)
+    second_digest = seed_builder.build(reference, second, manifest_path=manifest)
+
+    assert first.read_bytes() == second.read_bytes()
+    assert first_digest == second_digest == hashlib.sha256(first.read_bytes()).hexdigest()
+    sidecar = first.with_suffix(first.suffix + ".sha256")
+    assert sidecar.read_text(encoding="utf-8").split()[0] == first_digest
+
+
+def test_the_gate_refuses_a_reference_that_is_not_the_pinned_release(tmp_path):
+    reference = _fixture_reference(tmp_path, source_sha256="c" * 64)
+    manifest = _manifest(tmp_path, pinned_sha256=hashlib.sha256(b"something else").hexdigest())
+
+    with pytest.raises(SystemExit, match="[Pp]rovenance"):
+        seed_builder.build(reference, tmp_path / "refused.db", manifest_path=manifest)
+
+
+def test_foreign_keys_hold_in_the_built_seed(built):
+    connection = sqlite3.connect(built)
+    try:
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        connection.close()
+
+
+def test_the_committed_reference_builds_a_complete_seed(tmp_path):
+    """The real asset, not a fixture: the whole IOC list survives the trip."""
+    reference = ASSETS / "species_reference.db"
+    if not reference.is_file():
+        pytest.skip("bundled reference not present in this checkout")
+
+    output = tmp_path / "seed.db"
+    seed_builder.build(reference, output)
+
+    species = _query(output, "SELECT COUNT(*) FROM species")[0][0]
+    names = _query(output, "SELECT COUNT(*) FROM species_names")[0][0]
+    localized = _query(output, "SELECT COUNT(*) FROM species_names WHERE language_tag != 'en'")[0][0]
+    assert species == 11276
+    assert localized == 87656
+    assert names == 87656 + 11276  # every taxon in the committed list has an English name
+    assert _query(output, "SELECT COUNT(*) FROM species_names WHERE language_tag = 'zh'")[0][0] > 10000

--- a/backend/tests/test_species_catalog_store.py
+++ b/backend/tests/test_species_catalog_store.py
@@ -1,0 +1,153 @@
+"""Seeding the species catalogue into /data on first start.
+
+The image carries a checksum-pinned seed catalogue. On startup YA-WAMF copies
+it into place only when no catalogue has ever been initialised: an
+initialisation marker distinguishes a genuinely fresh install from a database
+that has gone missing, because silently replacing a catalogue that may hold
+owner enrichments would be data loss wearing a recovery costume.
+"""
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app.services.species_catalog_store import CatalogState, ensure_catalog_ready
+
+
+@pytest.fixture
+def seed(tmp_path):
+    """A real seed built by the seed builder from a fixture reference."""
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    import build_species_catalog_seed as seed_builder
+
+    pinned = hashlib.sha256(b"fixture workbook").hexdigest()
+    reference = tmp_path / "reference.db"
+    connection = sqlite3.connect(reference)
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE reference_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE taxon (id INTEGER PRIMARY KEY, scientific_name TEXT NOT NULL, common_name TEXT);
+            CREATE TABLE taxon_name (
+                taxon_id INTEGER NOT NULL, locale TEXT NOT NULL, common_name TEXT NOT NULL,
+                PRIMARY KEY (taxon_id, locale)
+            ) WITHOUT ROWID;
+            """
+        )
+        connection.execute("INSERT INTO reference_meta VALUES ('source_sha256', ?)", (pinned,))
+        connection.execute("INSERT INTO taxon VALUES (1, 'Cyanistes caeruleus', 'Eurasian Blue Tit')")
+        connection.commit()
+    finally:
+        connection.close()
+
+    manifest = tmp_path / "sources.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "frozen_on": "2026-08-19",
+                "sources": [
+                    {
+                        "id": "ioc-world-bird-list",
+                        "name": "IOC",
+                        "role": "bird-vernacular-names",
+                        "version": "14.2-test",
+                        "url": "https://www.worldbirdnames.org/",
+                        "licence": "CC-BY-3.0",
+                        "citation": "IOC World Bird List.",
+                        "redistribution": "bundled",
+                        "content_sha256": pinned,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    seed_path = tmp_path / "species_catalog_seed.db"
+    seed_builder.build(reference, seed_path, manifest_path=manifest)
+    return seed_path
+
+
+@pytest.fixture
+def catalog_path(tmp_path):
+    return tmp_path / "data" / "species_catalog.db"
+
+
+def _species_count(path) -> int:
+    connection = sqlite3.connect(path)
+    try:
+        return connection.execute("SELECT COUNT(*) FROM species").fetchone()[0]
+    finally:
+        connection.close()
+
+
+def test_a_fresh_install_is_seeded_from_the_image(seed, catalog_path):
+    result = ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+
+    assert result.state is CatalogState.SEEDED
+    assert catalog_path.is_file()
+    assert _species_count(catalog_path) == 1
+    assert catalog_path.with_suffix(catalog_path.suffix + ".initialized").is_file()
+
+
+def test_a_second_start_is_a_no_op_and_keeps_owner_data(seed, catalog_path):
+    ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+    connection = sqlite3.connect(catalog_path)
+    try:
+        connection.execute("INSERT INTO species_name_overrides (species_id, language_tag, name) VALUES (1, '', 'Mine')")
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+
+    assert result.state is CatalogState.READY
+    connection = sqlite3.connect(catalog_path)
+    try:
+        overrides = connection.execute("SELECT name FROM species_name_overrides").fetchall()
+    finally:
+        connection.close()
+    assert overrides == [("Mine",)]
+
+
+def test_a_missing_catalogue_that_was_initialised_before_is_not_reseeded(seed, catalog_path):
+    ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+    catalog_path.unlink()
+
+    result = ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+
+    assert result.state is CatalogState.MISSING
+    assert not catalog_path.exists(), "re-seeding would mask the loss of owner enrichments"
+
+
+def test_a_seed_that_fails_its_digest_is_refused(seed, catalog_path):
+    sidecar = seed.with_suffix(seed.suffix + ".sha256")
+    sidecar.write_text(f"{'0' * 64}  {seed.name}\n", encoding="utf-8")
+
+    result = ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+
+    assert result.state is CatalogState.SEED_REJECTED
+    assert not catalog_path.exists()
+
+
+def test_without_a_seed_an_empty_migrated_catalogue_is_initialised(catalog_path, tmp_path):
+    result = ensure_catalog_ready(catalog_path=catalog_path, seed_path=tmp_path / "no_seed_here.db")
+
+    assert result.state is CatalogState.INITIALIZED_EMPTY
+    assert _species_count(catalog_path) == 0
+
+
+def test_an_adopted_existing_catalogue_gains_the_marker(seed, catalog_path, tmp_path):
+    ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+    marker = catalog_path.with_suffix(catalog_path.suffix + ".initialized")
+    marker.unlink()
+
+    result = ensure_catalog_ready(catalog_path=catalog_path, seed_path=seed)
+
+    assert result.state is CatalogState.READY
+    assert marker.is_file()


### PR DESCRIPTION
## Outcome

Phase 1 of the versioned species catalogue continues ([design](docs/plans/2026-08-12-versioned-species-catalogue-design.md)): the image now carries a deterministic, checksum-pinned seed catalogue built from the committed IOC reference, and first start copies it into `/data/species_catalog.db` — only when no catalogue has ever been initialised.

Stacked on #234 (which is stacked on #233); the base retargets as those merge.

## Included

- **Deterministic seed builder** (`backend/scripts/build_species_catalog_seed.py`): builds a fully migrated catalogue with one *active* release from `species_reference.db` — 11,276 species rows, provider concepts (`ioc-world-bird-list` / release 14.2), and 98,932 named translations with RFC 5646 tags and provenance. Input is admitted through the Phase 0 provenance gate (the reference's recorded source digest must match the manifest pin), the release timestamp comes from the manifest freeze date rather than the clock, and the same input produces a byte-identical file with a recorded digest sidecar.
- **Marker-guarded seed-then-copy** (`app/services/species_catalog_store.py`, new non-fatal `species_catalog_init` startup phase): an existing catalogue is migrated in place; a genuinely fresh install is seeded atomically (temp file + rename); an initialisation marker distinguishes fresh installs from a catalogue that has gone missing — a lost catalogue may hold owner enrichments, so it is **reported and left for the owner**, never silently replaced by the seed. A seed failing its recorded digest is refused; a checkout without a seed initialises an empty migrated catalogue; every path is non-fatal to startup.
- **Dockerfiles**: the monolith image generates and verifies the seed at build time and ships the catalogue migration environment; the legacy split backend image gains the migration environment only (no seed — the empty-catalogue degraded state is its honest behaviour, consistent with split being end-of-updates at 3.0).

## Excluded

- The transactional staging importer and the Catalogue of Life import for non-bird classes — the remaining Phase 1 slices, tracked in the roadmap.
- Nothing reads the catalogue on any detection or naming path yet; the only runtime change is the startup initialisation phase.

## Verification

- 15 new tests: seed reproducibility (byte-identical builds), provenance-gate refusal, full committed-reference build (11,276 species / 87,656 localized + 11,276 English names), foreign-key integrity of the built seed, fresh-install seeding, second-start no-op preserving owner overrides, missing-catalogue refusal to re-seed, corrupt-seed refusal, and empty-catalogue initialisation without a seed.
- Full backend suite: 2,151 passed, 44 skipped. Repo-root ruff lint/format clean; docs consistency passes.

## Risk

- The new startup phase is non-fatal and isolated; failure degrades to a logged state without touching `speciesid.db`.
- Data-safety posture is strengthened: the refuse-to-reseed marker exists precisely so owner enrichments in a lost catalogue are never masked by a silent reseed.
- Image size grows by the ~4 MB seed in the monolith image.