### PR TITLE
Record every model output, including the ones nothing identified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **Every model output is now recorded, including the ones nothing could identify.** An output whose
+  species could not be resolved was skipped entirely, so for 707 of a 10,000-class model's outputs
+  the catalogue held nothing at all, not even the label the model uses. That is what kept
+  `labels.txt` load-bearing at runtime. Those rows now exist, carrying the label and an explicit
+  `unknown` class. Coverage counts identified outputs rather than rows, so a model is not called
+  complete merely because every index has a row: the reported figures are unchanged, except that
+  two models drop by one apiece where an output explicitly declared `unknown` had been counted as
+  mapped. An unknown output also reads as an unresolved gap rather than a non-species class, since
+  "we cannot identify this" and "this is not a species" are different claims.
+
 ### Fixed
 
 - **A bird that has been renamed no longer counts twice.** The catalogue takes bird names from the

--- a/backend/app/services/species_catalog_resolver.py
+++ b/backend/app/services/species_catalog_resolver.py
@@ -154,10 +154,16 @@ class SpeciesCatalogResolver:
             return ShadowResolution(verdict="unregistered")
 
         entry = self._outputs.get(checksum, {}).get(output_index)
-        if entry is None:
+        # An index the catalogue cannot identify now carries a row holding the
+        # model's own label, so the label text does not depend on `labels.txt`.
+        # That row says `unknown`, which means exactly what an absent row meant:
+        # nothing here knows what this output is. Reporting it as `non_species`
+        # would claim knowledge that it is not a species, which is a different
+        # and unearned statement.
+        if entry is None or entry.class_kind == "unknown":
             return ShadowResolution(
                 verdict="unresolved_index",
-                model_artifact_id=artifact_row_id,
+                model_artifact_id=(entry.artifact_row_id if entry is not None else artifact_row_id),
                 model_output_index=output_index,
             )
 

--- a/backend/app/services/species_catalog_status.py
+++ b/backend/app/services/species_catalog_status.py
@@ -124,8 +124,13 @@ class SpeciesCatalogStatus:
 
             artifacts: list[dict[str, Any]] = []
             for row in connection.execute(
+                # Counts identified outputs, not rows. Every output index now
+                # has a row, including ones nothing could resolve, so counting
+                # rows would report a model as fully mapped while hundreds of
+                # its outputs still had no identity.
                 "SELECT a.registry_id, a.model_sha256, a.output_width,"
-                " (SELECT COUNT(*) FROM model_output_taxa t WHERE t.model_artifact_id = a.id) AS mapped"
+                " (SELECT COUNT(*) FROM model_output_taxa t"
+                "  WHERE t.model_artifact_id = a.id AND t.class_kind != 'unknown') AS mapped"
                 " FROM model_artifacts a ORDER BY a.registry_id"
             ):
                 unresolved = int(row["output_width"]) - int(row["mapped"])
@@ -165,7 +170,8 @@ class SpeciesCatalogStatus:
         try:
             row = connection.execute(
                 "SELECT a.id, a.registry_id, a.output_width, a.mapping_set_sha256,"
-                " (SELECT COUNT(*) FROM model_output_taxa t WHERE t.model_artifact_id = a.id) AS mapped"
+                " (SELECT COUNT(*) FROM model_output_taxa t"
+                "  WHERE t.model_artifact_id = a.id AND t.class_kind != 'unknown') AS mapped"
                 " FROM model_artifacts a WHERE a.model_sha256 = ?",
                 (checksum,),
             ).fetchone()
@@ -183,6 +189,8 @@ class SpeciesCatalogStatus:
             "registry_id": row["registry_id"],
             "output_width": int(row["output_width"]),
             "mapped_outputs": int(row["mapped"]),
+            # Same rule as the artifact listing: an `unknown` output is not
+            # mapped, whether it is present as a row or absent entirely.
             "unresolved_outputs": int(row["output_width"]) - int(row["mapped"]),
             "mapping_set_sha256": row["mapping_set_sha256"],
         }

