### PR TITLE
Group species by catalogue identity rather than name text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   catalogue cannot identify groups exactly as it did before. Each source is namespaced, because
   `species_id` and `taxa_id` are integers from different databases with overlapping ranges and
   would otherwise merge unrelated species. Verified against a year of real detections: the same 42
-  groups before and after, with no group split and none merged.
+  groups before and after, with no group split and none merged. The daily rollup keeps writing
+  the key format already on disk, because it persists that key and the table holds aggregate
+  history whose detections no longer exist; migrating it is a separate step.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **Species are counted by catalogue identity rather than by name text.** Phase 4 of the versioned
+  species catalogue begins. A scientific name is not stable: when a taxon is split, lumped or
+  synonymised, `Parus caeruleus` and `Cyanistes caeruleus` become two different birds to anything
+  keying on the text, so a leaderboard divides and a species page shows half its sightings with
+  nothing to warn anyone. Grouping now prefers the catalogue's opaque `species_id`, which does not
+  move when a name does, and keeps the existing taxon and name keys underneath so a detection the
+  catalogue cannot identify groups exactly as it did before. Each source is namespaced, because
+  `species_id` and `taxa_id` are integers from different databases with overlapping ranges and
+  would otherwise merge unrelated species. Verified against a year of real detections: the same 42
+  groups before and after, with no group split and none merged.
+
 ### Added
 
 - **Installed models can be deleted from Settings > Detection.** Models are the largest thing

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -585,11 +585,44 @@ class DetectionRepository:
         ]
 
     @staticmethod
-    def _canonical_key_sql(*, detection_alias: str = "d", taxonomy_alias: str = "tc") -> str:
+    def _canonical_key_sql(
+        *,
+        detection_alias: str = "d",
+        taxonomy_alias: str | None = "tc",
+    ) -> str:
+        """The key that decides whether two detections are the same bird.
+
+        Catalogue identity first, then the older text keys for rows the
+        catalogue cannot identify, so nothing that groups today stops grouping.
+
+        A scientific name is not stable. When a taxon is split, lumped or
+        synonymised, `Parus caeruleus` and `Cyanistes caeruleus` become two
+        different birds to anything keying on the text, and history divides with
+        nothing to warn anyone. The catalogue's opaque `species_id` does not
+        move when a name does.
+
+        Each source is namespaced because `species_id` and `taxa_id` are
+        integers from different databases with overlapping ranges: on a live
+        install `taxa_id` spans 487 to 1,289,423 and `species_id` spans 1,391 to
+        17,542. Cast bare into one key space they would merge unrelated species.
+        `'species:' || NULL` is NULL, so an absent id still falls through.
+        """
+        taxon_id = (
+            f"COALESCE({detection_alias}.taxa_id, {taxonomy_alias}.taxa_id)"
+            if taxonomy_alias
+            else f"{detection_alias}.taxa_id"
+        )
+        scientific = (
+            f"COALESCE({detection_alias}.scientific_name, {taxonomy_alias}.scientific_name)"
+            if taxonomy_alias
+            else f"{detection_alias}.scientific_name"
+        )
         return (
-            f"COALESCE(CAST(COALESCE({detection_alias}.taxa_id, {taxonomy_alias}.taxa_id) AS TEXT), "
-            f"LOWER(COALESCE({detection_alias}.scientific_name, {taxonomy_alias}.scientific_name)), "
-            f"LOWER({detection_alias}.display_name))"
+            f"COALESCE("
+            f"'species:' || CAST({detection_alias}.species_id AS TEXT), "
+            f"'taxon:' || CAST({taxon_id} AS TEXT), "
+            f"'name:' || LOWER({scientific}), "
+            f"'label:' || LOWER({detection_alias}.display_name))"
         )
 
     @staticmethod
@@ -717,6 +750,27 @@ class DetectionRepository:
             species_name=species_name,
             has_taxonomy_cache=has_taxonomy_cache,
         )
