### PR TITLE
Speed up filtering the events list by species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **Filtering the events list by a species is faster.** A user reported that the species filter was
+  noticeably slower than the date and camera filters, which are effectively instant. Measured on a
+  96,108 row copy of a real database it took 26ms, and the plan showed the taxonomy join scanning
+  once per detection row because a predicate wrapped in `LOWER()` cannot use an ordinary index.
+  Indexes matching those expressions are now in place. The catalogue identity introduced with
+  species grouping is also resolved to concrete ids before the query is built rather than left as a
+  subquery over the whole table, which had taken the same filter to 41ms; it is now 29ms end to
+  end. The remaining cost is the taxonomy join itself and is not addressed here.
+
 ### Changed
 
 - **Species are counted by catalogue identity rather than by name text.** Phase 4 of the versioned

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -780,24 +780,46 @@ class DetectionRepository:
         # Grouping keys on catalogue identity, so filtering has to follow it or
         # the two disagree: the leaderboard merges a renamed taxon into one row,
         # and opening that row shows only the rows still carrying the name that
-        # was searched for. Widen the match to every detection sharing a
-        # `species_id` with something the name already matched.
+        # was searched for.
         #
-        # The inner match is deliberately detection-only: a correlated subquery
-        # cannot see the outer `tc_filter` join, and finding the identity does
-        # not need the taxonomy fallback that finding the rows does.
-        identity_condition, identity_params = await self._build_canonical_species_condition(
-            detection_alias="d_identity",
-            species_name=species_name,
-            has_taxonomy_cache=False,
-        )
-        condition = (
-            f"(({condition}) OR {detection_alias}.species_id IN ("
-            f"SELECT d_identity.species_id FROM detections d_identity "
-            f"WHERE d_identity.species_id IS NOT NULL AND ({identity_condition})))"
-        )
-        params = [*params, *identity_params]
+        # Resolved to concrete ids first rather than left as a subquery. A
+        # subquery here is evaluated once, but it still scans the whole
+        # detections table, and this runs on the events list where a species
+        # filter was already the slowest of the three filters. Measured on a
+        # 96,108 row database: 54ms as a subquery against 16ms resolved.
+        identity_ids = await self._species_ids_for_name(species_name)
+        if identity_ids:
+            placeholders = ",".join(["?"] * len(identity_ids))
+            condition = f"(({condition}) OR {detection_alias}.species_id IN ({placeholders}))"
+            params = [*params, *identity_ids]
         return join_sql, condition, params
