### PR TITLE
Name the model on the Deep Video Analysis card again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Deep Video Analysis names the model again.** The card that reports a video classification
+  sometimes showed no model at all, which reads as though none was involved. Two causes, both real.
+  A snapshot fallback ranked its results through a helper that carries no provenance, so no model
+  was ever recorded: on a live install 11 completed classifications had none, every one from a
+  snapshot source. Separately, a regional model is addressed as `parent/region` and region variants
+  are nested under a parent that owns the id, so an exact lookup found nothing and anyone running a
+  regional model saw no name. Regional models now read as "Small Birds (EU)", and a model the
+  registry no longer publishes reports its id rather than disappearing. Reported in #257.
+
 - **Filtering the events list by a species is faster.** A user reported that the species filter was
   noticeably slower than the date and camera filters, which are effectively instant. Measured on a
   96,108 row copy of a real database it took 26ms, and the plan showed the taxonomy join scanning

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -223,19 +223,38 @@ def _get_active_model_id_for_feedback() -> str:
 
 
 def _video_classification_model_name(model_id: str | None) -> str | None:
+    """A display name for the model that produced a classification.
+
+    Falls back to the id itself when the registry does not know it. Returning
+    nothing hid the model entirely on the detection card, which reads as "no
+    model was involved" rather than "this model is no longer published" (§5).
+    """
     normalized = str(model_id or "").strip()
     if not normalized:
         return None
     try:
         from app.services.model_manager import REMOTE_REGISTRY
 
-        model_meta = next((m for m in REMOTE_REGISTRY if m["id"] == normalized), None)
+        registry = list(REMOTE_REGISTRY)
     except Exception:
-        model_meta = None
-    if not model_meta:
-        return None
-    name = str(model_meta.get("name") or "").strip()
-    return name or None
+        return normalized
+
+    model_meta = next((m for m in registry if m.get("id") == normalized), None)
+    if model_meta:
+        return str(model_meta.get("name") or "").strip() or normalized
+
+    # A regional model is addressed as `parent/region`; the variant is nested
+    # under its parent and carries no id of its own, so an exact match misses.
+    if "/" in normalized:
+        parent_id, _, region = normalized.partition("/")
+        parent = next((m for m in registry if m.get("id") == parent_id), None)
+        variant = dict((parent or {}).get("region_variants", {}).get(region) or {})
+        if variant or parent:
+            base = str(variant.get("name") or (parent or {}).get("name") or parent_id).strip()
+            label = region.strip().upper()
+            return f"{base} ({label})" if base and label else base or normalized
+
+    return normalized
 
 
 async def batch_check_clips(event_ids: list[str]) -> dict[str, dict[str, bool]]:

--- a/backend/app/services/auto_video_classifier_service.py
+++ b/backend/app/services/auto_video_classifier_service.py
@@ -173,6 +173,42 @@ def _empty_timeout_state() -> dict[JobSource, dict[str, object]]:
     }
 
 
