### PR TITLE
Stop warning about an expired Frigate event on every page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **An expired Frigate event is no longer reported as a warning on every page load.** Frigate
+  retires events long before YA-WAMF retires detections, so an older detection's upstream event is
+  gone for good. The events list checks media availability for every row it renders, and logged a
+  warning each time it found one missing: 958 log lines in 22 hours from 29 events on a reference
+  deployment, for a condition that is expected, permanent and needs nobody. Real warnings were
+  buried underneath. The condition is now stated once per event per window, at info, in words that
+  say what it means for the detection. Frigate is still asked every time, so a restored event or a
+  transient failure during a Frigate restart is never answered from stale memory.
+
 ### Changed
 
 - **NumPy 2 is now supported, and the numeric contract behind it is tested.** The dependency cap

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -14,6 +14,7 @@ from app.repositories.detection_repository import DetectionRepository
 from app.config import settings
 from app.services.classifier_service import get_classifier
 from app.services.frigate_client import frigate_client
+from app.services.frigate_event_absence import frigate_event_absence
 from app.services.auto_video_classifier_service import auto_video_classifier
 from app.services.media_cache import media_cache
 from app.services.broadcaster import broadcaster
@@ -267,18 +268,27 @@ async def batch_check_clips(event_ids: list[str]) -> dict[str, dict[str, bool]]:
                     "has_clip": bool(media and media.suffix.lower() in {".mp4", ".mov", ".webm"}),
                     "has_snapshot": bool(snapshot),
                 }
+            # Frigate is always asked, so a restored event or a transient 404
+            # during a Frigate restart is never reported from stale memory. The
+            # absence record only throttles logging.
             try:
