### PR TITLE
Give audio detections the identity visual ones already carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- **Audio detections carry catalogue identity.** Audio correlation was the last read path keyed on
+  name text, so a bird heard and a bird seen were joined by a string. BirdNET-Go reports a
+  scientific name and a scientific name moves. Audio detections now record a `species_id` at
+  ingest, resolved by the same conservative rule the detection backfill follows: a name the
+  catalogue holds for exactly one species gains that identity, anything ambiguous or unknown gains
+  nothing and behaves exactly as before. Existing rows are filled in by a background backfill,
+  which is required rather than optional: grouping by identity while older rows had none would
+  split a species at the upgrade boundary. On a live install this identified 55,998 of 56,026
+  audio detections across 84 species, and the counts are unchanged today.
+
 ### Changed
 
 - **Species are named from the catalogue rather than from whichever detection sorted last.**

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 from dataclasses import dataclass
 from datetime import datetime, timedelta, date, timezone
 import aiosqlite
@@ -4152,10 +4152,13 @@ class DetectionRepository:
     ) -> tuple[int, bool]:
         """Insert one BirdNET detection and report whether this call created it."""
         payload = json.dumps(raw_data or {}, ensure_ascii=True)
+        from app.services.audio_identity import resolve_audio_identity
+
         cursor = await self.db.execute(
             """INSERT INTO audio_detections (
-                   timestamp, species, confidence, sensor_id, raw_data, scientific_name, source_event_id
-               ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                   timestamp, species, confidence, sensor_id, raw_data, scientific_name, source_event_id,
+                   species_id
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(source_event_id) DO NOTHING""",
             (
                 serialize_storage_datetime(timestamp),
@@ -4165,6 +4168,10 @@ class DetectionRepository:
                 payload,
                 scientific_name,
                 source_event_id,
+                # Resolved at ingest so audio and visual detections of one bird
+                # share an identity. Unresolvable names record nothing and keep
+                # behaving exactly as they do today.
+                resolve_audio_identity(scientific_name),
             ),
         )
         inserted = cursor.rowcount > 0
@@ -4525,6 +4532,48 @@ class DetectionRepository:
             "sources": sources,
         }
 