+
+        # Grouping keys on catalogue identity, so filtering has to follow it or
+        # the two disagree: the leaderboard merges a renamed taxon into one row,
+        # and opening that row shows only the rows still carrying the name that
+        # was searched for. Widen the match to every detection sharing a
+        # `species_id` with something the name already matched.
+        #
+        # The inner match is deliberately detection-only: a correlated subquery
+        # cannot see the outer `tc_filter` join, and finding the identity does
+        # not need the taxonomy fallback that finding the rows does.
+        identity_condition, identity_params = await self._build_canonical_species_condition(
+            detection_alias="d_identity",
+            species_name=species_name,
+            has_taxonomy_cache=False,
+        )
+        condition = (
+            f"(({condition}) OR {detection_alias}.species_id IN ("
+            f"SELECT d_identity.species_id FROM detections d_identity "
+            f"WHERE d_identity.species_id IS NOT NULL AND ({identity_condition})))"
+        )
+        params = [*params, *identity_params]
         return join_sql, condition, params
 
     async def _last_statement_changes(self) -> int:
@@ -2992,9 +3046,10 @@ class DetectionRepository:
 
     async def get_species_counts(self) -> list[dict]:
         """Get detection counts per species with taxonomic metadata."""
-        query = """
+        canonical_key = self._canonical_key_sql(taxonomy_alias=None)
+        query = f"""
             SELECT 
-                COALESCE(CAST(d.taxa_id AS VARCHAR), LOWER(d.scientific_name), LOWER(d.display_name)) as unified_id,
+                {canonical_key} as unified_id,
                 COUNT(*) as count, 
                 MAX(d.scientific_name) as scientific_name, 
                 MAX(d.common_name) as common_name,
@@ -3051,6 +3106,9 @@ class DetectionRepository:
                     "scientific_name": row[2],
                     "common_name": row[3],
                     "taxa_id": row[5],
+                    # The grouping key itself, so callers join on it rather than
+                    # rebuilding the same rule and drifting out of step.
+                    "unified_key": row[0],
                     "first_seen": _parse_datetime(row[6]) if row[6] else None,
                     "last_seen": _parse_datetime(row[7]) if row[7] else None,
                     "avg_confidence": row[8] or 0.0,
@@ -3535,19 +3593,19 @@ class DetectionRepository:
     async def get_unified_species_window_metrics(self, lookback_days: int = 30) -> dict[str, dict]:
         """Aggregate recent per-species metrics using a stable unified key.
 
-        Key priority:
-        - taxa_id (stringified)
-        - scientific_name (lowercased)
-        - display_name (lowercased)
+        Keyed by `_canonical_key_sql`, the same rule the leaderboard groups by.
         """
         window = f"-{lookback_days} day"
-        query = """
+        # The same key and the same join as the leaderboard, because the
+        # leaderboard looks its trends up in this result by that key. Matching
+        # only by coincidence is how a species silently shows a flat trend:
+        # without the join a row whose scientific name is absent keys on its
+        # label here and on the cached scientific name there.
+        canonical_key = self._canonical_key_sql()
+        taxonomy_join = self._taxonomy_join_sql()
+        query = f"""
             SELECT
-                COALESCE(
-                    CAST(d.taxa_id AS TEXT),
-                    LOWER(d.scientific_name),
-                    LOWER(d.display_name)
-                ) as unified_key,
+                {canonical_key} as unified_key,
                 SUM(CASE WHEN d.detection_time >= datetime('now','-1 day') THEN 1 ELSE 0 END) as count_1d,
                 SUM(CASE WHEN d.detection_time >= datetime('now','-7 day') THEN 1 ELSE 0 END) as count_7d,
                 SUM(CASE WHEN d.detection_time >= datetime('now','-30 day') THEN 1 ELSE 0 END) as count_30d,
@@ -3557,6 +3615,7 @@ class DetectionRepository:
                 COUNT(DISTINCT CASE WHEN d.detection_time >= datetime('now','-30 day') THEN date(d.detection_time) END) as days_seen_30d,
                 MAX(d.detection_time) as last_seen_recent
             FROM detections d