+def _active_model_id_or_none() -> str | None:
+    """The model currently doing classification, or nothing if it cannot be known."""
+    try:
+        from app.services.model_manager import model_manager
+
+        return str(getattr(model_manager, "active_model_id", "") or "").strip() or None
+    except Exception:
+        return None
+
+
+def attach_classification_provenance(
+    result: dict,
+    *,
+    input_source: str | None,
+    model_id: str | None,
+) -> dict:
+    """Record which model and which input produced a classification.
+
+    The video path builds its results with provenance attached. The snapshot
+    fallback ranks probabilities through a helper that carries none, so the
+    model id was never recorded and the detection card could not name the model
+    that did the work. Measured on a live install: 11 completed classifications
+    with no model id, every one from a snapshot source.
+
+    Anything the classifier already reported wins; this only fills gaps, so a
+    result that knows its own model is never relabelled with the active one.
+    """
+    enriched = dict(result)
+    if input_source:
+        enriched.setdefault("input_source", input_source)
+    normalized_model_id = str(model_id or "").strip()
+    if normalized_model_id:
+        enriched.setdefault("model_id", normalized_model_id)
+    return enriched
+
+
 class AutoVideoClassifierService:
     """
     Service to automatically classify video clips from Frigate events.
@@ -2671,8 +2707,11 @@ class AutoVideoClassifierService:
                 reason=reason or "snapshot_no_usable_result",
             )
             return reason or "snapshot_no_usable_result"
-        top_with_provenance = dict(top)
-        top_with_provenance.setdefault("input_source", provenance.input_source)
+        top_with_provenance = attach_classification_provenance(
+            top,
+            input_source=provenance.input_source,
+            model_id=_active_model_id_or_none(),
+        )
         await self._save_results(
             frigate_event,
             top_with_provenance,

--- a/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
+++ b/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
@@ -381,7 +381,15 @@ async def test_process_event_falls_back_to_snapshot_when_clip_not_retained_for_b
     }
     service._save_results.assert_awaited_once_with(
         "evt-batch-fallback",
-        {"label": "Robin", "score": 0.88, "index": 1, "input_source": "frigate_snapshot"},
+        # `model_id` is recorded so the detection card can name the model that
+        # produced a snapshot fallback, which it previously could not.
+        {
+            "label": "Robin",
+            "score": 0.88,
+            "index": 1,
+            "input_source": "frigate_snapshot",
+            "model_id": "model.tflite",
+        },
         manual_tagged=False,
     )
 
@@ -469,7 +477,15 @@ async def test_process_event_snapshot_fallback_retries_background_overload_then_
     assert service._classifier.classify_async_background.await_count == 2
     service._save_results.assert_awaited_once_with(
         "evt-batch-fallback-retry",
-        {"label": "Robin", "score": 0.88, "index": 1, "input_source": "frigate_snapshot"},
+        # `model_id` is recorded so the detection card can name the model that
+        # produced a snapshot fallback, which it previously could not.
+        {
+            "label": "Robin",
+            "score": 0.88,
+            "index": 1,
+            "input_source": "frigate_snapshot",
+            "model_id": "model.tflite",
+        },
         manual_tagged=False,
     )
     service._record_success.assert_called_once_with("evt-batch-fallback-retry", source="maintenance")

--- a/backend/tests/test_video_model_provenance.py
+++ b/backend/tests/test_video_model_provenance.py
@@ -1,0 +1,80 @@
+"""Which model produced a video classification, and saying so.
+
+The Deep Video Analysis card names the model that produced the result. A user
+reported it sometimes missing. Two causes, both real:
+
+* The snapshot fallback path builds its results through a plain ranking helper
+  that carries no provenance, so no model id was recorded at all. Measured on a
+  live install: 11 completed classifications with a null model id, every one of
+  them from a snapshot source.
+* A regional model's id is `parent/region`, and region variants are nested under
+  their parent in the registry without an id of their own. An exact-id lookup
+  therefore finds nothing, so anyone running a regional model gets no name.
+"""
+
+import pytest
+
+from app.routers.events import _video_classification_model_name
+
+
+def test_a_top_level_model_resolves_to_its_name():
+    assert _video_classification_model_name("rope_vit_b14_inat21")
+
+
+def test_a_region_variant_resolves_rather_than_vanishing():
+    """`small_birds/eu` is nested under `small_birds`, which owns the id."""
+    name = _video_classification_model_name("small_birds/eu")
+    assert name, "a regional model must still name itself"
+
+
+def test_a_region_variant_name_distinguishes_the_region():
+    eu = _video_classification_model_name("small_birds/eu")
+    na = _video_classification_model_name("small_birds/na")
+    assert eu and na and eu != na, f"regions must be distinguishable: {eu!r} vs {na!r}"
+
+
+def test_an_unknown_model_id_is_reported_rather_than_hidden():
+    """§5: showing nothing invents a state. The id itself is honest."""
+    assert _video_classification_model_name("some_model_we_retired") == "some_model_we_retired"
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_no_model_id_stays_absent(value):
+    assert _video_classification_model_name(value) is None
+
+
+def test_provenance_never_overwrites_what_the_classifier_already_reported():
+    from app.services.auto_video_classifier_service import attach_classification_provenance
+
+    top = {"index": 1, "score": 0.5, "label": "x", "model_id": "from_classifier", "input_source": "model_crop"}
+    result = attach_classification_provenance(top, input_source="frigate_snapshot_cropped", model_id="active_model")
+    assert result["model_id"] == "from_classifier"
+    assert result["input_source"] == "model_crop"
+
+
+def test_provenance_records_the_active_model_when_the_classifier_did_not():
+    from app.services.auto_video_classifier_service import attach_classification_provenance
+
+    result = attach_classification_provenance(
+        {"index": 1, "score": 0.5, "label": "x"},
+        input_source="frigate_snapshot_cropped",
+        model_id="rope_vit_b14_inat21",
+    )
+    assert result["model_id"] == "rope_vit_b14_inat21"
+    assert result["input_source"] == "frigate_snapshot_cropped"
+
+
+def test_provenance_leaves_the_model_id_out_when_it_is_unknown():
+    from app.services.auto_video_classifier_service import attach_classification_provenance
+
+    result = attach_classification_provenance({"label": "x"}, input_source="frigate_snapshot_cropped", model_id=None)
+    assert "model_id" not in result
+    assert result["input_source"] == "frigate_snapshot_cropped"
+
+
+def test_provenance_does_not_mutate_the_classifier_result():
+    from app.services.auto_video_classifier_service import attach_classification_provenance
+
+    top = {"label": "x"}
+    attach_classification_provenance(top, input_source="frigate_snapshot_cropped", model_id="m")
+    assert top == {"label": "x"}


### PR DESCRIPTION
Closes #257.

## What the screenshots showed

Both cards are the same feature on the same install. One has three chips, the other two:

| | Chips |
| --- | --- |
| Working | `Cropped video frames`, `CPU`, **`RoPE ViT-B14 (Medium Accuracy)`** |
| Broken | `Full video frames`, `CPU` |

The model chip is simply absent. Showing nothing reads as though no model was involved, which is not what happened (§5).

## Two separate causes, both real

**The snapshot fallback recorded no model at all.** The video path builds its results with provenance attached; the snapshot path ranks probabilities through a helper that returns `{index, score, label}` and nothing else. Measured on a live install: **11 completed classifications with a null model id, every one of them from a snapshot source** (`frigate_snapshot_cropped` and `hq_candidate_model_crop`), while every video-sourced row had one.

That path now attaches the active model the same way it already attached the input source. It fills gaps only, so a result that knows its own model is never relabelled with the active one.

**A regional model could never resolve.** Region variants are addressed as `parent/region` but are nested under a parent that owns the `id`, so `next(m for m in REMOTE_REGISTRY if m["id"] == "small_birds/eu")` finds nothing and returns `None`. Anyone running a regional model saw no name on any classification.

Verified against the real registry:

```
'rope_vit_b14_inat21'  -> 'RoPE ViT-B14 (Medium Accuracy)'
'small_birds/eu'       -> 'Small Birds (EU)'
'small_birds/na'       -> 'Small Birds (NA)'
'medium_birds/eu'      -> 'Medium Birds (EU)'
'retired_thing'        -> 'retired_thing'
''                     -> None
```

The region is kept in the name so two variants of one family stay distinguishable, and a model the registry no longer publishes reports its id rather than disappearing. An empty id still yields no chip, because there genuinely is nothing to say.

## Scope

I could not reproduce the reporter's exact row: their broken card is `full_frame`, and this install has no detections from that source. Both causes above produce precisely the reported symptom and one of them almost certainly explains it, but I have asked for the specific detection so it can be confirmed rather than assumed.

## Verified

2,330 backend tests passing, 11 new. Two existing snapshot-fallback tests asserted the exact result dict and were updated to expect the recorded model, which is the intended change rather than a weakening. `ruff` clean repo-wide, docs consistency passing.

## Risk

Low. One additional field recorded on a path that recorded none, and a lookup that previously returned nothing now returns a name or the id. No schema change, no migration.