--- a/backend/scripts/build_species_catalog_seed.py
+++ b/backend/scripts/build_species_catalog_seed.py
@@ -257,9 +257,21 @@ def build(
                 artifact_row_id = cursor.lastrowid
                 for row in entry["outputs"]:
                     if "unresolved" in row:
-                        # An unresolved species class stays a visible gap; the
-                        # artifact is not activatable from the catalogue until
-                        # it is resolved or explicitly declared.
+                        # An output nothing could resolve still gets a row, so
+                        # the catalogue knows what the model calls it even when
+                        # it cannot say what it is. Without that the label text
+                        # existed only in `labels.txt`, which is what stopped
+                        # that file being retired.
+                        #
+                        # It is recorded as `unknown`, and coverage counts
+                        # identified outputs rather than rows, so the artifact
+                        # stays incomplete and unactivatable exactly as before.
+                        connection.execute(
+                            "INSERT INTO model_output_taxa"
+                            " (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                            " VALUES (?, ?, 'unknown', NULL, ?)",
+                            (artifact_row_id, row["index"], row["label"]),
+                        )
                         continue
                     species_id = None
                     if row["kind"] == "species":

--- a/backend/tests/test_model_mapping_completeness.py
+++ b/backend/tests/test_model_mapping_completeness.py
@@ -1,0 +1,141 @@
+"""Every model output has a row, and coverage stays honest about it.
+
+Retiring `labels.txt` needs the catalogue to know what every output index is
+called. It did not: an output whose species could not be resolved was skipped
+entirely, so for 707 of a 10,000-class model's outputs the catalogue held
+nothing at all, not even the label text.
+
+Those rows now exist, carrying their label and an explicit `unknown` class.
+
+The trap is that coverage counted rows. Simply adding rows would have taken
+every model to "complete" and flipped its activation verdict to `ready` while
+707 outputs still had no identity. Coverage therefore counts *identified*
+outputs, so the reported numbers do not move: what changes is that the
+catalogue can now name an output it cannot identify.
+"""
+
+import sqlite3
+
+import pytest
+
+from app.services.species_catalog_status import SpeciesCatalogStatus
+
+
+@pytest.fixture
+def catalogue(tmp_path):
+    path = tmp_path / "species_catalog.db"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE alembic_version (version_num TEXT);
+        CREATE TABLE catalogue_releases (id INTEGER PRIMARY KEY, schema_version INTEGER,
+            source_manifest TEXT, content_sha256 TEXT, generated_at TEXT, state TEXT);
+        CREATE TABLE species (species_id INTEGER PRIMARY KEY, rank TEXT, status TEXT,
+            accepted_species_id INTEGER);
+        CREATE TABLE model_artifacts (id INTEGER PRIMARY KEY, registry_id TEXT, model_sha256 TEXT,
+            mapping_set_sha256 TEXT, output_width INTEGER, runtime TEXT, model_version TEXT, state TEXT);
+        CREATE TABLE model_output_taxa (model_artifact_id INTEGER, output_index INTEGER,
+            class_kind TEXT, species_id INTEGER, source_label TEXT,
+            PRIMARY KEY (model_artifact_id, output_index));
+        INSERT INTO catalogue_releases VALUES (1, 1, '{}', 'abc', '2026-08-23T00:00:00Z', 'active');
+        INSERT INTO species VALUES (1,'species','accepted',NULL);
+        INSERT INTO model_artifacts VALUES (1,'test_model','sha-1',NULL,4,'onnx',NULL,'installed');
+        """
+    )
+    # Four outputs: two identified, one an explicit background class, one unknown.
+    connection.executemany(
+        "INSERT INTO model_output_taxa VALUES (?,?,?,?,?)",
+        [
+            (1, 0, "species", 1, "Prunella modularis"),
+            (1, 1, "species", 1, "Erithacus rubecula"),
+            (1, 2, "background", None, "background"),
+            (1, 3, "unknown", None, "Some label nothing resolved"),
+        ],
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def test_an_output_the_catalogue_cannot_identify_still_has_its_label(catalogue):
+    connection = sqlite3.connect(catalogue)
+    label = connection.execute("SELECT source_label FROM model_output_taxa WHERE output_index = 3").fetchone()[0]
+    connection.close()
+    assert label == "Some label nothing resolved"
+
+
+def test_coverage_counts_identified_outputs_rather_than_rows(catalogue):
+    """Four rows, but one is `unknown`, so three are actually mapped."""
+    status = SpeciesCatalogStatus(catalogue).status()
+    artifact = status["artifacts"][0]
+    assert artifact["output_width"] == 4
+    assert artifact["mapped_outputs"] == 3
+    assert artifact["unresolved_outputs"] == 1
+
+
+def test_a_model_with_an_unknown_output_is_not_called_complete(catalogue):
+    """Rows for every index must not be mistaken for an identity for every index."""
+    status = SpeciesCatalogStatus(catalogue).status()
+    assert status["artifacts"][0]["complete"] is False
+
+
+def test_a_model_with_every_output_identified_is_complete(catalogue):
+    connection = sqlite3.connect(catalogue)
+    connection.execute("UPDATE model_output_taxa SET class_kind='background' WHERE output_index=3")
+    connection.commit()
+    connection.close()
+
+    status = SpeciesCatalogStatus(catalogue).status()
+    artifact = status["artifacts"][0]
+    assert artifact["mapped_outputs"] == 4
+    assert artifact["unresolved_outputs"] == 0
+    assert artifact["complete"] is True
+
+
+def test_a_missing_row_still_counts_as_unresolved(catalogue):
+    """Absence and `unknown` must both be honest, not only one of them."""
+    connection = sqlite3.connect(catalogue)
+    connection.execute("DELETE FROM model_output_taxa WHERE output_index = 3")
+    connection.commit()
+    connection.close()
+
+    artifact = SpeciesCatalogStatus(catalogue).status()["artifacts"][0]
+    assert artifact["unresolved_outputs"] == 1
+    assert artifact["complete"] is False
+
+
+def test_an_unknown_output_reads_as_a_gap_rather_than_a_non_species_class(tmp_path):
+    """`unknown` and `background` are different claims and must not merge.
+
+    Every output index now has a row, so an index the catalogue cannot identify
+    is present rather than absent. Reporting it as `non_species` would assert
+    that it is known not to be a species, which is a stronger statement than
+    the catalogue can make.
+    """
+    from app.services.species_catalog_resolver import SpeciesCatalogResolver
+
+    path = tmp_path / "species_catalog.db"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE species (species_id INTEGER PRIMARY KEY, rank TEXT, status TEXT, accepted_species_id INTEGER);
+        CREATE TABLE species_concepts (species_id INTEGER, provider TEXT, provider_taxon_id TEXT,
+            source_release TEXT, scientific_name TEXT, authorship TEXT, accepted_name_usage TEXT, status TEXT);
+        CREATE TABLE species_aliases (alias TEXT, alias_kind TEXT, species_id INTEGER, resolution TEXT,
+            source TEXT, confidence REAL);
+        CREATE TABLE model_artifacts (id INTEGER PRIMARY KEY, registry_id TEXT, model_sha256 TEXT,
+            mapping_set_sha256 TEXT, output_width INTEGER, runtime TEXT, model_version TEXT, state TEXT);
+        CREATE TABLE model_output_taxa (model_artifact_id INTEGER, output_index INTEGER, class_kind TEXT,
+            species_id INTEGER, source_label TEXT, PRIMARY KEY (model_artifact_id, output_index));
+        INSERT INTO model_artifacts VALUES (1,'m','bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',NULL,2,'onnx',NULL,'installed');
+        INSERT INTO model_output_taxa VALUES (1,0,'background',NULL,'background');
+        INSERT INTO model_output_taxa VALUES (1,1,'unknown',NULL,'Some label');
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    sha = "b" * 64
+    resolver = SpeciesCatalogResolver(path)
+    assert resolver.shadow_resolve(sha, 0, None).verdict == "non_species"
+    assert resolver.shadow_resolve(sha, 1, "Some label").verdict == "unresolved_index"

--- a/backend/tests/test_model_output_mappings.py
+++ b/backend/tests/test_model_output_mappings.py
@@ -310,11 +310,24 @@ class TestSeedIntegration:
         rows = _query(built, "SELECT class_kind, species_id FROM model_output_taxa WHERE output_index = 1")
         assert rows == [("background", None)]
 
-    def test_an_unresolved_class_is_a_visible_gap_not_a_row(self, built):
+    def test_an_unresolved_class_is_a_row_that_says_it_is_unknown(self, built):
+        """A gap used to be an absent row, which lost the label with it.
+
+        Every output index now has a row, so the catalogue holds what the model
+        calls an output even when it cannot say what it is. The gap is still a
+        gap: the row says `unknown` and coverage counts identity, not rows.
+        """
         indices = {row[0] for row in _query(built, "SELECT output_index FROM model_output_taxa")}
-        assert indices == {0, 1, 3}
         width = _query(built, "SELECT output_width FROM model_artifacts")[0][0]
-        assert len(indices) < width
+        assert indices == set(range(width)), "every output index is present"
+
+        unknown = _query(
+            built,
+            "SELECT output_index, species_id, source_label FROM model_output_taxa WHERE class_kind = 'unknown'",
+        )
+        assert [row[0] for row in unknown] == [2]
+        assert unknown[0][1] is None, "an unknown output claims no identity"
+        assert unknown[0][2], "but it keeps the label the model uses"
 
     def test_a_mapping_that_references_an_unknown_concept_refuses_the_build(self, tmp_path):
         mappings = _mappings_json(tmp_path, taxon_override="Nonexistus maximus")
@@ -358,7 +371,8 @@ class TestImporterCarry:
 
         assert result.status == "already_imported" or result.status == "imported"
         assert _query(live, "SELECT COUNT(*) FROM model_artifacts")[0][0] == 1
-        assert _query(live, "SELECT COUNT(*) FROM model_output_taxa")[0][0] == 3
+        # One row per output index, so the unresolved index counts too.
+        assert _query(live, "SELECT COUNT(*) FROM model_output_taxa")[0][0] == 4
 
 
 ASSETS = Path(__file__).resolve().parents[1] / "app" / "assets"
@@ -417,7 +431,8 @@ def test_the_committed_assets_build_a_fully_mapped_catalogue(tmp_path):
     seed_builder.build(reference, output, col_concepts_path=col, model_mappings_path=mappings)
 
     assert _query(output, "SELECT COUNT(*) FROM model_artifacts")[0][0] == 10
-    assert _query(output, "SELECT COUNT(*) FROM model_output_taxa")[0][0] == 32312
+    # One row per output index across every artifact, unresolved ones included.
+    assert _query(output, "SELECT COUNT(*) FROM model_output_taxa")[0][0] == 34746
     orphans = _query(
         output,
         "SELECT COUNT(*) FROM model_output_taxa t WHERE t.species_id IS NOT NULL"

--- a/backend/tests/test_species_catalog_resolver.py
+++ b/backend/tests/test_species_catalog_resolver.py
@@ -37,7 +37,7 @@ MODEL_SHA = "d" * 64
 @pytest.fixture
 def catalog(tmp_path):
     """A catalogue mapping one artifact: blue tit, a synonym-resolved toad,
-    an unknown class, and one unresolved index."""
+    a genuine non-species class, and one unresolved index."""
     ioc_pinned = hashlib.sha256(b"resolver ioc").hexdigest()
     col_pinned = hashlib.sha256(b"resolver col").hexdigest()
 
@@ -133,7 +133,7 @@ def catalog(tmp_path):
                                 "provider": "catalogue-of-life",
                                 "taxon": "A1",
                             },