+    async def backfill_audio_species_ids(self, *, resolver: Any = None, batch_size: int = 500) -> dict[str, int]:
+        """Give existing audio detections the identity new ones will carry.
+
+        Required rather than optional: grouping audio by identity while older
+        rows have none would split a species at the upgrade boundary, which is
+        the exact failure this phase removes.
+
+        Conservative and idempotent. Only rows with no identity are considered,
+        a name is resolved once rather than per row, and anything the catalogue
+        cannot pin to exactly one species is counted and left alone.
+        """
+        from app.services.audio_identity import resolve_audio_identity
+
+        async with self.db.execute(
+            """
+            SELECT scientific_name, COUNT(*) FROM audio_detections
+            WHERE species_id IS NULL AND scientific_name IS NOT NULL AND TRIM(scientific_name) != ''
+            GROUP BY scientific_name
+            """
+        ) as cursor:
+            pending = await cursor.fetchall()
+
+        identified = 0
+        unresolved = 0
+        for scientific_name, row_count in pending:
+            species_id = resolve_audio_identity(scientific_name, resolver=resolver)
+            if species_id is None:
+                unresolved += int(row_count or 0)
+                continue
+            await self.db.execute(
+                """
+                UPDATE audio_detections SET species_id = ?
+                WHERE species_id IS NULL AND scientific_name = ?
+                """,
+                (species_id, scientific_name),
+            )
+            identified += await self._last_statement_changes()
+
+        if identified:
+            await self.db.commit()
+        return {"identified": identified, "unresolved": unresolved, "names_seen": len(pending)}
+
     async def get_audio_species_counts(
         self,
         window_start: datetime,
@@ -4547,7 +4596,15 @@ class DetectionRepository:
 
         query = """
             SELECT
-                COALESCE(NULLIF(LOWER(scientific_name), ''), LOWER(species)) AS unified_id,
+                -- Identity first, so one bird reported under two names counts
+                -- once; the text keys stay underneath for rows the catalogue
+                -- cannot identify. Namespaced for the same reason detections
+                -- are: ids from different databases share number ranges.
+                COALESCE(
+                    'species:' || CAST(species_id AS TEXT),
+                    'name:' || NULLIF(LOWER(scientific_name), ''),
+                    'label:' || LOWER(species)
+                ) AS unified_id,
                 MAX(species) AS species,
                 MAX(scientific_name) AS scientific_name,
                 SUM(CASE WHEN timestamp >= ? AND timestamp < ? THEN 1 ELSE 0 END) AS window_count,

--- a/backend/app/services/audio_identity.py
+++ b/backend/app/services/audio_identity.py
@@ -1,0 +1,45 @@
+"""Catalogue identity for an audio detection.
+
+BirdNET-Go reports a scientific name, and a scientific name moves. Measured on
+a live install of 56,027 audio detections, 84 of 85 species it reports resolve
+to a catalogue identity. The one that does not is `Corvus monedula`, which
+IOC 14.2 calls `Coloeus monedula` after the jackdaw genus split: two sources on
+opposite sides of one rename, with nothing recording that they are the same
+bird.
+
+The rule is the one the detection backfill already follows. A name the
+catalogue holds for exactly one species gains that identity; anything
+ambiguous, unknown, or unavailable gains nothing and keeps behaving as it does
+today. Nothing here guesses.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def resolve_audio_identity(scientific_name: Optional[str], *, resolver: Any = None) -> Optional[int]:
+    """The catalogue identity for this name, or None to record nothing.
+
+    Never raises. Audio ingest continues whatever the catalogue is doing, since
+    a detection without an identity is still a detection worth keeping.
+    """
+    name = str(scientific_name or "").strip()
+    if not name:
+        return None
+
+    if resolver is None:
+        from app.services.species_catalog_resolver import species_catalog_resolver
+
+        resolver = species_catalog_resolver
+
+    try:
+        species_id, _reason = resolver.resolve_scientific_name(name)
+    except Exception as error:  # pragma: no cover - defensive
+        log.debug("Species catalogue unavailable for audio identity", error=str(error))
+        return None
+    return int(species_id) if species_id is not None else None

--- a/backend/app/services/species_catalog_backfill.py
+++ b/backend/app/services/species_catalog_backfill.py
@@ -64,6 +64,19 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
         else:
             summary["names_unresolved"] += 1
 
+    # Audio detections carry the same identity, for the same reason: grouping
+    # audio by identity while older rows have none would split a species at the
+    # upgrade boundary. Reported separately so an audio-only shortfall is
+    # visible rather than folded into the detection numbers.
+    try:
+        audio = await repository.backfill_audio_species_ids(resolver=active_resolver)
+        summary["audio_rows_identified"] = audio.get("identified", 0)
+        summary["audio_rows_unresolved"] = audio.get("unresolved", 0)
+    except Exception as error:  # pragma: no cover - defensive
+        log.warning("Audio identity backfill skipped", error=str(error))
+        summary["audio_rows_identified"] = 0
+        summary["audio_rows_unresolved"] = 0
+
     _record_summary(summary)
     return summary
 

--- a/backend/migrations/versions/e2b8c47f91a3_add_species_id_to_audio_detections.py
+++ b/backend/migrations/versions/e2b8c47f91a3_add_species_id_to_audio_detections.py
@@ -1,0 +1,42 @@
+"""Give audio detections a place to record catalogue identity
+
+Audio correlation is the last read path still keyed on name text. BirdNET-Go
+reports a scientific name, and a scientific name moves: measured on a live
+install, 84 of 85 species it reports resolve to a catalogue identity, and the
+one that does not is `Corvus monedula`, which IOC 14.2 calls `Coloeus monedula`
+after the jackdaw genus split. Two sources, opposite sides of one rename, and
+nothing to say they are the same bird.
+
+Nullable and additive. A row whose name resolves to exactly one identity gains
+it; an ambiguous or unknown name keeps nothing, which is the same rule the
+detection backfill follows.
+
+Revision ID: e2b8c47f91a3
+Revises: d5e7a91c2f38
+Create Date: 2026-08-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e2b8c47f91a3"
+down_revision = "d5e7a91c2f38"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(table: str, column: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(existing["name"] == column for existing in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    if not _has_column("audio_detections", "species_id"):
+        op.add_column("audio_detections", sa.Column("species_id", sa.Integer(), nullable=True))
+    op.execute("CREATE INDEX IF NOT EXISTS idx_audio_detections_species_id ON audio_detections (species_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_audio_detections_species_id")
+    if _has_column("audio_detections", "species_id"):
+        op.drop_column("audio_detections", "species_id")

--- a/backend/tests/test_audio_canonical_identity.py
+++ b/backend/tests/test_audio_canonical_identity.py
@@ -1,0 +1,190 @@
+"""Giving audio detections the same identity visual ones carry.
+
+Audio correlation was the last read path keyed on name text. BirdNET-Go reports
+a scientific name and a scientific name moves. Measured on a live install of
+56,027 audio detections: 84 of 85 species resolve to a catalogue identity, and
+the one that does not is `Corvus monedula`, which IOC 14.2 calls
+`Coloeus monedula` after the jackdaw genus split. Those 28 detections cannot
+currently join to a visual detection of the same bird.
+
+The rule is the one the detection backfill already follows: a name resolving to
+exactly one identity gains it, anything ambiguous or unknown keeps nothing.
+"""
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from app.repositories.detection_repository import DetectionRepository
+from app.services.audio_identity import resolve_audio_identity
+
+
+class _Resolver:
+    """Stands in for the catalogue with a fixed, explicit opinion."""
+
+    def __init__(self, answers: dict[str, tuple[int | None, str]]):
+        self._answers = answers
+
+    def resolve_scientific_name(self, name):
+        return self._answers.get(str(name or "").strip(), (None, "unknown"))
+
+
+def test_a_name_the_catalogue_holds_once_gains_that_identity():
+    resolver = _Resolver({"Prunella modularis": (10081, "resolved")})
+    assert resolve_audio_identity("Prunella modularis", resolver=resolver) == 10081
+
+
+def test_an_ambiguous_name_gains_nothing_rather_than_picking_one():
+    resolver = _Resolver({"Shared name": (None, "ambiguous")})
+    assert resolve_audio_identity("Shared name", resolver=resolver) is None
+
+
+def test_a_name_no_source_holds_gains_nothing():
+    """`Corvus monedula` is the real example until an alias records the split."""
+    resolver = _Resolver({})
+    assert resolve_audio_identity("Corvus monedula", resolver=resolver) is None
+
+
+def test_no_catalogue_is_not_an_error():
+    resolver = _Resolver({"Prunella modularis": (None, "unavailable")})
+    assert resolve_audio_identity("Prunella modularis", resolver=resolver) is None
+
+
+@pytest.mark.parametrize("blank", [None, "", "   "])
+def test_a_blank_name_is_never_looked_up(blank):
+    class Exploding:
+        def resolve_scientific_name(self, name):
+            raise AssertionError("should not be consulted")
+
+    assert resolve_audio_identity(blank, resolver=Exploding()) is None
+
+
+def test_a_resolver_that_fails_never_breaks_ingest():
+    """Audio ingest must not stop because the catalogue had a bad moment."""
+
+    class Broken:
+        def resolve_scientific_name(self, name):
+            raise RuntimeError("catalogue on fire")
+
+    assert resolve_audio_identity("Prunella modularis", resolver=Broken()) is None
+
+
+async def _audio_table(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE audio_detections (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TIMESTAMP NOT NULL,
+            species VARCHAR NOT NULL,
+            confidence FLOAT NOT NULL,
+            sensor_id VARCHAR,
+            raw_data TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            scientific_name VARCHAR,
+            source_event_id VARCHAR(512),
+            species_id INTEGER
+        )
+        """
+    )
+    await db.commit()
+
+
+@pytest_asyncio.fixture
+async def audio_repo():
+    async with aiosqlite.connect(":memory:") as db:
+        await _audio_table(db)
+        yield DetectionRepository(db), db
+
+
+@pytest.mark.asyncio
+async def test_the_backfill_only_touches_rows_without_an_identity(audio_repo):
+    repo, db = audio_repo
+    await db.execute(
+        "INSERT INTO audio_detections (timestamp, species, confidence, scientific_name, species_id)"
+        " VALUES ('2026-08-23 08:00:00','Dunnock',0.9,'Prunella modularis',NULL)"
+    )
+    await db.execute(
+        "INSERT INTO audio_detections (timestamp, species, confidence, scientific_name, species_id)"
+        " VALUES ('2026-08-23 08:01:00','Robin',0.9,'Erithacus rubecula',4242)"
+    )
+    await db.commit()
+
+    resolver = _Resolver({"Prunella modularis": (10081, "resolved"), "Erithacus rubecula": (9293, "resolved")})
+    summary = await repo.backfill_audio_species_ids(resolver=resolver)
+
+    assert summary["identified"] == 1
+    rows = await (await db.execute("SELECT scientific_name, species_id FROM audio_detections ORDER BY id")).fetchall()
+    assert rows[0][1] == 10081
+    assert rows[1][1] == 4242, "an identity already recorded is never rewritten"
+
+
+@pytest.mark.asyncio
+async def test_the_backfill_counts_what_it_could_not_identify(audio_repo):
+    repo, db = audio_repo
+    await db.execute(
+        "INSERT INTO audio_detections (timestamp, species, confidence, scientific_name)"
+        " VALUES ('2026-08-23 08:00:00','Jackdaw',0.9,'Corvus monedula')"
+    )
+    await db.commit()
+
+    summary = await repo.backfill_audio_species_ids(resolver=_Resolver({}))
+    assert summary["identified"] == 0
+    assert summary["unresolved"] == 1
+
+
+@pytest.mark.asyncio
+async def test_running_the_backfill_again_changes_nothing(audio_repo):
+    repo, db = audio_repo
+    await db.execute(
+        "INSERT INTO audio_detections (timestamp, species, confidence, scientific_name)"
+        " VALUES ('2026-08-23 08:00:00','Dunnock',0.9,'Prunella modularis')"
+    )
+    await db.commit()
+    resolver = _Resolver({"Prunella modularis": (10081, "resolved")})
+
+    first = await repo.backfill_audio_species_ids(resolver=resolver)
+    second = await repo.backfill_audio_species_ids(resolver=resolver)
+
+    assert first["identified"] == 1
+    assert second["identified"] == 0, "a second run has nothing left to do"
+
+
+@pytest.mark.asyncio
+async def test_two_names_for_one_bird_are_counted_once(audio_repo):
+    """The whole point: a renamed taxon must not appear twice in the counts."""
+    from datetime import datetime, timedelta
+
+    repo, db = audio_repo
+    now = datetime(2026, 8, 23, 8, 0, 0)
+    for offset, (species, sci) in enumerate([("Jackdaw", "Corvus monedula"), ("Western Jackdaw", "Coloeus monedula")]):
+        await db.execute(
+            "INSERT INTO audio_detections (timestamp, species, confidence, scientific_name, species_id)"
+            " VALUES (?,?,?,?,7056)",
+            ((now + timedelta(minutes=offset)).isoformat(sep=" "), species, 0.9, sci),
+        )
+    await db.commit()
+
+    rows = await repo.get_audio_species_counts(
+        now - timedelta(hours=1), now + timedelta(hours=1), now - timedelta(hours=2), now - timedelta(hours=1)
+    )
+    assert len(rows) == 1, f"one bird under two names must count once: {rows}"
+    assert rows[0]["window_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_audio_without_identity_groups_by_name_as_before(audio_repo):
+    from datetime import datetime, timedelta
+
+    repo, db = audio_repo
+    now = datetime(2026, 8, 23, 8, 0, 0)
+    for offset, sci in enumerate(["Prunella modularis", "Prunella modularis", "Erithacus rubecula"]):
+        await db.execute(
+            "INSERT INTO audio_detections (timestamp, species, confidence, scientific_name) VALUES (?,?,?,?)",
+            ((now + timedelta(minutes=offset)).isoformat(sep=" "), "x", 0.9, sci),
+        )
+    await db.commit()
+
+    rows = await repo.get_audio_species_counts(
+        now - timedelta(hours=1), now + timedelta(hours=1), now - timedelta(hours=2), now - timedelta(hours=1)
+    )
+    assert sorted(r["window_count"] for r in rows) == [1, 2]

--- a/backend/tests/test_detection_repository.py
+++ b/backend/tests/test_detection_repository.py
@@ -1230,7 +1230,8 @@ async def _create_audio_detections_table(db: aiosqlite.Connection) -> None:
             source_event_id TEXT UNIQUE,
             raw_data TEXT,
             scientific_name TEXT,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            species_id INTEGER
         )
     """)
 


### PR DESCRIPTION
Phase 4 of the versioned species catalogue, third slice. Audio correlation was the last read path keyed on name text.

## Why

A bird heard and a bird seen were joined by a string. BirdNET-Go reports a scientific name, and a scientific name moves.

Audio detections now record a `species_id` at ingest, resolved by the rule the detection backfill already follows: a name the catalogue holds for exactly one species gains that identity; anything ambiguous, unknown or unavailable gains nothing and behaves exactly as before. Ingest never fails because of the catalogue, since a detection without an identity is still a detection worth keeping.

## The backfill is required, not optional

Grouping by identity while older rows have none would split a species at the upgrade boundary, which is precisely the failure this phase removes. That is the same trap the daily rollup presented in the first slice, so it is handled here rather than discovered later.

It resolves each distinct name once rather than per row, never rewrites an identity already recorded, and is idempotent. A second run finds nothing to do, which is asserted.

## Measured against a live install

56,027 audio detections across 84 species, seven weeks of real data:

| | |
| --- | ---: |
| Rows identified | **55,998** |
| Rows unresolved | 28 |
| Distinct groups before | 84 |
| Distinct groups after | 84 |
| Groups merging more than one name | 0 |

A no-op on today's data, and load-bearing the first time a name drifts. Same shape as the grouping slice.

## What this does not fix, with numbers

The 28 unresolved rows are `Corvus monedula`, which IOC 14.2 calls `Coloeus monedula` after the jackdaw genus split.

That install already holds **both names for the same bird in the same table**: `Coloeus monedula` 102 rows and `Corvus monedula` 28 rows, both labelled "Eurasian Jackdaw". BirdNET-Go evidently changed its taxonomy mid-stream. The audio species list shows the jackdaw twice today.

**This change does not fix that**, and it is worth being plain about why. The catalogue holds 636 aliases and **every one of them is `unresolved`**, so nothing records that the two names are one bird. The alias machinery exists and the synonym data does not. Populating it belongs to the catalogue build rather than to a hand-written row here, because a synonym asserted by hand is exactly the kind of guess this phase was built to stop making.

So the jackdaw stays split until the crosswalk records it. The numbers are in the commit message and here so it is a measured gap rather than a surprise for whoever picks it up.

## Migration

`e2b8c47f91a3`, one nullable column and an index. Additive, so neither direction can lose a row. Verified `upgrade → downgrade → upgrade` with a single head.

## Verified

2,367 backend tests passing, 13 new, covering the resolution rule, a resolver that throws, blank names, the backfill's conservatism and idempotence, and that two names for one bird count once when the identity is known. `ruff` clean repo-wide, docs consistency passing.

## Risk

Low. One nullable column, one additional resolution at ingest that cannot fail the write, and a background backfill that only fills gaps. Counts are unchanged on real data.