+            {taxonomy_join}
             WHERE d.detection_time >= datetime('now', ?)
               AND (d.is_hidden = 0 OR d.is_hidden IS NULL)
             GROUP BY unified_key
@@ -3936,7 +3995,8 @@ class DetectionRepository:
 
     async def get_daily_species_counts(self, start_date: datetime, end_date: datetime) -> list[dict]:
         """Get detection counts per species for a specific time range."""
-        query = """
+        canonical_key = self._canonical_key_sql(taxonomy_alias=None)
+        query = f"""
             WITH filtered AS (
                 SELECT
                     d.id,
@@ -3946,7 +4006,7 @@ class DetectionRepository:
                     d.common_name,
                     d.display_name,
                     d.taxa_id,
-                    COALESCE(CAST(d.taxa_id AS VARCHAR), LOWER(d.scientific_name), LOWER(d.display_name)) AS unified_id
+                    {canonical_key} AS unified_id
                 FROM detections d
                 WHERE d.detection_time >= ? AND d.detection_time <= ?
                   AND (d.is_hidden = 0 OR d.is_hidden IS NULL)

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -626,6 +626,32 @@ class DetectionRepository:
         )
 
     @staticmethod
+    def _legacy_rollup_key_sql(*, detection_alias: str = "d", taxonomy_alias: str = "tc") -> str:
+        """The grouping rule as it was before catalogue identity, for the rollup only.
+
+        `species_daily_rollup` *persists* this value as half its primary key, so
+        unlike every other use it is not recomputed on read. Writing the new
+        namespaced key would leave the table in two formats either side of an
+        upgrade, and anything grouping on it would split a species at that
+        boundary.
+
+        The obvious remedy, clearing the derived table and rebuilding it, is not
+        available: on the reference deployment 29 rollup rows covering 97
+        detections predate the oldest surviving detection, so the rollup is the
+        only remaining record of them and §1 does not allow discarding it.
+
+        Nothing in production reads this column today; it identifies a row for
+        upsert. Migrating it needs `species_id` on the rollup and a backfill of
+        what is still resolvable, which is its own phase-4 slice and its own
+        migration. Until then the stored format stays exactly as it is.
+        """
+        return (
+            f"COALESCE(CAST(COALESCE({detection_alias}.taxa_id, {taxonomy_alias}.taxa_id) AS TEXT), "
+            f"LOWER(COALESCE({detection_alias}.scientific_name, {taxonomy_alias}.scientific_name)), "
+            f"LOWER({detection_alias}.display_name))"
+        )
+
+    @staticmethod
     def _taxonomy_join_sql(*, detection_alias: str = "d", taxonomy_alias: str = "tc") -> str:
         return (
             f"LEFT JOIN taxonomy_cache {taxonomy_alias} "
@@ -3334,7 +3360,7 @@ class DetectionRepository:
                 FROM enriched
                 GROUP BY rollup_date, canonical_key
             """.format(
-                canonical_key=self._canonical_key_sql(detection_alias="d", taxonomy_alias="tc"),
+                canonical_key=self._legacy_rollup_key_sql(detection_alias="d", taxonomy_alias="tc"),
                 taxonomy_join=self._taxonomy_join_sql(detection_alias="d", taxonomy_alias="tc"),
             )
         else:

--- a/backend/app/routers/species.py
+++ b/backend/app/routers/species.py
@@ -357,16 +357,16 @@ async def _hydrate_species_search_results(
 
 
 def _species_unified_metrics_key(row: dict) -> str | None:
-    taxa_id = row.get("taxa_id")
-    if taxa_id is not None:
-        return str(taxa_id)
-    scientific_name = row.get("scientific_name")
-    if scientific_name:
-        return str(scientific_name).lower()
-    species = row.get("species")
-    if species:
-        return str(species).lower()
-    return None
+    """The grouping key the repository already computed for this row.
+
+    This used to rebuild the key in Python from `taxa_id`, then scientific name,
+    then display name. That is the same rule the repository applies in SQL, and
+    two copies of one rule drift: when the SQL key gained catalogue identity and
+    a namespace, a Python copy would have matched nothing and every species
+    would have shown a flat trend with no error to notice.
+    """
+    key = row.get("unified_key")
+    return str(key) if key else None
 
 
 def _to_utc_naive(dt: datetime | None) -> datetime | None:

--- a/backend/tests/test_canonical_identity_grouping.py
+++ b/backend/tests/test_canonical_identity_grouping.py
@@ -1,0 +1,207 @@
+"""Grouping detections by catalogue identity rather than by name text.
+
+Phase 4 of the species catalogue. Until now the grouping key was
+`taxa_id`, then scientific name, then display name, all as text. A scientific
+name is not stable: when a taxon is split, lumped or synonymised,
+`Parus caeruleus` and `Cyanistes caeruleus` become two different birds to
+anything keying on the text, so a leaderboard divides and a species page shows
+half its sightings, silently.
+
+The catalogue's opaque `species_id` is the fix. It goes in front of the existing
+fallbacks rather than replacing them, so a row the catalogue cannot identify
+behaves exactly as it does today.
+
+Two things make this less obvious than it looks, and both are asserted here:
+
+* `species_id` and `taxa_id` are integers from different databases with
+  overlapping ranges. Measured on a live install, `taxa_id` spans 487 to
+  1,289,423 and `species_id` spans 1,391 to 17,542. Casting both to bare text in
+  one key space merges unrelated species, so each source is namespaced.
+* Preferring `species_id` could *split* a species whose rows are only partly
+  identified, which is the very failure this phase exists to remove.
+"""
+
+from datetime import datetime, timedelta
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from app.repositories.detection_repository import DetectionRepository
+from tests.test_detection_repository import _create_detections_table, _create_taxonomy_tables
+
+
+@pytest_asyncio.fixture
+async def seeded_repository():
+    """A repository over an in-memory database, plus a terse way to add a row."""
+    async with aiosqlite.connect(":memory:") as db:
+        await _create_detections_table(db)
+        await _create_taxonomy_tables(db)
+        await db.commit()
+        repo = DetectionRepository(db)
+        counter = {"n": 0}
+
+        async def add(
+            *,
+            display_name: str,
+            scientific_name: str | None = None,
+            species_id: int | None = None,
+            taxa_id: int | None = None,
+            is_hidden: bool = False,
+        ) -> None:
+            counter["n"] += 1
+            await db.execute(
+                """
+                INSERT INTO detections (
+                    detection_time, detection_index, score, display_name, category_name,
+                    frigate_event, camera_name, is_hidden, scientific_name, taxa_id, species_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    datetime(2026, 8, 23, 8, 0, 0) + timedelta(minutes=counter["n"]),
+                    1,
+                    0.9,
+                    display_name,
+                    display_name,
+                    f"evt-{counter['n']}",
+                    "birdcam",
+                    1 if is_hidden else 0,
+                    scientific_name,
+                    taxa_id,
+                    species_id,
+                ),
+            )
+            await db.commit()
+
+        yield repo, add
+
+
+@pytest.fixture
+def key() -> str:
+    return DetectionRepository._canonical_key_sql()
+
+
+def test_catalogue_identity_is_preferred_over_every_text_key(key):
+    identity = key.index("species_id")
+    assert identity < key.index("taxa_id")
+    assert identity < key.index("scientific_name")
+    assert identity < key.index("display_name")
+
+
+def test_the_text_fallbacks_are_kept_for_rows_the_catalogue_cannot_identify(key):
+    assert "taxa_id" in key
+    assert "scientific_name" in key
+    assert "display_name" in key
+
+
+def test_identity_and_taxonomy_ids_cannot_collide_in_one_key_space(key):
+    """`species_id` 10081 is a Dunnock; `taxa_id` 10081 is some other taxon."""
+    assert "'species:'" in key or '"species:"' in key
+    assert "'taxon:'" in key or '"taxon:"' in key
+
+
+@pytest.mark.asyncio
+async def test_two_names_for_one_species_count_as_one_bird(seeded_repository):
+    """The defect this phase exists to fix: a renamed taxon dividing history."""
+    repo, add = seeded_repository
+    await add(display_name="Blue Tit", scientific_name="Parus caeruleus", species_id=4242)
+    await add(display_name="Blue Tit", scientific_name="Cyanistes caeruleus", species_id=4242)
+
+    rows = await repo.get_species_leaderboard_base()
+    blue_tits = [r for r in rows if r["count"] == 2]
+    assert len(blue_tits) == 1, f"expected one Blue Tit group, got {rows}"
+
+
+@pytest.mark.asyncio
+async def test_a_species_id_never_merges_with_an_equal_taxa_id(seeded_repository):
+    repo, add = seeded_repository
+    await add(display_name="Dunnock", scientific_name="Prunella modularis", species_id=10081)
+    await add(display_name="Something Else", scientific_name="Aliud aliud", taxa_id=10081)
+
+    rows = await repo.get_species_leaderboard_base()
+    assert len(rows) == 2, f"a species_id and a taxa_id sharing a number must not merge: {rows}"
+
+
+@pytest.mark.asyncio
+async def test_rows_without_catalogue_identity_group_exactly_as_before(seeded_repository):
+    repo, add = seeded_repository
+    await add(display_name="Unknown Bird")
+    await add(display_name="Unknown Bird")
+    await add(display_name="Robin", scientific_name="Erithacus rubecula")
+    await add(display_name="Robin", scientific_name="Erithacus rubecula")
+
+    rows = await repo.get_species_leaderboard_base()
+    assert sorted(r["count"] for r in rows) == [2, 2]
+
+
+@pytest.mark.asyncio
+async def test_different_species_are_never_merged_by_identity(seeded_repository):
+    repo, add = seeded_repository
+    await add(display_name="Dunnock", scientific_name="Prunella modularis", species_id=10081)
+    await add(display_name="Robin", scientific_name="Erithacus rubecula", species_id=9293)
+
+    rows = await repo.get_species_leaderboard_base()
+    assert len(rows) == 2
+    assert all(r["count"] == 1 for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_hidden_detections_stay_out_of_the_counts(seeded_repository):
+    repo, add = seeded_repository
+    await add(display_name="Dunnock", scientific_name="Prunella modularis", species_id=10081)
+    await add(display_name="Dunnock", scientific_name="Prunella modularis", species_id=10081, is_hidden=True)
+
+    rows = await repo.get_species_leaderboard_base()
+    assert [r["count"] for r in rows] == [1]
+
+
+@pytest.mark.asyncio
+async def test_filtering_a_species_finds_every_row_the_leaderboard_counted(seeded_repository):
+    """Grouping and filtering must agree, or a species page contradicts the leaderboard.
+
+    Grouping by identity while filtering by name text reintroduces the exact
+    defect this phase removes: the leaderboard merges a renamed taxon into one
+    row, then opening that row shows only the half that still carries the
+    displayed name.
+    """
+    repo, add = seeded_repository
+    await add(display_name="Blue Tit", scientific_name="Parus caeruleus", species_id=4242)
+    await add(display_name="Blue Tit", scientific_name="Cyanistes caeruleus", species_id=4242)
+
+    rows = await repo.get_species_leaderboard_base()
+    grouped = next(r for r in rows if r["count"] == 2)
+    assert grouped is not None
+
+    join_sql, condition, params = await repo._canonical_species_query_parts(
+        detection_alias="d",
+        species_name="Cyanistes caeruleus",
+    )
+    async with repo.db.execute(
+        f"SELECT COUNT(DISTINCT d.id) FROM detections d{join_sql} WHERE {condition}", params
+    ) as cursor:
+        matched = (await cursor.fetchone())[0]
+
+    assert matched == 2, f"the leaderboard counted 2 for this species, so filtering it must return 2; got {matched}"
+
+
+@pytest.mark.asyncio
+async def test_the_leaderboard_returns_the_key_its_metrics_are_looked_up_by(seeded_repository):
+    """Trend data is joined on this key, and a mismatch fails silently.
+
+    The router used to rebuild the grouping rule in Python. Two copies of one
+    rule drift, and when they do `metrics.get(...)` returns an empty dict, so
+    every species shows a flat trend and nothing raises.
+    """
+    repo, add = seeded_repository
+    await add(display_name="Dunnock", scientific_name="Prunella modularis", species_id=10081)
+    await add(display_name="Dunnock", scientific_name="Prunella modularis", species_id=10081)
+
+    rows = await repo.get_species_leaderboard_base()
+    metrics = await repo.get_unified_species_window_metrics()
+
+    assert rows[0]["unified_key"], "the leaderboard must expose the key it grouped on"
+    assert rows[0]["unified_key"] in metrics, (
+        f"leaderboard key {rows[0]['unified_key']!r} is absent from metrics keys "
+        f"{list(metrics)!r}; trends would silently read as flat"
+    )
+    assert metrics[rows[0]["unified_key"]]["count_30d"] >= 2

--- a/backend/tests/test_canonical_identity_grouping.py
+++ b/backend/tests/test_canonical_identity_grouping.py
@@ -205,3 +205,25 @@ async def test_the_leaderboard_returns_the_key_its_metrics_are_looked_up_by(seed
         f"{list(metrics)!r}; trends would silently read as flat"
     )
     assert metrics[rows[0]["unified_key"]]["count_30d"] >= 2
+
+
+def test_the_rollup_keeps_writing_the_key_format_already_on_disk():
+    """`species_daily_rollup` persists its key as half the primary key.
+
+    Writing the namespaced key would leave the table in two formats either side
+    of an upgrade, splitting a species at that boundary. The derived table
+    cannot simply be rebuilt: on a live install 29 rollup rows covering 97
+    detections predate the oldest surviving detection, so it is the only record
+    of them.
+    """
+    legacy = DetectionRepository._legacy_rollup_key_sql()
+    assert "species:" not in legacy
+    assert "taxon:" not in legacy
+    assert "species_id" not in legacy
+
+
+def test_live_grouping_and_the_rollup_key_are_deliberately_different():
+    live = DetectionRepository._canonical_key_sql()
+    legacy = DetectionRepository._legacy_rollup_key_sql()
+    assert live != legacy, "the rollup key is pinned on purpose; see _legacy_rollup_key_sql"
+    assert "species:" in live

--- a/backend/tests/test_detection_repository.py
+++ b/backend/tests/test_detection_repository.py
@@ -649,11 +649,13 @@ async def test_unified_species_window_metrics_combines_alias_variants():
             )
 
         metrics = await repo.get_unified_species_window_metrics()
