### PR TITLE
Name a species from the catalogue rather than from one of its rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **Species are named from the catalogue rather than from whichever detection sorted last.**
+  Grouping already keyed on catalogue identity, but the name shown for a group was still taken
+  from one of its rows, so a taxon recorded under two names was counted once and then labelled
+  arbitrarily. One precedence rule now decides, at read time and in one place: an owner's own
+  rename first, then the catalogue's curated name for the reader's language, then English, then
+  the scientific name, and only then whatever the detection already carried. Nothing is written
+  back into a detection's identity, because a name in a language is a rendering and not a fact
+  about the bird. On a real install this changed 3 of 42 species, each toward the IOC spelling:
+  "Eurasian Blackbird" to "Common Blackbird", "Common Wood-Pigeon" to "Common Wood Pigeon", and
+  "Gray-headed" to "Grey-headed". It also brings the Italian and Chinese names that the previous
+  sources largely did not carry.
+
 ### Fixed
 
 - **Deep Video Analysis names the model again.** The card that reports a video classification

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -3138,7 +3138,9 @@ class DetectionRepository:
                 AVG(d.score) as avg_confidence,
                 MAX(d.score) as max_confidence,
                 MIN(d.score) as min_confidence,
-                COUNT(DISTINCT d.camera_name) as camera_count
+                COUNT(DISTINCT d.camera_name) as camera_count,
+                MAX(d.species_id) as species_id,
+                MAX(tc.manual_common_name) as manual_common_name
             FROM detections d
             {taxonomy_join}
             WHERE (d.is_hidden = 0 OR d.is_hidden IS NULL)
@@ -3163,6 +3165,12 @@ class DetectionRepository:
                     "max_confidence": row[9] or 0.0,
                     "min_confidence": row[10] or 0.0,
                     "camera_count": row[11] or 0,
+                    # The group's catalogue identity, so a name can be chosen
+                    # for the group rather than taken from one of its rows.
+                    # Every row in a group shares it, so MAX is just "the one".
+                    "species_id": int(row[12]) if row[12] is not None else None,
+                    # An owner rename still wins over any catalogue name.
+                    "manual_common_name": row[13],
                 }
                 for row in rows
             ]

--- a/backend/app/routers/species.py
+++ b/backend/app/routers/species.py
@@ -866,6 +866,17 @@ async def get_species_list(request: Request):
         unknown_labels = settings.classification.unknown_bird_labels
         filtered_stats = []
 
+        # One batched lookup for the whole page rather than a query per row.
+        # A group is named from its catalogue identity so a merged taxon reads
+        # consistently, instead of taking whichever of its rows sorted last.
+        from app.services.species_names import species_name_lookup
+
+        catalogue_names = await asyncio.to_thread(
+            species_name_lookup.display_names,
+            [s.get("species_id") for s in stats if s.get("species_id") is not None],
+            language=lang,
+        )
+
         for s in stats:
             if s["species"] in unknown_labels or should_hide_species_label(s["species"]):
                 continue
@@ -879,7 +890,14 @@ async def get_species_list(request: Request):
 
             common_name = s.get("common_name")
             taxa_id = s.get("taxa_id")
-            if taxa_id:
+            # An owner rename is the person's own decision and outranks every
+            # source. Below it the catalogue is preferred, because its names are
+            # curated per language and cover locales the providers do not.
+            owner_renamed = bool(str(s.get("manual_common_name") or "").strip())
+            catalogue_name = None if owner_renamed else catalogue_names.get(s.get("species_id"))
+            if catalogue_name:
+                common_name = catalogue_name
+            elif taxa_id:
                 if lang != "en":
                     localized = await taxonomy_service.get_localized_common_name(taxa_id, lang, db=db)
                     if localized:

--- a/backend/app/services/species_names.py
+++ b/backend/app/services/species_names.py
@@ -1,0 +1,161 @@
+"""One rule for which name to show a person for a species.
+
+Species are grouped by catalogue identity, so two names for one bird count as
+one bird. The name shown for that group used to be `MAX(display_name)`, which
+is whichever name happened to sort last. Correct grouping with an arbitrary
+label is half a feature, because the label is the part anyone actually reads.
+
+The rule lives here, once, and is applied at read time. A locale-dependent name
+is a rendering rather than a fact about the bird, so nothing here is ever
+written back into a detection's identity.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping, Optional
+
+import structlog
+
+log = structlog.get_logger()
+
+DEFAULT_LANGUAGE = "en"
+
+
+@dataclass(frozen=True)
+class CatalogueNames:
+    """What the catalogue knows about one species' names.
+
+    `overrides` and `vernacular` are keyed by language tag; the empty tag in
+    `overrides` is a rename the owner applied to every language at once.
+    """
+
+    overrides: Mapping[str, Optional[str]] = field(default_factory=dict)
+    vernacular: Mapping[str, Optional[str]] = field(default_factory=dict)
+    scientific: Optional[str] = None
+
+
+def normalize_language(language: Optional[str]) -> str:
+    """`  pt-BR ` and `PT` both mean the `pt` names the catalogue holds."""
+    tag = str(language or "").strip().lower()
+    if not tag:
+        return DEFAULT_LANGUAGE
+    return tag.split("-", 1)[0].split("_", 1)[0] or DEFAULT_LANGUAGE
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    text = str(value or "").strip()
+    return text or None
+
+
+def choose_display_name(names: CatalogueNames, *, language: Optional[str]) -> Optional[str]:
+    """The name to show, or None to leave the caller's own name alone.
+
+    In order: what the owner renamed it to for this language, what they renamed
+    it to for every language, the catalogue's name in this language, the
+    catalogue's English name, then the scientific name.
+
+    English is the stand-in because coverage is uneven and measurable: IOC 14.2
+    names all 11,276 species in English and 10,210 in Italian, so a species with
+    no Italian name is an ordinary case rather than an error.
+    """
+    tag = normalize_language(language)
+
+    for candidate in (
+        names.overrides.get(tag),
+        names.overrides.get(""),
+        names.vernacular.get(tag),
+        names.vernacular.get(DEFAULT_LANGUAGE),
+        names.scientific,
+    ):
+        cleaned = _clean(candidate)
+        if cleaned:
+            return cleaned
+    return None
+
+
+class SpeciesNameLookup:
+    """Names for a handful of species, read on demand.
+
+    Deliberately not loaded into memory the way the resolver's mappings are:
+    the catalogue holds 98,932 names across nine languages, and a page shows
+    one language and a few dozen species. One indexed query per read costs far
+    less than holding all of it.
+
+    Never raises into a read path. A catalogue that is absent or unreadable
+    yields no names, and the caller keeps whatever name it already had.
+    """
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = path
+
+    def _resolved_path(self) -> Path:
+        if self._path is not None:
+            return Path(self._path)
+        from app.services.species_catalog_store import default_catalog_path
+
+        return default_catalog_path()
+
+    def display_names(self, species_ids: Iterable[int], *, language: Optional[str]) -> dict[int, str]:
+        wanted = {int(value) for value in species_ids if value is not None}
+        if not wanted:
+            return {}
+
+        tag = normalize_language(language)
+        placeholders = ",".join(["?"] * len(wanted))
+        ids = list(wanted)
+
+        try:
+            connection = sqlite3.connect(f"file:{self._resolved_path()}?mode=ro", uri=True)
+        except sqlite3.Error as error:
+            log.debug("Species catalogue unavailable for naming", error=str(error))
+            return {}
+
+        try:
+            overrides: dict[int, dict[str, Optional[str]]] = {}
+            for species_id, language_tag, name in connection.execute(
+                f"SELECT species_id, language_tag, name FROM species_name_overrides"
+                f" WHERE species_id IN ({placeholders})",
+                ids,
+            ):
+                overrides.setdefault(int(species_id), {})[str(language_tag or "")] = name
+
+            vernacular: dict[int, dict[str, Optional[str]]] = {}
+            # Only the language asked for and English, which is the stand-in.
+            for species_id, language_tag, name in connection.execute(
+                f"SELECT species_id, language_tag, name FROM species_names"
+                f" WHERE species_id IN ({placeholders}) AND language_tag IN (?, ?)",
+                [*ids, tag, DEFAULT_LANGUAGE],
+            ):
+                vernacular.setdefault(int(species_id), {})[str(language_tag or "")] = name
+
+            scientific: dict[int, str] = {}
+            for species_id, name in connection.execute(
+                f"SELECT species_id, scientific_name FROM species_concepts WHERE species_id IN ({placeholders})",
+                ids,
+            ):
+                scientific.setdefault(int(species_id), str(name))
+        except sqlite3.Error as error:
+            log.debug("Species catalogue unreadable for naming", error=str(error))
+            return {}
+        finally:
+            connection.close()
+
+        resolved: dict[int, str] = {}
+        for species_id in wanted:
+            chosen = choose_display_name(
+                CatalogueNames(
+                    overrides=overrides.get(species_id, {}),
+                    vernacular=vernacular.get(species_id, {}),
+                    scientific=scientific.get(species_id),
+                ),
+                language=tag,
+            )
+            if chosen:
+                resolved[species_id] = chosen
+        return resolved
+
+
+species_name_lookup = SpeciesNameLookup()

--- a/backend/tests/test_canonical_identity_grouping.py
+++ b/backend/tests/test_canonical_identity_grouping.py
@@ -259,3 +259,24 @@ async def test_a_name_with_no_recorded_identity_adds_no_clause(seeded_repository
         species_name="Unknown Bird",
     )
     assert "species_id IN (" not in condition, "an absent identity must not widen the filter"
+
+
+@pytest.mark.asyncio
+async def test_the_leaderboard_exposes_the_species_identity_for_naming(seeded_repository):
+    """Naming a merged group needs its identity, not one of its labels."""
+    repo, add = seeded_repository
+    await add(display_name="Blue Tit", scientific_name="Parus caeruleus", species_id=4242)
+    await add(display_name="Eurasian Blue Tit", scientific_name="Cyanistes caeruleus", species_id=4242)
+
+    rows = await repo.get_species_leaderboard_base()
+    merged = next(r for r in rows if r["count"] == 2)
+    assert merged["species_id"] == 4242
+
+
+@pytest.mark.asyncio
+async def test_a_group_without_identity_reports_none_rather_than_guessing(seeded_repository):
+    repo, add = seeded_repository
+    await add(display_name="Unknown Bird")
+
+    rows = await repo.get_species_leaderboard_base()
+    assert rows[0]["species_id"] is None

--- a/backend/tests/test_species_name_precedence.py
+++ b/backend/tests/test_species_name_precedence.py
@@ -1,0 +1,204 @@
+"""Which name to show for a species, and why that one.
+
+Grouping now keys on catalogue identity, so two names for one bird count as one
+bird. The name shown for that group was still `MAX(display_name)`, which is
+whichever name sorts last alphabetically. Correct grouping with an arbitrary
+label is a half-finished feature: the label is the part a person sees.
+
+One precedence rule, applied at read time. Identity is never renamed by it: a
+locale-dependent name is a rendering, not a fact about the bird.
+"""
+
+import pytest
+
+from app.services.species_names import CatalogueNames, choose_display_name
+
+
+def _names(**kwargs) -> CatalogueNames:
+    return CatalogueNames(
+        overrides=kwargs.get("overrides", {}),
+        vernacular=kwargs.get("vernacular", {}),
+        scientific=kwargs.get("scientific"),
+    )
+
+
+def test_an_owner_rename_for_the_language_wins_outright():
+    names = _names(
+        overrides={"de": "Heckenbraunelle (mein Name)", "": "My Dunnock"},
+        vernacular={"de": "Heckenbraunelle", "en": "Dunnock"},
+        scientific="Prunella modularis",
+    )
+    assert choose_display_name(names, language="de") == "Heckenbraunelle (mein Name)"
+
+
+def test_an_owner_rename_with_no_language_applies_to_every_language():
+    names = _names(overrides={"": "Garden Dunnock"}, vernacular={"de": "Heckenbraunelle"})
+    assert choose_display_name(names, language="de") == "Garden Dunnock"
+
+
+def test_a_language_specific_rename_beats_a_global_one():
+    names = _names(overrides={"": "Global", "fr": "Local"}, vernacular={"fr": "Accenteur mouchet"})
+    assert choose_display_name(names, language="fr") == "Local"
+
+
+def test_the_catalogue_name_for_the_asked_language_is_used():
+    names = _names(vernacular={"it": "Passera scopaiola", "en": "Dunnock"}, scientific="Prunella modularis")
+    assert choose_display_name(names, language="it") == "Passera scopaiola"
+
+
+def test_english_stands_in_when_the_language_has_no_name():
+    """Measured: Italian covers 10,210 of 11,276 species, so this path is real."""
+    names = _names(vernacular={"en": "Dunnock"}, scientific="Prunella modularis")
+    assert choose_display_name(names, language="it") == "Dunnock"
+
+
+def test_the_scientific_name_is_the_last_resort_before_giving_up():
+    names = _names(scientific="Prunella modularis")
+    assert choose_display_name(names, language="en") == "Prunella modularis"
+
+
+def test_nothing_known_returns_nothing_so_the_caller_keeps_what_it_had():
+    assert choose_display_name(_names(), language="en") is None
+
+
+def test_a_regional_language_tag_falls_back_to_its_base_language():
+    names = _names(vernacular={"pt": "ferreirinha"})
+    assert choose_display_name(names, language="pt-BR") == "ferreirinha"
+
+
+def test_language_matching_ignores_case_and_surrounding_space():
+    names = _names(vernacular={"de": "Heckenbraunelle"})
+    assert choose_display_name(names, language="  DE  ") == "Heckenbraunelle"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", None])
+def test_a_blank_name_is_never_shown(blank):
+    names = _names(overrides={"en": blank}, vernacular={"en": "Dunnock"})
+    assert choose_display_name(names, language="en") == "Dunnock"
+
+
+def test_an_absent_language_defaults_to_english_rather_than_failing():
+    names = _names(vernacular={"en": "Dunnock", "de": "Heckenbraunelle"})
+    assert choose_display_name(names, language=None) == "Dunnock"
+
+
+@pytest.fixture
+def catalogue(tmp_path):
+    """A miniature catalogue with the same shape as the shipped one."""
+    import sqlite3
+
+    path = tmp_path / "species_catalog.db"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE species_concepts (species_id INTEGER, provider TEXT, provider_taxon_id TEXT,
+            source_release TEXT, scientific_name TEXT, authorship TEXT, accepted_name_usage TEXT, status TEXT);
+        CREATE TABLE species_names (id INTEGER PRIMARY KEY, species_id INTEGER, language_tag TEXT,
+            name TEXT, name_kind TEXT DEFAULT 'vernacular', preferred INTEGER DEFAULT 1,
+            region TEXT, provider TEXT, source_release TEXT);
+        CREATE TABLE species_name_overrides (id INTEGER PRIMARY KEY, species_id INTEGER,
+            language_tag TEXT DEFAULT '', name TEXT, updated_at TEXT);
+        """
+    )
+    connection.execute(
+        "INSERT INTO species_concepts VALUES (10081,'ioc','Prunella modularis','14.2','Prunella modularis',NULL,NULL,NULL)"
+    )
+    for tag, name in (("en", "Dunnock"), ("de", "Heckenbraunelle"), ("it", "Passera scopaiola")):
+        connection.execute(
+            "INSERT INTO species_names (species_id, language_tag, name, provider, source_release)"
+            " VALUES (?,?,?,'ioc','14.2')",
+            (10081, tag, name),
+        )
+    connection.execute(
+        "INSERT INTO species_concepts VALUES (9293,'ioc','Erithacus rubecula','14.2','Erithacus rubecula',NULL,NULL,NULL)"
+    )
+    connection.execute(
+        "INSERT INTO species_names (species_id, language_tag, name, provider, source_release)"
+        " VALUES (9293,'en','European Robin','ioc','14.2')"
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def test_the_lookup_reads_names_for_the_species_asked_for(catalogue):
+    from app.services.species_names import SpeciesNameLookup
+
+    lookup = SpeciesNameLookup(catalogue)
+    assert lookup.display_names([10081], language="de") == {10081: "Heckenbraunelle"}
+    assert lookup.display_names([10081], language="it") == {10081: "Passera scopaiola"}
+
+
+def test_the_lookup_falls_back_to_english_then_scientific(catalogue):
+    from app.services.species_names import SpeciesNameLookup
+
+    lookup = SpeciesNameLookup(catalogue)
+    assert lookup.display_names([9293], language="de") == {9293: "European Robin"}
+
+
+def test_the_lookup_answers_for_several_species_at_once(catalogue):
+    from app.services.species_names import SpeciesNameLookup
+
+    lookup = SpeciesNameLookup(catalogue)
+    resolved = lookup.display_names([10081, 9293], language="en")
+    assert resolved == {10081: "Dunnock", 9293: "European Robin"}
+
+
+def test_an_owner_override_is_honoured_by_the_lookup(catalogue):
+    import sqlite3
+
+    from app.services.species_names import SpeciesNameLookup
+
+    connection = sqlite3.connect(catalogue)
+    connection.execute(
+        "INSERT INTO species_name_overrides (species_id, language_tag, name) VALUES (10081,'','Hedge Sparrow')"
+    )
+    connection.commit()
+    connection.close()
+
+    assert SpeciesNameLookup(catalogue).display_names([10081], language="de") == {10081: "Hedge Sparrow"}
+
+
+def test_an_unknown_species_is_simply_absent(catalogue):
+    from app.services.species_names import SpeciesNameLookup
+
+    assert SpeciesNameLookup(catalogue).display_names([999999], language="en") == {}
+
+
+def test_no_species_ids_asks_the_database_nothing(catalogue):
+    from app.services.species_names import SpeciesNameLookup
+
+    assert SpeciesNameLookup(catalogue).display_names([], language="en") == {}
+
+
+def test_a_missing_catalogue_never_raises_into_a_read_path(tmp_path):
+    from app.services.species_names import SpeciesNameLookup
+
+    assert SpeciesNameLookup(tmp_path / "absent.db").display_names([1], language="en") == {}
+
+
+def test_the_router_prefers_an_owner_rename_over_the_catalogue():
+    """A rename is the person's own decision and must outrank every source.
+
+    Guarded explicitly because the catalogue holds a curated name for nearly
+    every species, so a naive preference would quietly undo every rename an
+    owner had made.
+    """
+    import inspect
+
+    from app.routers import species as species_router
+
+    source = inspect.getsource(species_router)
+    assert "owner_renamed" in source
+    assert "None if owner_renamed else catalogue_names.get" in source
+
+
+def test_the_router_looks_names_up_once_for_the_page():
+    """A query per row would put the catalogue in the middle of a loop."""
+    import inspect
+
+    from app.routers import species as species_router
+
+    source = inspect.getsource(species_router)
+    assert source.count("species_name_lookup.display_names") == 1
+    assert "asyncio.to_thread" in source


### PR DESCRIPTION
Phase 4 of the versioned species catalogue, second slice.

## Why

The previous slice made species group by catalogue identity, so a taxon recorded under two names counts as one bird. The name shown for that group was still `MAX(display_name)`, whichever sorted last alphabetically.

Correct grouping with an arbitrary label is half a feature. The label is the part anyone actually reads, and the moment the thing this phase exists for happens, `Parus caeruleus` merging with `Cyanistes caeruleus`, the count would be right and the name a coin toss.

## The rule

One precedence chain, in one place, applied at read time:

1. The owner's own rename
2. The catalogue's curated name for the reader's language
3. The catalogue's English name
4. The scientific name
5. Whatever the detection already carried

Nothing here is written back into a detection's identity. A name in a language is a rendering, not a fact about the bird.

**The owner rename outranking everything is the part worth reviewing.** The catalogue holds a curated name for nearly every species, so preferring it naively would have quietly undone every rename anyone had made. That ordering is guarded by an explicit test. No renames exist on the install I tested against, which is exactly why it needed a test rather than an observation.

## Measured against real data

Read-only against a live catalogue of 11,276 species and 98,932 names:

| | |
| --- | ---: |
| Species groups | 42 |
| Unchanged | 31 |
| No catalogue name, left alone | 8 |
| **Changed** | **3** |

Every change moves to the IOC spelling the project already ships:

- `Eurasian Blackbird` to `Common Blackbird` (94 detections)
- `Common Wood-Pigeon` to `Common Wood Pigeon` (47)
- `Southern Gray-headed Sparrow` to `Southern Grey-headed Sparrow` (7)

Verified across every shipped locale against the real catalogue, including the two the previous sources could not serve:

```
it -> {10081: 'Passera scopaiola', 9293: 'Pettirosso'}
zh -> {10081: '林岩鹨',            9293: '欧亚鸲'}
xx -> {10081: 'Dunnock',           9293: 'European Robin'}   # unknown locale falls back
```

A Catalogue of Life non-bird correctly falls through to `Rattus norvegicus`, since IOC carries no vernacular for mammals. That is the precedence chain working, not a gap.

## Shape

Names are read on demand rather than loaded into memory the way the resolver's mappings are. The catalogue holds 98,932 names across nine languages; a page shows one language and a few dozen species. Confirmed on the real catalogue that both queries use an index:

```
SEARCH species_names USING COVERING INDEX ... (species_id=? AND language_tag=?)
SEARCH species_concepts USING INDEX idx_species_concepts_species (species_id=?)
```

One batched lookup per page, wrapped so it never blocks the event loop, and asserted as such by a test. A catalogue that is absent or unreadable yields no names and the caller keeps what it had, so this cannot fail a read path.

## Verified

2,354 backend tests passing, 24 new. The architecture gate (no blocking I/O in async) passes. `ruff` clean repo-wide, docs consistency passing. No schema change, no migration.

## Risk

Display names change for users, in the direction of the curated standard the project already chose. Owner renames are unaffected. Identity is untouched.