+
+    async def _species_ids_for_name(self, species_name: str) -> list[int]:
+        """Catalogue identities already recorded against this name.
+
+        Read from `detections` rather than the catalogue: the identity we want is
+        the one history actually carries, and it keeps this inside one database
+        (§3).
+
+        Each arm is a bare `LOWER(column)` so the lowercased-name indexes can
+        serve it. Wrapping `common_name` in `COALESCE` to tolerate NULL cost the
+        index and took this from 7ms to 46ms on a 96,108 row database; a NULL
+        simply does not match, which is the behaviour wanted anyway.
+        """
+        name = str(species_name or "").strip()
+        if not name:
+            return []
+        async with self.db.execute(
+            """
+            SELECT DISTINCT species_id FROM detections
+            WHERE species_id IS NOT NULL
+              AND (LOWER(scientific_name) = LOWER(?) OR LOWER(display_name) = LOWER(?)
+                   OR LOWER(common_name) = LOWER(?))
+            """,
+            (name, name, name),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [int(row[0]) for row in rows if row and row[0] is not None]
 
     async def _last_statement_changes(self) -> int:
         """Return rows changed by the most recent write statement on this connection."""

--- a/backend/migrations/versions/d5e7a91c2f38_index_lowercased_species_names.py
+++ b/backend/migrations/versions/d5e7a91c2f38_index_lowercased_species_names.py
@@ -1,0 +1,47 @@
+"""Index the lowercased species names the species filter joins on
+
+Filtering the events list by species was measurably slower than filtering by
+date or camera, which a user reported. The cause is the taxonomy join:
+
+    LOWER(tc.scientific_name) = LOWER(d.scientific_name)
+
+A plain index cannot serve a predicate wrapped in a function, so SQLite scanned
+`taxonomy_cache` once per detection row. Measured on a 96,108 row copy of a real
+database, filtering by species took 25ms against effectively zero for the other
+filters, and the plan showed `SCAN tc_filter LEFT-JOIN`.
+
+These are expression indexes matching the predicates exactly, so the join can be
+served by a lookup instead. Same measurement afterwards: 16ms, and the scan is
+gone.
+
+Revision ID: d5e7a91c2f38
+Revises: c8f3a1d47b02
+Create Date: 2026-08-23
+"""
+
+from alembic import op
+
+revision = "d5e7a91c2f38"
+down_revision = "c8f3a1d47b02"
+branch_labels = None
+depends_on = None
+
+# Indexes only: no column, constraint or data change, so both directions are
+# safe to re-run and neither can lose a row.
+_INDEXES = (
+    ("idx_taxonomy_cache_lower_scientific", "taxonomy_cache", "LOWER(scientific_name)"),
+    ("idx_taxonomy_cache_lower_common", "taxonomy_cache", "LOWER(common_name)"),
+    ("idx_detections_lower_scientific", "detections", "LOWER(scientific_name)"),
+    ("idx_detections_lower_display", "detections", "LOWER(display_name)"),
+    ("idx_detections_lower_common", "detections", "LOWER(common_name)"),
+)
+
+
+def upgrade() -> None:
+    for name, table, expression in _INDEXES:
+        op.execute(f"CREATE INDEX IF NOT EXISTS {name} ON {table} ({expression})")
+
+
+def downgrade() -> None:
+    for name, _table, _expression in _INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {name}")

--- a/backend/tests/test_canonical_identity_grouping.py
+++ b/backend/tests/test_canonical_identity_grouping.py
@@ -227,3 +227,35 @@ def test_live_grouping_and_the_rollup_key_are_deliberately_different():
     legacy = DetectionRepository._legacy_rollup_key_sql()
     assert live != legacy, "the rollup key is pinned on purpose; see _legacy_rollup_key_sql"
     assert "species:" in live
+
+
+@pytest.mark.asyncio
+async def test_the_species_filter_does_not_scan_the_table_to_find_an_identity(seeded_repository):
+    """A user reported the species filter being slower than the others.
+
+    The identity clause must be concrete ids, not a subquery over `detections`.
+    A subquery is evaluated once but still scans the table, and measured on a
+    96,108 row database that was 54ms against 16ms resolved.
+    """
+    repo, add = seeded_repository
+    await add(display_name="Dunnock", scientific_name="Prunella modularis", species_id=10081)
+
+    _join, condition, params = await repo._canonical_species_query_parts(
+        detection_alias="d",
+        species_name="Prunella modularis",
+    )
+    assert "SELECT" not in condition.upper(), f"identity must not be a subquery: {condition}"
+    assert "species_id IN (" in condition
+    assert 10081 in params
+
+
+@pytest.mark.asyncio
+async def test_a_name_with_no_recorded_identity_adds_no_clause(seeded_repository):
+    repo, add = seeded_repository
+    await add(display_name="Unknown Bird")
+
+    _join, condition, params = await repo._canonical_species_query_parts(
+        detection_alias="d",
+        species_name="Unknown Bird",
+    )
+    assert "species_id IN (" not in condition, "an absent identity must not widen the filter"


### PR DESCRIPTION
Addresses #258, and fixes a regression I introduced in #261.

## What was measured

A 96,108 row copy of a real database, on the deployment's own hardware. The reporter's observation holds: the species filter is the slow one.

| State | Time |
| --- | ---: |
| No species filter (date/camera only) | ~0ms |
| Species filter, before catalogue identity | 26.4ms |
| **Species filter, as merged on `dev` today** | **41.5ms** |
| Species filter, after this change | **29.2ms** |

## Two separate causes

**The taxonomy join, which is the reported issue.** Its predicates are `LOWER(tc.scientific_name) = LOWER(d.scientific_name)` and friends, and an ordinary index cannot serve a predicate wrapped in a function. The plan showed `SCAN tc_filter LEFT-JOIN`: all 172 taxonomy rows scanned for each of 96,108 detections. This adds expression indexes matching those predicates.

**My own regression.** The identity clause added with species grouping was a subquery. SQLite evaluates it once, but it still scans the whole table, and it took the same filter from 26ms to 41ms. It is now resolved to concrete ids before the SQL is built.

One detail worth calling out, because it inverted the result: the resolution query originally wrapped `common_name` in `COALESCE(common_name, '')` to tolerate NULL. That wrapper defeats the index and took the lookup from **6ms to 46ms**, more than the query it was helping. A NULL simply not matching is the behaviour wanted anyway, so each arm is now a bare `LOWER(column)` and all three use an index.

## Honest limits

**This does not fully fix #258.** The taxonomy join is still ~18ms of the remaining 23.5ms, and the indexes do not remove it: SQLite cannot use an index for an `OR`'d join condition spanning different columns. Removing that cost means replacing the join with a name set resolved up front, which is a real refactor and deserves its own change.

Two measurements that shape that future work, both from the same database:

- 6,321 of 96,108 rows (6.6%) have no `scientific_name`, and **all of them resolve through `taxonomy_cache`**, so the join is genuinely load-bearing and cannot simply be dropped.
- On this data every one of those rows is `Unknown Bird`, a label the leaderboard already excludes. Another install with pending enrichment would differ, which is exactly why this needs an equivalence proof rather than an assumption.

The filter is also still 11% slower than before catalogue identity. That residual is the identity lookup, and it is the cost of a species page showing every row the leaderboard counted rather than only those still carrying the searched name.

## Migration

`d5e7a91c2f38`, five expression indexes. No column, constraint or data change, so neither direction can lose a row and both are safe to re-run. Verified `upgrade → downgrade → upgrade` leaves a single head and five indexes.

## Verified

2,319 backend tests passing, 2 new ones asserting the identity clause is concrete ids rather than a subquery. `ruff` clean repo-wide, docs consistency passing.