-        assert metrics["1234"]["count_7d"] >= 2
+        # Keys are namespaced by source so a taxa_id cannot collide with a
+        # catalogue species_id of the same number.
+        assert metrics["taxon:1234"]["count_7d"] >= 2
 
 
 @pytest.mark.asyncio
-async def test_unified_species_window_metrics_uses_display_name_when_taxa_and_scientific_missing():
+async def test_unified_species_window_metrics_resolves_through_the_taxonomy_cache():
     async with aiosqlite.connect(":memory:") as db:
         await _create_detections_table(db)
         await _create_taxonomy_tables(db)
@@ -681,8 +683,13 @@ async def test_unified_species_window_metrics_uses_display_name_when_taxa_and_sc
         )
 
         metrics = await repo.get_unified_species_window_metrics()
-        assert "house sparrow" in metrics
-        assert "passer domesticus" not in metrics
+        # The detection carries no taxa_id or scientific name of its own, but the
+        # taxonomy cache resolves its label, so it keys on the cached taxon. That
+        # is the same key the leaderboard groups by, which is what lets the
+        # leaderboard find these trends; keying on the label here instead would
+        # match only when the label and the scientific name happen to be equal.
+        assert "taxon:1111" in metrics
+        assert "label:house sparrow" not in metrics
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Phase 4 of the versioned species catalogue begins. First slice: species aggregation.