-                            {"index": 2, "kind": "unknown", "label": "Unknown"},
+                            {"index": 2, "kind": "background", "label": "background"},
                             {
                                 "index": 3,
                                 "kind": "species",

--- a/backend/tests/test_species_catalog_status.py
+++ b/backend/tests/test_species_catalog_status.py
@@ -137,8 +137,11 @@ def test_status_reports_the_active_release_and_coverage(catalog):
     assert len(artifacts) == 1
     assert artifacts[0]["registry_id"] == "status_model"
     assert artifacts[0]["output_width"] == 4
-    assert artifacts[0]["mapped_outputs"] == 3
-    assert artifacts[0]["unresolved_outputs"] == 1
+    # Two of the four outputs are identified. Index 2 is declared `unknown`
+    # and index 3 resolved to nothing, and neither is a mapping: coverage
+    # counts identity rather than the presence of a row.
+    assert artifacts[0]["mapped_outputs"] == 2
+    assert artifacts[0]["unresolved_outputs"] == 2
     assert artifacts[0]["complete"] is False
 
 
@@ -152,11 +155,14 @@ class TestActivationCheck:
     def test_a_registered_complete_artifact_is_ready(self, catalog):
         connection = sqlite3.connect(catalog)
         try:
-            # Complete the mapping so the artifact has one row per index.
+            # Give every output an identity. A row alone is no longer enough:
+            # index 2 is declared `unknown` and index 3 resolved to nothing, so
+            # both have to become something the catalogue can name before the
+            # artifact is complete.
             connection.execute(
-                "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
-                " VALUES (1, 3, 'species', 2, 'Mystery bird')"
+                "UPDATE model_output_taxa SET class_kind='background', source_label='background' WHERE output_index = 2"
             )
+            connection.execute("UPDATE model_output_taxa SET class_kind='species', species_id=2 WHERE output_index = 3")
             connection.commit()
         finally:
             connection.close()
@@ -170,7 +176,8 @@ class TestActivationCheck:
         check = SpeciesCatalogStatus(catalog).activation_check("s" * 64, tensor_width=4)
 
         assert check["verdict"] == "incomplete_mapping"
-        assert check["unresolved_outputs"] == 1
+        # Index 2 is declared `unknown` and index 3 resolved to nothing.
+        assert check["unresolved_outputs"] == 2
 
     def test_a_tensor_width_mismatch_fails_the_check(self, catalog):
         check = SpeciesCatalogStatus(catalog).activation_check("s" * 64, tensor_width=1486)


### PR DESCRIPTION
Phase 5's first slice, and the prerequisite for the rest of it.

## Why

Retiring `labels.txt` needs the catalogue to know what every output index is called. It did not. An output whose species could not be resolved was **skipped entirely**, so for 707 of a 10,000-class model's outputs the catalogue held nothing at all, not even the label text. Measured across the installed models:

| Model | Width | Rows before |
| --- | ---: | ---: |
| `rope_vit_b14_inat21` | 10,000 | 9,293 |
| `mobilenet_v2_birds` | 965 | 863 |
| `medium_birds/na` | 555 | 493 |

Those rows now exist, carrying the model's own label and an explicit `unknown` class. Every artifact has one row per output index.

## The trap, which is most of the work

**Coverage counted rows.** Adding rows alone would have taken every model to `complete: true` and flipped its activation verdict from `incomplete_mapping` to `ready`, while hundreds of outputs still had no identity. Phase 2 explicitly says that check must stay advisory until label-file authority retires, so this would have quietly undone that.

Coverage now counts **identified** outputs. The reported figures therefore do not move:

```
convnext_large_inat21: 9293 -> 9293
eva02_large_inat21:    9293 -> 9293
```

Two models drop by exactly one, where an output **explicitly declared** `unknown` had been counted as mapped:

```
eu_medium_focalnet_b:  683 -> 682
flexivit_il_all:       535 -> 534
```

That was an overstatement, and correcting it is deliberate.

## A second consequence the review caught

Once the row existed, the resolver reported an unidentified output as **`non_species`** rather than `unresolved_index`. Those are different claims: one says nothing here knows what this output is, the other asserts it is known not to be a species. The existing test even called an output seeded as `unknown` "a non-species class", which is the same conflation written down.

The resolver now treats `unknown` as an unresolved gap, the fixture seeds a genuine `background` class so the `non_species` branch is still covered, and a new test holds the two apart.

## What this does not do

It does not retire `labels.txt`. The classifier still reads it for grouped labels and display, and moving those is the next slice. This removes the reason it could not be done.

## Verified

2,389 backend tests passing, 6 new. Every artifact rebuilt with `rows == output_width`, identified counts unchanged. `ruff` clean repo-wide, docs consistency passing. The seed is generated at image build, so no binary is committed.

## Risk

Reporting only. Coverage numbers are the same or one lower where they were overstated, no model becomes activatable that was not before, and no identity is claimed that was not already held.