-                event_data, _error = await frigate_client.get_event_with_error(
+                event_data, error = await frigate_client.get_event_with_error(
                     event_id,
                     timeout=CLIP_CHECK_TIMEOUT_SECONDS,
                 )
                 cached_flags = cached_media_flags(event_id)
                 if not event_data:
+                    if error == "event_not_found" and frigate_event_absence.record_absent(event_id):
+                        log.info(
+                            "Frigate no longer has this event; serving cached media only",
+                            event_id=event_id,
+                        )
                     return event_id, {
                         "has_frigate_event": False,
                         "has_clip": cached_flags["has_clip"],
                         "has_snapshot": cached_flags["has_snapshot"],
                     }
+                frigate_event_absence.record_present(event_id)
                 return event_id, {
                     "has_frigate_event": True,
                     "has_clip": bool(event_data.get("has_clip", False)) or cached_flags["has_clip"],

--- a/backend/app/services/frigate_client.py
+++ b/backend/app/services/frigate_client.py
@@ -253,7 +253,10 @@ class FrigateClient:
             if resp.status_code == 200:
                 return resp.json(), None
             if resp.status_code == 404:
-                log.warning("Event not found", event_id=event_id)
+                # Expected once Frigate's retention passes the event by, and
+                # permanent when it does. The caller decides whether a given
+                # sighting is worth reporting; see `frigate_event_absence`.
+                log.debug("Event not found", event_id=event_id)
                 return None, "event_not_found"
             log.warning("Failed to fetch event", event_id=event_id, status=resp.status_code)
             return None, f"event_http_{resp.status_code}"

--- a/backend/app/services/frigate_event_absence.py
+++ b/backend/app/services/frigate_event_absence.py
@@ -1,0 +1,89 @@
+"""How often to mention that Frigate no longer has an event.
+
+Frigate's retention is shorter than the detection history we keep, so an older
+detection's upstream event is gone for good. The events list checks media
+availability for every row it renders, which meant reporting that same expected,
+permanent and unactionable condition once per row per page load: 958 log lines
+in 22 hours from 29 events on the reference deployment, drowning the warnings
+that do need a person.
+
+This remembers that an absence has been reported recently, so it is stated once
+per window instead of once per render. It deliberately does **not** decide
+whether the event exists. Frigate is still asked every time, so a restored event
+or a transient 404 during a Frigate restart is never answered from stale memory.
+Whether a detection's media is really gone is settled by the maintenance
+reconcile, which is the only place allowed to act on it.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+DEFAULT_TTL_SECONDS = 300.0
+DEFAULT_MAX_ENTRIES = 2048
+
+
+class FrigateEventAbsence:
+    """Throttles repeat reports of an event Frigate has retired.
+
+    Not thread-safe by design: it is only touched from the event loop, and a
+    lost update costs one duplicate log line, never a wrong answer, because
+    nothing reads this to decide whether the event exists.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._ttl = max(0.0, float(ttl_seconds))
+        self._max_entries = max(1, int(max_entries))
+        self._clock = clock or _monotonic
+        self._absent_since: dict[str, float] = {}
+
+    @property
+    def tracked_count(self) -> int:
+        return len(self._absent_since)
+
+    def record_absent(self, event_id: str) -> bool:
+        """Note a 404. Returns True when this absence is worth reporting.
+
+        True on the first sighting and again once the window has passed, so an
+        operator still sees the condition periodically without it repeating on
+        every render.
+        """
+        if self._ttl <= 0.0:
+            return True
+        now = self._clock()
+        recorded = self._absent_since.get(event_id)
+        first_sighting = recorded is None or (now - recorded) >= self._ttl
+        if first_sighting:
+            self._reclaim(now)
+        self._absent_since[event_id] = now
+        return first_sighting
+
+    def record_present(self, event_id: str) -> None:
+        """Frigate answered, so a later absence is news again and is reported."""
+        self._absent_since.pop(event_id, None)
+
+    def _reclaim(self, now: float) -> None:
+        """Drop expired entries, then oldest-first if still over the cap."""
+        expired = [key for key, seen in self._absent_since.items() if now - seen >= self._ttl]
+        for key in expired:
+            self._absent_since.pop(key, None)
+        overflow = len(self._absent_since) + 1 - self._max_entries
+        if overflow > 0:
+            oldest = sorted(self._absent_since.items(), key=lambda item: item[1])[:overflow]
+            for key, _ in oldest:
+                self._absent_since.pop(key, None)
+
+
+def _monotonic() -> float:
+    import time
+
+    return time.monotonic()
+
+
+frigate_event_absence = FrigateEventAbsence()

--- a/backend/tests/test_frigate_event_absence.py
+++ b/backend/tests/test_frigate_event_absence.py
@@ -1,0 +1,140 @@
+"""Remembering that Frigate no longer has an event.
+
+Frigate's retention is shorter than YA-WAMF's history, so an old detection's
+event is gone upstream permanently. The events list checks media availability
+for every row it returns, which meant re-asking Frigate for the same absent
+events on every page load and logging a warning each time: 958 warnings in 22
+hours from 29 events on the reference deployment, for a condition that is
+expected and unactionable.
+
+This remembers an absence for a short window so the list path can answer from
+memory, and so the fact is logged once per window rather than once per render.
+"""
+
+import pytest
+
+from app.services.frigate_event_absence import FrigateEventAbsence
+
+
+@pytest.fixture
+def clock():
+    class Clock:
+        now = 1000.0
+
+        def __call__(self) -> float:
+            return self.now
+
+        def advance(self, seconds: float) -> None:
+            self.now += seconds
+
+    return Clock()
+
+
+def test_the_first_sighting_of_an_absence_is_worth_logging(clock):
+    absence = FrigateEventAbsence(ttl_seconds=60.0, clock=clock)
+    assert absence.record_absent("evt-1") is True
+
+
+def test_repeat_sightings_within_the_window_are_not_worth_logging(clock):
+    absence = FrigateEventAbsence(ttl_seconds=60.0, clock=clock)
+    absence.record_absent("evt-1")
+    assert absence.record_absent("evt-1") is False
+    assert absence.record_absent("evt-1") is False
+
+
+def test_the_absence_is_worth_logging_again_once_the_window_passes(clock):
+    absence = FrigateEventAbsence(ttl_seconds=60.0, clock=clock)
+    absence.record_absent("evt-1")
+    clock.advance(61.0)
+    assert absence.record_absent("evt-1") is True
+
+
+def test_reporting_starts_afresh_after_frigate_answers_again(clock):
+    absence = FrigateEventAbsence(ttl_seconds=60.0, clock=clock)
+    absence.record_absent("evt-1")
+    absence.record_present("evt-1")
+    assert absence.record_absent("evt-1") is True
+
+
+def test_memory_is_bounded_so_a_long_history_cannot_grow_without_limit(clock):
+    absence = FrigateEventAbsence(ttl_seconds=60.0, clock=clock, max_entries=10)
+    for index in range(50):
+        absence.record_absent(f"evt-{index}")
+    assert absence.tracked_count <= 10
+
+
+def test_a_zero_ttl_reports_every_time_rather_than_silencing_everything(clock):
+    absence = FrigateEventAbsence(ttl_seconds=0.0, clock=clock)
+    assert absence.record_absent("evt-1") is True
+    assert absence.record_absent("evt-1") is True
+
+
+def test_expired_entries_are_reclaimed_rather_than_retained(clock):
+    absence = FrigateEventAbsence(ttl_seconds=60.0, clock=clock)
+    for index in range(5):
+        absence.record_absent(f"evt-{index}")
+    clock.advance(61.0)
+    absence.record_absent("evt-fresh")
+    assert absence.tracked_count == 1
+
+
+@pytest.mark.asyncio
+async def test_the_events_list_reports_a_gone_event_once_not_once_per_render(monkeypatch, caplog):
+    """The reported defect: a warning per absent row, per page load."""
+    import logging
+    from unittest.mock import AsyncMock
+
+    from app.routers import events as events_router
+    from app.services.frigate_event_absence import FrigateEventAbsence
+
+    monkeypatch.setattr(events_router, "frigate_event_absence", FrigateEventAbsence(ttl_seconds=300.0))
+    lookup = AsyncMock(return_value=(None, "event_not_found"))
+    monkeypatch.setattr(events_router.frigate_client, "get_event_with_error", lookup)
+
+    with caplog.at_level(logging.INFO):
+        for _ in range(5):
+            result = await events_router.batch_check_clips(["evt-gone"])
+
+    # Frigate stays the source of truth, so it is still asked every time.
+    assert lookup.await_count == 5
+    mentions = [r for r in caplog.records if "evt-gone" in str(getattr(r, "event_id", ""))]
+    assert len(mentions) <= 1, "an expected absence must not be reported on every render"
+    assert result["evt-gone"]["has_frigate_event"] is False
+
+
+@pytest.mark.asyncio
+async def test_an_event_frigate_still_has_is_reported_present(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from app.routers import events as events_router
+    from app.services.frigate_event_absence import FrigateEventAbsence
+
+    monkeypatch.setattr(events_router, "frigate_event_absence", FrigateEventAbsence(ttl_seconds=300.0))
+    lookup = AsyncMock(return_value=({"has_clip": True, "has_snapshot": True}, None))
+    monkeypatch.setattr(events_router.frigate_client, "get_event_with_error", lookup)
+
+    await events_router.batch_check_clips(["evt-live"])
+    result = await events_router.batch_check_clips(["evt-live"])
+
+    assert lookup.await_count == 2
+    assert result["evt-live"]["has_frigate_event"] is True
+    assert result["evt-live"]["has_clip"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_restored_event_is_reported_present_immediately(monkeypatch):
+    """No stale memory: a 404 during a Frigate restart must not linger."""
+    from unittest.mock import AsyncMock
+
+    from app.routers import events as events_router
+    from app.services.frigate_event_absence import FrigateEventAbsence
+
+    monkeypatch.setattr(events_router, "frigate_event_absence", FrigateEventAbsence(ttl_seconds=300.0))
+    lookup = AsyncMock(return_value=(None, "event_not_found"))
+    monkeypatch.setattr(events_router.frigate_client, "get_event_with_error", lookup)
+    absent = await events_router.batch_check_clips(["evt-back"])
+    assert absent["evt-back"]["has_frigate_event"] is False
+
+    lookup.return_value = ({"has_clip": True, "has_snapshot": True}, None)
+    restored = await events_router.batch_check_clips(["evt-back"])
+    assert restored["evt-back"]["has_frigate_event"] is True


### PR DESCRIPTION
## Outcome

Frigate retires events long before YA-WAMF retires detections, so an older detection's upstream event is gone permanently. `batch_check_clips` checks media availability for every row the events list renders, and logged a warning each time it found one missing.

Measured on the reference deployment: **958 warnings in 22 hours from 29 distinct events**, roughly 15 an hour whenever a dashboard is open, for a condition that is expected, permanent and actionable by nobody. Genuine warnings were buried underneath it.

The condition is now reported once per event per window, at info, worded so it says what it means for the detection rather than naming an HTTP status. The 404 itself drops to debug in the client, because whether a given sighting matters is the caller's judgement, not the transport's.

## What this deliberately does not do

**It does not answer from remembered absence.** My first cut skipped the Frigate request when an absence was already known, which also removed the redundant upstream load. That was wrong: a transient 404 during a Frigate restart would then report the event as gone for the whole window, and claiming a state we have stopped measuring is worse than the noise it saved. Frigate is asked every time and remains the source of truth. The record only throttles reporting.

**It does not write to the database.** The read path discovers the absence but does not act on it, so a `GET` never mutates history and never triggers the `delete` branch of the missing-media policy. Whether a detection's media is really gone stays with the owner-triggered maintenance reconcile, which is the only place allowed to act on it.

That leaves `frigate_status` still reading `present` for events Frigate has dropped, which is a real gap, but closing it from a read path is not the right shape and closing it properly means a scheduled reconcile. Worth a separate issue rather than smuggling it in here.

## Verified

- 2,284 backend tests passing, 10 of them new
- The reported defect is asserted directly: five renders of an absent event produce at most one log line, while Frigate is still asked all five times
- A restored event is reported present immediately, with no window to wait out
- `ruff check` and `ruff format --check` clean repo-wide, docs consistency passing

## Risk

Low. One log level change, one throttle, no behaviour change in what the API returns. The absence record is bounded and reclaims expired entries, so it cannot grow without limit on a long-running daemon.