## Outcome

A scientific name is not stable. When a taxon is split, lumped or synonymised, `Parus caeruleus` and `Cyanistes caeruleus` become two different birds to anything keying on the text, so a leaderboard divides and a species page shows half its sightings with nothing to warn anyone. That is the defect the catalogue exists to remove.

Grouping now prefers the catalogue's opaque `species_id`, which does not move when a name does, and keeps the taxon and name keys underneath so a detection the catalogue cannot identify groups exactly as before.

## Four defects found while reviewing this, all fixed here

**Grouping and filtering disagreed.** Making the leaderboard group by identity while `_build_canonical_species_condition` still matched on name text reintroduces the same defect at the other end. Proven by test: the leaderboard counted 2 and the filter returned 1. Filtering now follows identity through a subquery contained entirely within the detections database, so no cross-database join is introduced (§3).

**The router rebuilt the same key in Python.** `_species_unified_metrics_key` independently reconstructed the grouping rule to look trends up. Namespacing the SQL side would have made that lookup miss entirely, so every species would have shown a flat trend with nothing raising. The repository now returns the key it grouped on and the duplicate is gone.

**Leaderboard and metrics matched only by coincidence.** The leaderboard applied the taxonomy join, the metrics query did not. Under the old un-namespaced key both produced the identical string for a row whose label equals its scientific name, so it worked by accident; namespacing exposed it. Both now share one key and one join and agree by construction.

