### PR TITLE
Let the split image's build context carry the seed builder script

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -7,5 +7,8 @@ data/
 debug_white_screen.png
 models/
 scripts/
+# The split image builds the seed catalogue at image build time; only that
+# script re-enters the context.
+!scripts/build_species_catalog_seed.py
 tests/
 venv/


### PR DESCRIPTION
## Outcome

Fixes the `build-backend` failure on dev after #240: `backend/.dockerignore` excludes `scripts/` from the split image's build context (context `./backend`), so the new `COPY scripts /app/scripts` step failed with `"/scripts": not found`. A targeted `!scripts/build_species_catalog_seed.py` exception re-includes exactly the one script the seed build needs.

## Verification

All monolith flavors (context `.`, root dockerignore) built green with the identical seed step in the same run, so the step itself is proven; this only restores the file to the split context. The dev image build after merge is the end-to-end check.

## Risk

None beyond the build: one additional file enters the split image context.