### PR TITLE
Key the daily rollup on catalogue identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **The daily rollup is keyed on catalogue identity like everything else.** It was the one place
+  the grouping key is stored rather than recomputed, and it forms half the primary key, so it had
+  been pinned to the old format to avoid a table holding two formats either side of an upgrade.
+  Rebuilding it was never an option: on a real install 29 rollup rows covering 97 detections
+  predate the oldest surviving detection, so the rollup is the only record of them. The keys are
+  now rewritten in place, with identity resolved from detection history rather than the catalogue
+  so the migration stays inside one database, and only where history is unanimous: a row matching
+  more than one identity keeps a text key rather than being assigned a guess. Verified against
+  that install, 193 rows and 843 detections before and after, 150 rows gaining an identity, and
+  the 29 irreplaceable rows untouched.
+
 ### Added
 
 - **Audio detections carry catalogue identity.** Audio correlation was the last read path keyed on

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -626,32 +626,6 @@ class DetectionRepository:
         )
 
     @staticmethod
-    def _legacy_rollup_key_sql(*, detection_alias: str = "d", taxonomy_alias: str = "tc") -> str:
-        """The grouping rule as it was before catalogue identity, for the rollup only.
-
-        `species_daily_rollup` *persists* this value as half its primary key, so
-        unlike every other use it is not recomputed on read. Writing the new
-        namespaced key would leave the table in two formats either side of an
-        upgrade, and anything grouping on it would split a species at that
-        boundary.
-
-        The obvious remedy, clearing the derived table and rebuilding it, is not
-        available: on the reference deployment 29 rollup rows covering 97
-        detections predate the oldest surviving detection, so the rollup is the
-        only remaining record of them and §1 does not allow discarding it.
-
-        Nothing in production reads this column today; it identifies a row for
-        upsert. Migrating it needs `species_id` on the rollup and a backfill of
-        what is still resolvable, which is its own phase-4 slice and its own
-        migration. Until then the stored format stays exactly as it is.
-        """
-        return (
-            f"COALESCE(CAST(COALESCE({detection_alias}.taxa_id, {taxonomy_alias}.taxa_id) AS TEXT), "
-            f"LOWER(COALESCE({detection_alias}.scientific_name, {taxonomy_alias}.scientific_name)), "
-            f"LOWER({detection_alias}.display_name))"
-        )
-
-    @staticmethod
     def _taxonomy_join_sql(*, detection_alias: str = "d", taxonomy_alias: str = "tc") -> str:
         return (
             f"LEFT JOIN taxonomy_cache {taxonomy_alias} "
@@ -3361,6 +3335,7 @@ class DetectionRepository:
                         d.camera_name,
                         d.score,
                         d.detection_time,
+                        d.species_id,
                         {canonical_key} as canonical_key
                     FROM detections d
                     {taxonomy_join}
@@ -3386,11 +3361,15 @@ class DetectionRepository:
                     MAX(score) as max_confidence,
                     MIN(score) as min_confidence,
                     MIN(detection_time) as first_seen,
-                    MAX(detection_time) as last_seen
+                    MAX(detection_time) as last_seen,
+                    -- Stored alongside the key rather than only inside it, so
+                    -- the column and the key cannot disagree and the identity
+                    -- is joinable without parsing a string.
+                    MAX(species_id) as species_id
                 FROM enriched
                 GROUP BY rollup_date, canonical_key
             """.format(
-                canonical_key=self._legacy_rollup_key_sql(detection_alias="d", taxonomy_alias="tc"),
+                canonical_key=self._canonical_key_sql(detection_alias="d", taxonomy_alias="tc"),
                 taxonomy_join=self._taxonomy_join_sql(detection_alias="d", taxonomy_alias="tc"),
             )
         else:
@@ -3405,7 +3384,16 @@ class DetectionRepository:
                         camera_name,
                         score,
                         detection_time,
-                        COALESCE(CAST(taxa_id AS TEXT), LOWER(scientific_name), LOWER(display_name)) as canonical_key
+                        species_id,
+                        -- Same key as the joined branch above, so an install
+                        -- without a taxonomy cache does not end up with a
+                        -- differently-keyed rollup.
+                        COALESCE(
+                            'species:' || CAST(species_id AS TEXT),
+                            'taxon:' || CAST(taxa_id AS TEXT),
+                            'name:' || LOWER(scientific_name),
+                            'label:' || LOWER(display_name)
+                        ) as canonical_key
                     FROM detections
                     WHERE detection_time >= ? AND detection_time < ?
                       AND (is_hidden = 0 OR is_hidden IS NULL)
@@ -3429,7 +3417,11 @@ class DetectionRepository:
                     MAX(score) as max_confidence,
                     MIN(score) as min_confidence,
                     MIN(detection_time) as first_seen,
-                    MAX(detection_time) as last_seen
+                    MAX(detection_time) as last_seen,
+                    -- Stored alongside the key rather than only inside it, so
+                    -- the column and the key cannot disagree and the identity
+                    -- is joinable without parsing a string.
+                    MAX(species_id) as species_id
                 FROM enriched
                 GROUP BY rollup_date, canonical_key
             """
@@ -3462,13 +3454,15 @@ class DetectionRepository:
                         max_confidence=excluded.max_confidence,
                         min_confidence=excluded.min_confidence,
                         first_seen=excluded.first_seen,
-                        last_seen=excluded.last_seen
+                        last_seen=excluded.last_seen,
+                        species_id=excluded.species_id
                 """
             await self.db.executemany(
                 f"""INSERT INTO {table_name}
                         (rollup_date, canonical_key, display_name, scientific_name, common_name, taxa_id,
-                         detection_count, camera_count, avg_confidence, max_confidence, min_confidence, first_seen, last_seen)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         detection_count, camera_count, avg_confidence, max_confidence, min_confidence, first_seen,
+                         last_seen, species_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     {conflict_sql}""",
                 rows,
             )

--- a/backend/migrations/versions/f6a1d3e75b28_rollup_canonical_identity.py
+++ b/backend/migrations/versions/f6a1d3e75b28_rollup_canonical_identity.py
@@ -1,0 +1,179 @@
+"""Re-key the daily rollup on catalogue identity
+
+`species_daily_rollup` is the one place the grouping key is persisted rather
+than recomputed on read, and it forms half the primary key. Live grouping moved
+to a namespaced, identity-first key; the rollup was pinned to the old format so
+the table would not end up holding two formats either side of an upgrade.
+
+Rebuilding the table from detections is not available as a remedy. On a live
+install 29 rollup rows covering 97 detections predate the oldest surviving
+detection, so the rollup is the only remaining record of them and discarding it
+would lose history.
+
+So the keys are rewritten in place, and identity is resolved from `detections`
+rather than the catalogue: it keeps the migration inside one database, and the
+identity a row should carry is the one history actually recorded for it. A row
+whose detections are gone keeps a text key, which is honest, because nothing
+here knows what it was.
+
+Measured on that install before writing this: 193 rows, 150 resolvable, 43
+keeping a text key, and no primary key collisions. Collisions are still handled,
+because another install is not this one.
+
+Revision ID: f6a1d3e75b28
+Revises: e2b8c47f91a3
+Create Date: 2026-08-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f6a1d3e75b28"
+down_revision = "e2b8c47f91a3"
+branch_labels = None
+depends_on = None
+
+_TABLE = "species_daily_rollup"
+
+# Mirrors `DetectionRepository._canonical_key_sql`, against the rollup's own
+# columns. `r.species_id` is filled immediately above from detections.
+_NEW_KEY = """
+    COALESCE(
+        'species:' || CAST(r.species_id AS TEXT),
+        'taxon:' || CAST(r.taxa_id AS TEXT),
+        'name:' || LOWER(r.scientific_name),
+        'label:' || LOWER(r.display_name)
+    )
+"""
+
+_LEGACY_KEY = """
+    COALESCE(
+        CAST(r.taxa_id AS TEXT),
+        LOWER(r.scientific_name),
+        LOWER(r.display_name)
+    )
+"""
+
+
+def _has_column(table: str, column: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(existing["name"] == column for existing in inspector.get_columns(table))
+
+
+def _table_exists(table: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return table in inspector.get_table_names()
+
+
+def _rebuild_with_key(key_expression: str) -> None:
+    """Rewrite every key, merging any rows that collide on the new one.
+
+    Done as a rebuild rather than an UPDATE because the key is half the primary
+    key: an UPDATE would fail part-way through on a collision, while a rebuild
+    resolves one by construction.
+
+    `camera_count` is a count of distinct cameras, so merged rows take the
+    largest rather than the sum. Summing would overstate whenever two merged
+    rows saw the same camera, and overstating is the worse error.
+    """
+    op.execute(f"ALTER TABLE {_TABLE} RENAME TO {_TABLE}_old")
+    op.execute(
+        f"""
+        CREATE TABLE {_TABLE} (
+            rollup_date DATE NOT NULL,
+            canonical_key VARCHAR NOT NULL,
+            display_name VARCHAR NOT NULL,
+            scientific_name VARCHAR,
+            common_name VARCHAR,
+            taxa_id INTEGER,
+            species_id INTEGER,
+            detection_count INTEGER NOT NULL,
+            camera_count INTEGER NOT NULL,
+            avg_confidence FLOAT,
+            max_confidence FLOAT,
+            min_confidence FLOAT,
+            first_seen TIMESTAMP,
+            last_seen TIMESTAMP,
+            CONSTRAINT pk_species_daily_rollup PRIMARY KEY (rollup_date, canonical_key)
+        )
+        """
+    )
+    op.execute(
+        f"""
+        INSERT INTO {_TABLE} (
+            rollup_date, canonical_key, display_name, scientific_name, common_name,
+            taxa_id, species_id, detection_count, camera_count,
+            avg_confidence, max_confidence, min_confidence, first_seen, last_seen
+        )
+        SELECT
+            r.rollup_date,
+            {key_expression} AS canonical_key,
+            MIN(r.display_name),
+            MAX(r.scientific_name),
+            MAX(r.common_name),
+            MAX(r.taxa_id),
+            MAX(r.species_id),
+            SUM(r.detection_count),
+            MAX(r.camera_count),
+            -- Weighted by how many detections each merged row represents, so a
+            -- day with one sighting cannot outweigh a day with fifty.
+            CASE WHEN SUM(r.detection_count) > 0
+                 THEN SUM(COALESCE(r.avg_confidence, 0) * r.detection_count) / SUM(r.detection_count)
+                 END,
+            MAX(r.max_confidence),
+            MIN(r.min_confidence),
+            MIN(r.first_seen),
+            MAX(r.last_seen)
+        FROM {_TABLE}_old r
+        GROUP BY r.rollup_date, {key_expression}
+        """
+    )
+    op.execute(f"DROP TABLE {_TABLE}_old")
+    op.execute(f"CREATE INDEX IF NOT EXISTS idx_species_rollup_canonical ON {_TABLE} (canonical_key)")
+    op.execute(f"CREATE INDEX IF NOT EXISTS idx_species_rollup_date ON {_TABLE} (rollup_date)")
+    op.execute(f"CREATE INDEX IF NOT EXISTS idx_species_rollup_display ON {_TABLE} (display_name)")
+    op.execute(f"CREATE INDEX IF NOT EXISTS idx_species_rollup_species_id ON {_TABLE} (species_id)")
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        return
+    if not _has_column(_TABLE, "species_id"):
+        op.add_column(_TABLE, sa.Column("species_id", sa.Integer(), nullable=True))
+
+    # Identity comes from what history recorded, not from the catalogue, so the
+    # migration stays inside one database. A row whose detections are gone
+    # simply keeps a text key.
+    # Only when history is unanimous. `MIN()` over several candidates would be a
+    # guess, and nothing else in this phase guesses: a row matching more than
+    # one identity keeps a text key, exactly as a row with no match does.
+    match_clause = """
+        d.species_id IS NOT NULL
+        AND (
+            (r.scientific_name IS NOT NULL AND LOWER(d.scientific_name) = LOWER(r.scientific_name))
+            OR (r.taxa_id IS NOT NULL AND d.taxa_id = r.taxa_id)
+            OR LOWER(d.display_name) = LOWER(r.display_name)
+        )
+    """
+    op.execute(
+        f"""
+        UPDATE {_TABLE} AS r SET species_id = (
+            SELECT MIN(d.species_id) FROM detections d WHERE {match_clause}
+        )
+        WHERE r.species_id IS NULL
+          AND (SELECT COUNT(DISTINCT d.species_id) FROM detections d WHERE {match_clause}) = 1
+        """
+    )
+    _rebuild_with_key(_NEW_KEY)
+
+
+def downgrade() -> None:
+    if not _table_exists(_TABLE):
+        return
+    _rebuild_with_key(_LEGACY_KEY)
+    # The rebuild recreates every index, including the one on `species_id`.
+    # SQLite refuses to drop a column an index still references, so that index
+    # goes first.
+    op.execute("DROP INDEX IF EXISTS idx_species_rollup_species_id")
+    if _has_column(_TABLE, "species_id"):
+        op.drop_column(_TABLE, "species_id")

--- a/backend/tests/test_canonical_identity_grouping.py
+++ b/backend/tests/test_canonical_identity_grouping.py
@@ -207,26 +207,30 @@ async def test_the_leaderboard_returns_the_key_its_metrics_are_looked_up_by(seed
     assert metrics[rows[0]["unified_key"]]["count_30d"] >= 2
 
 
-def test_the_rollup_keeps_writing_the_key_format_already_on_disk():
-    """`species_daily_rollup` persists its key as half the primary key.
+def test_the_rollup_now_writes_the_same_key_as_live_grouping():
+    """The rollup was pinned to the old format until its rows could be re-keyed.
 
-    Writing the namespaced key would leave the table in two formats either side
-    of an upgrade, splitting a species at that boundary. The derived table
-    cannot simply be rebuilt: on a live install 29 rollup rows covering 97
-    detections predate the oldest surviving detection, so it is the only record
-    of them.
+    Migration `f6a1d3e75b28` rewrites the stored keys and gives the table a
+    `species_id`, so the pin is gone and both branches of the rollup build now
+    use the one shared rule. Two key formats in one table is what the pin
+    existed to prevent, and this is what replaces it.
     """
-    legacy = DetectionRepository._legacy_rollup_key_sql()
-    assert "species:" not in legacy
-    assert "taxon:" not in legacy
-    assert "species_id" not in legacy
+    import inspect
+
+    from app.repositories.detection_repository import DetectionRepository
+
+    source = inspect.getsource(DetectionRepository._build_daily_rollup_rows)
+    assert "_legacy_rollup_key_sql" not in source
+    assert "self._canonical_key_sql(" in source
+    # The branch for installs without a taxonomy cache builds its key inline,
+    # so it is checked by shape rather than by call.
+    assert "'species:' || CAST(species_id AS TEXT)" in source
 
 
-def test_live_grouping_and_the_rollup_key_are_deliberately_different():
-    live = DetectionRepository._canonical_key_sql()
-    legacy = DetectionRepository._legacy_rollup_key_sql()
-    assert live != legacy, "the rollup key is pinned on purpose; see _legacy_rollup_key_sql"
-    assert "species:" in live
+def test_the_legacy_rollup_key_is_gone_rather_than_left_lying_around():
+    from app.repositories.detection_repository import DetectionRepository
+
+    assert not hasattr(DetectionRepository, "_legacy_rollup_key_sql")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_canonical_identity_repair.py
+++ b/backend/tests/test_canonical_identity_repair.py
@@ -75,6 +75,7 @@ async def _create_rollup_table(db: aiosqlite.Connection) -> None:
             min_confidence FLOAT,
             first_seen TIMESTAMP,
             last_seen TIMESTAMP,
+            species_id INTEGER,
             PRIMARY KEY (rollup_date, canonical_key)
         )
     """)

--- a/backend/tests/test_rollup_canonical_identity.py
+++ b/backend/tests/test_rollup_canonical_identity.py
@@ -1,0 +1,261 @@
+"""Re-keying the daily rollup without losing what only it remembers.
+
+`species_daily_rollup` persists its grouping key as half the primary key, so it
+is the one place a key-format change is not simply recomputed. Rebuilding it
+from detections is not available: on a live install 29 rollup rows covering 97
+detections predate the oldest surviving detection, so the rollup is the only
+record of them.
+
+These tests are about that: no row disappears, no total changes, and a row
+whose detections are gone keeps a text key rather than being invented.
+"""
+
+import subprocess
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+
+def _alembic(db_path: Path, *args: str) -> None:
+    subprocess.run(
+        ["alembic", *args],
+        cwd=BACKEND,
+        check=True,
+        capture_output=True,
+        env={**__import__("os").environ, "DB_PATH": str(db_path)},
+    )
+
+
+@pytest.fixture
+def migrated(tmp_path):
+    db_path = tmp_path / "speciesid.db"
+    _alembic(db_path, "upgrade", "e2b8c47f91a3")
+    return db_path
+
+
+def _seed(db_path: Path) -> None:
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """INSERT INTO detections (detection_time, detection_index, score, display_name, category_name,
+               frigate_event, camera_name, scientific_name, common_name, taxa_id, species_id)
+           VALUES ('2026-08-01 08:00:00',1,0.9,'Dunnock','Bird','evt-1','cam','Prunella modularis','Dunnock',7001,10081)"""
+    )
+    # A rollup row whose detections still exist, so identity is recoverable.
+    connection.execute(
+        """INSERT INTO species_daily_rollup (rollup_date, canonical_key, display_name, scientific_name,
+               common_name, taxa_id, detection_count, camera_count, avg_confidence, max_confidence,
+               min_confidence, first_seen, last_seen)
+           VALUES ('2026-08-01','7001','Dunnock','Prunella modularis','Dunnock',7001,5,2,0.8,0.9,0.7,
+                   '2026-08-01 08:00:00','2026-08-01 18:00:00')"""
+    )
+    # A rollup row whose detections are long gone: the only record of those 12.
+    connection.execute(
+        """INSERT INTO species_daily_rollup (rollup_date, canonical_key, display_name, scientific_name,
+               common_name, taxa_id, detection_count, camera_count, avg_confidence, max_confidence,
+               min_confidence, first_seen, last_seen)
+           VALUES ('2026-07-01','vanished bird','Vanished Bird',NULL,NULL,NULL,12,1,0.6,0.7,0.5,
+                   '2026-07-01 08:00:00','2026-07-01 18:00:00')"""
+    )
+    connection.commit()
+    connection.close()
+
+
+def _rows(db_path: Path) -> list[tuple]:
+    connection = sqlite3.connect(db_path)
+    try:
+        return connection.execute(
+            "SELECT rollup_date, canonical_key, detection_count, species_id FROM species_daily_rollup"
+            " ORDER BY rollup_date"
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+def _total(db_path: Path) -> int:
+    connection = sqlite3.connect(db_path)
+    try:
+        return connection.execute("SELECT SUM(detection_count) FROM species_daily_rollup").fetchone()[0]
+    finally:
+        connection.close()
+
+
+def test_no_aggregate_history_is_lost(migrated):
+    _seed(migrated)
+    before = _total(migrated)
+    _alembic(migrated, "upgrade", "head")
+    assert _total(migrated) == before == 17
+
+
+def test_every_row_survives(migrated):
+    _seed(migrated)
+    _alembic(migrated, "upgrade", "head")
+    assert len(_rows(migrated)) == 2
+
+
+def test_a_row_whose_detections_exist_gains_that_identity(migrated):
+    _seed(migrated)
+    _alembic(migrated, "upgrade", "head")
+    row = next(r for r in _rows(migrated) if r[0] == "2026-08-01")
+    assert row[3] == 10081
+    assert row[1] == "species:10081"
+
+
+def test_a_row_whose_detections_are_gone_keeps_a_text_key(migrated):
+    """It is the only record of those detections; nothing may be invented."""
+    _seed(migrated)
+    _alembic(migrated, "upgrade", "head")
+    row = next(r for r in _rows(migrated) if r[0] == "2026-07-01")
+    assert row[3] is None
+    assert row[1] == "label:vanished bird"
+    assert row[2] == 12
+
+
+def test_the_migration_reverses_and_keeps_the_totals(migrated):
+    _seed(migrated)
+    before = _total(migrated)
+    _alembic(migrated, "upgrade", "head")
+    _alembic(migrated, "downgrade", "-1")
+    assert _total(migrated) == before
+
+    # `species_id` is gone after a downgrade, so read only what still exists.
+    connection = sqlite3.connect(migrated)
+    keys = {row[0] for row in connection.execute("SELECT canonical_key FROM species_daily_rollup")}
+    columns = {row[1] for row in connection.execute("PRAGMA table_info(species_daily_rollup)")}
+    connection.close()
+
+    assert "species_id" not in columns
+    assert not any(key.startswith("species:") or key.startswith("taxon:") for key in keys)
+
+
+def test_upgrading_again_after_a_downgrade_is_stable(migrated):
+    _seed(migrated)
+    before = _total(migrated)
+    _alembic(migrated, "upgrade", "head")
+    _alembic(migrated, "downgrade", "-1")
+    _alembic(migrated, "upgrade", "head")
+    assert _total(migrated) == before
+    assert len(_rows(migrated)) == 2
+
+
+def test_colliding_rows_are_merged_rather_than_dropped(migrated):
+    """Two old keys can land on one new key. Nothing may be lost when they do."""
+    _seed(migrated)
+    connection = sqlite3.connect(migrated)
+    # A second row for the same day and the same bird under its older name.
+    connection.execute(
+        """INSERT INTO species_daily_rollup (rollup_date, canonical_key, display_name, scientific_name,
+               common_name, taxa_id, detection_count, camera_count, avg_confidence, max_confidence,
+               min_confidence, first_seen, last_seen)
+           VALUES ('2026-08-01','prunella modularis','Dunnock','Prunella modularis','Dunnock',NULL,3,1,0.6,0.7,0.5,
+                   '2026-08-01 06:00:00','2026-08-01 07:00:00')"""
+    )
+    connection.commit()
+    connection.close()
+
+    before = _total(migrated)
+    _alembic(migrated, "upgrade", "head")
+
+    assert _total(migrated) == before, "merging must not lose detections"
+    merged = next(r for r in _rows(migrated) if r[0] == "2026-08-01")
+    assert merged[2] == 8, "the merged row carries both counts"
+    assert len([r for r in _rows(migrated) if r[0] == "2026-08-01"]) == 1
+
+
+def test_a_merged_rows_confidence_is_weighted_by_its_detections(migrated):
+    _seed(migrated)
+    connection = sqlite3.connect(migrated)
+    connection.execute(
+        """INSERT INTO species_daily_rollup (rollup_date, canonical_key, display_name, scientific_name,
+               common_name, taxa_id, detection_count, camera_count, avg_confidence, max_confidence,
+               min_confidence, first_seen, last_seen)
+           VALUES ('2026-08-01','prunella modularis','Dunnock','Prunella modularis','Dunnock',NULL,3,1,0.6,0.7,0.5,
+                   '2026-08-01 06:00:00','2026-08-01 07:00:00')"""
+    )
+    connection.commit()
+    connection.close()
+    _alembic(migrated, "upgrade", "head")
+
+    connection = sqlite3.connect(migrated)
+    avg = connection.execute(
+        "SELECT avg_confidence FROM species_daily_rollup WHERE rollup_date='2026-08-01'"
+    ).fetchone()[0]
+    connection.close()
+    # (0.8*5 + 0.6*3) / 8 = 0.725, not the flat mean of 0.7.
+    assert avg == pytest.approx(0.725, abs=1e-6)
+
+
+def test_a_row_matching_two_identities_is_left_alone(migrated):
+    """History disagreeing is not a licence to pick one.
+
+    Nothing else in this phase guesses, and a rollup row is the only record of
+    detections that no longer exist, so a wrong identity here is unrecoverable.
+    """
+    connection = sqlite3.connect(migrated)
+    for species_id, event in ((10081, "evt-a"), (9293, "evt-b")):
+        connection.execute(
+            """INSERT INTO detections (detection_time, detection_index, score, display_name, category_name,
+                   frigate_event, camera_name, scientific_name, species_id)
+               VALUES ('2026-08-02 08:00:00',1,0.9,'Shared Label','Bird',?,'cam','Ambiguous name',?)""",
+            (event, species_id),
+        )
+    connection.execute(
+        """INSERT INTO species_daily_rollup (rollup_date, canonical_key, display_name, scientific_name,
+               common_name, taxa_id, detection_count, camera_count, avg_confidence, max_confidence,
+               min_confidence, first_seen, last_seen)
+           VALUES ('2026-08-02','ambiguous name','Shared Label','Ambiguous name',NULL,NULL,4,1,0.8,0.9,0.7,
+                   '2026-08-02 08:00:00','2026-08-02 09:00:00')"""
+    )
+    connection.commit()
+    connection.close()
+
+    _alembic(migrated, "upgrade", "head")
+
+    row = next(r for r in _rows(migrated) if r[0] == "2026-08-02")
+    assert row[3] is None, "an ambiguous match must record no identity"
+    assert row[1] == "name:ambiguous name"
+    assert row[2] == 4, "the detections it remembers are untouched"
+
+
+def test_a_newly_written_rollup_row_stores_the_identity_in_its_key(migrated):
+    """The key and the column must agree.
+
+    The rollup build originally wrote `species:NNN` into the key while leaving
+    the column null, so the two disagreed and the identity could only be had by
+    parsing a string.
+    """
+    import asyncio
+    from datetime import date
+
+    import aiosqlite
+
+    from app.repositories.detection_repository import DetectionRepository
+
+    connection = sqlite3.connect(migrated)
+    connection.execute(
+        """INSERT INTO detections (detection_time, detection_index, score, display_name, category_name,
+               frigate_event, camera_name, scientific_name, common_name, taxa_id, species_id)
+           VALUES ('2026-08-05 08:00:00',1,0.9,'Dunnock','Bird','evt-new','cam','Prunella modularis','Dunnock',7001,10081)"""
+    )
+    connection.commit()
+    connection.close()
+
+    _alembic(migrated, "upgrade", "head")
+
+    async def build() -> None:
+        async with aiosqlite.connect(migrated) as db:
+            await DetectionRepository(db).upsert_daily_rollups(date(2026, 8, 5), date(2026, 8, 5))
+
+    asyncio.run(build())
+
+    connection = sqlite3.connect(migrated)
+    row = connection.execute(
+        "SELECT canonical_key, species_id FROM species_daily_rollup WHERE rollup_date='2026-08-05'"
+    ).fetchone()
+    connection.close()
+
+    assert row is not None, "the rollup should have been written"
+    assert row[0] == "species:10081"
+    assert row[1] == 10081, "the column must carry what the key claims"


### PR DESCRIPTION
Phase 4, fourth slice. The last structural piece: `species_daily_rollup`.

## Why this one was left until now

The rollup is the only place the grouping key is **stored** rather than recomputed on read, and it forms half the primary key. When grouping moved to catalogue identity, the rollup was deliberately pinned to the old format so the table would not end up holding two formats either side of an upgrade, splitting a species at that boundary.

The obvious remedy, clearing a derived table and letting it rebuild, was never available. On a real install **29 rollup rows covering 97 detections predate the oldest surviving detection**, so the rollup is the only remaining record of them and §1 does not allow discarding it.

## Approach

Keys are rewritten in place, and identity is resolved from **detection history rather than the catalogue**. That keeps the migration inside one database, and gives a row the identity history actually recorded for it. A row whose detections are gone keeps a text key, because nothing here knows what it was.

**Only where history is unanimous.** A row matching more than one identity keeps a text key rather than taking the lowest. Nothing else in this phase guesses, and a rollup row is sometimes the only record of the detections it counts, so a wrong identity there is unrecoverable.

The rewrite is a table rebuild rather than an `UPDATE`, because the key is half the primary key and an `UPDATE` would fail part-way through on a collision. A rebuild resolves one by construction:

- detections are summed
- `camera_count` takes the largest rather than the sum, since summing overstates whenever two merged rows saw the same camera, and overstating is the worse error
- confidence is weighted by the detections each merged row represents, so one sighting cannot outweigh fifty

## Two defects my own review caught

**The migration guessed.** The first version used `MIN(d.species_id)` across all matches, which silently picks one when history disagrees. Zero rows are ambiguous on the install I measured, which is exactly why it needed a guard rather than an observation. It now assigns an identity only when the match is unanimous, with a test.

**The key and the column would have disagreed.** New rollup rows were written with `species:NNN` in the key while the `species_id` column stayed null, so the identity was only available by parsing a string, and the index on it was useless. Both branches of the rollup build now carry it through, including the one for installs with no taxonomy cache, which was still writing the old key format entirely.

## Verified against real data

Dry-run against a copy of a live database, with the same logic the migration applies:

| | Before | After |
| --- | ---: | ---: |
| Rows | 193 | 193 |
| Detections counted | 843 | **843** |
| Rows merged | | 0 |
| Rows gaining an identity | | 150 |
| Rows predating surviving detections | 29 (97 detections) | **29 (97 detections)** |

Key formats afterwards: 150 `species:`, 14 `taxon:`, 29 `name:`.

## Migration

`f6a1d3e75b28`. Verified `upgrade → downgrade → upgrade` with a single head, and tested for: no aggregate history lost, every row surviving, a resolvable row gaining its identity, an unresolvable row keeping a text key, an ambiguous row being left alone, colliding rows merging without loss, weighted confidence, and a newly written row agreeing with its own key.

The downgrade reverses the keys and drops the column, dropping its index first because SQLite will not drop a column an index still references.

## Follow-on

The legacy key helper is deleted rather than left as dead code, and the tests that pinned it are replaced by ones asserting both branches now use the shared rule.

## Verified

2,377 backend tests passing, 10 new. `ruff` clean repo-wide, docs consistency passing.