**Identity and taxonomy ids could collide.** `species_id` and `taxa_id` are integers from different databases with overlapping ranges: measured here, `taxa_id` spans 487 to 1,289,423 and `species_id` spans 1,391 to 17,542. Cast bare into one key space they merge unrelated species, so each source is namespaced.

## The daily rollup is deliberately left alone

`species_daily_rollup` **persists** its key as half the primary key, unlike every other use which recomputes on read. Writing the new format would leave the table in two formats either side of an upgrade and split a species at that boundary.

Rebuilding the derived table is not available: **29 rollup rows covering 97 detections predate the oldest surviving detection**, so the rollup is the only remaining record of them and discarding it would lose history (§1). Migrating it needs `species_id` on the rollup plus a backfill of what is still resolvable, which deserves its own slice and its own migration.

Nothing in production reads that column today; it identifies a row for upsert. The format is now pinned behind a named `_legacy_rollup_key_sql`, documented, and covered by tests so it cannot be re-pointed by accident.

## Verified against real data

Read-only against a live install holding 747 detections:

| Check | Result |
| --- | --- |
| Distinct groups, before and after | 42 and 42 |
| Old groups that split into more than one new group | 0 |
| New groups that merge more than one old group | 0 |
| Species filter row count, before and after | 114 and 114 |
| Leaderboard keys with no matching metrics key | 0 |

2,317 backend tests passing, 12 of them new. `ruff` clean repo-wide, docs consistency passing.

## Scope

Not included, and named rather than left to be discovered:

- `get_audio_species_counts` groups `audio_detections`, which carries no `species_id`. The design already places audio's canonical joins later in Phase 4.
- `get_timebucket_species_counts` is driven by an explicit caller-supplied label map, so it is a different concern.
- The merged group's display name is still `MAX(display_name)`, which is arbitrary. Phase 4's shared name-precedence function is a later slice.
- `get_species_counts` and `get_rollup_metrics` turned out to have no production callers at all. Worth deleting deliberately, not as a side effect of this change.

## Risk

Read paths only. No schema change, no migration, nothing written differently to disk. The change is a no-op on today's data and becomes load-bearing the first time a taxon is renamed.