### PR TITLE
Give an existing install the model output rows it was missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **An existing install now gets the model output rows it was missing.** An artifact's mapping
+  digest is computed over the whole source mapping, including outputs nothing could resolve, while
+  the rows actually stored were a filtered subset of it. A live catalogue could therefore hold
+  9,293 rows for a 10,000-output model under a digest asserting the mapping was complete, and the
+  importer skipped the artifact because the digests matched. Recording every output reached fresh
+  installs only. A matching digest means the source mapping is identical, so a row the catalogue
+  lacks is absent rather than different: those rows are now added, including when the release
+  itself is already held, because completing a mapping is a repair rather than an import. A row
+  that would *change* is still refused, since that is a correction and needs its own supersession
+  policy. On a live catalogue this added 2,434 rows across ten artifacts, left every existing row
+  untouched, and left coverage reporting unchanged.
+
 ### Changed
 
 - **Every model output is now recorded, including the ones nothing could identify.** An output whose

--- a/backend/app/services/species_catalog_importer.py
+++ b/backend/app/services/species_catalog_importer.py
@@ -171,6 +171,79 @@ def _map_species(live: sqlite3.Connection, bundle: _Bundle) -> tuple[dict[int, i
     return id_map, added, matched
 
 
+def complete_artifact_mapping(live: sqlite3.Connection, *, artifact_row_id: int, bundle_rows) -> int:
+    """Add output rows the live catalogue lacks, and change none that it has.
+
+    Only called when the bundle's `mapping_set_sha256` matches the registered
+    artifact's, which means the source mapping is identical. A row the live
+    catalogue does not hold is therefore absent rather than different, and
+    adding it claims no identity that the mapping did not already carry.
+
+    The digest is computed over the whole source mapping, including outputs
+    nothing could resolve, while the stored rows were once a filtered subset of
+    it. That is why a live catalogue can hold fewer rows than its own digest
+    describes, and why this exists.
+
+    A row that would *change* is refused. That is a mapping correction, and it
+    needs an explicit supersession policy rather than arriving quietly here.
+    """
+    # Read by position so this does not depend on the caller's row factory.
+    existing = {
+        int(index): (str(kind), species_id, str(label))
+        for index, kind, species_id, label in live.execute(
+            "SELECT output_index, class_kind, species_id, source_label FROM model_output_taxa"
+            " WHERE model_artifact_id = ?",
+            (artifact_row_id,),
+        )
+    }
+
+    added = 0
+    for row in bundle_rows:
+        index = int(row["output_index"])
+        incoming = (str(row["class_kind"]), row["species_id"], str(row["source_label"]))
+        held = existing.get(index)
+        if held is not None:
+            if held != incoming:
+                raise CatalogImportError(
+                    f"Bundle mapping for output {index} differs from the one already recorded"
+                    f" for this artifact; refusing to rewrite it"
+                )
+            continue
+        live.execute(
+            "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (artifact_row_id, index, row["class_kind"], row["species_id"], row["source_label"]),
+        )
+        added += 1
+    return added
+
+
+def _complete_registered_mappings(live: sqlite3.Connection, bundle: "_Bundle") -> int:
+    """Add absent output rows for every artifact already registered here.
+
+    Only artifacts whose `mapping_set_sha256` matches are touched: a differing
+    digest is a mapping change, which `import_release` refuses outright.
+    """
+    added = 0
+    for artifact in bundle.model_artifacts:
+        row = live.execute(
+            "SELECT id, mapping_set_sha256 FROM model_artifacts WHERE model_sha256 = ?",
+            (artifact["model_sha256"],),
+        ).fetchone()
+        if row is None or row["mapping_set_sha256"] != artifact["mapping_set_sha256"]:
+            continue
+        added += complete_artifact_mapping(
+            live,
+            artifact_row_id=int(row["id"]),
+            bundle_rows=[
+                output
+                for output in bundle.model_outputs
+                if str(output["artifact_sha256"]) == str(artifact["model_sha256"])
+            ],
+        )
+    return added
+
+
 def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> ImportResult:
     bundle = _read_bundle(Path(bundle_path))
     path = Path(catalog_path or default_catalog_path())
@@ -192,8 +265,22 @@ def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> Im
                 (bundle.release["content_sha256"],),
             ).fetchone()
             if existing:
-                live.execute("ROLLBACK")
-                log.info("Catalogue release already imported", release_id=existing["id"])
+                # The release is already held, but its artifacts may still be
+                # missing output rows: the stored mapping was once a filtered
+                # subset of the mapping its own digest describes. Completing
+                # that is a repair rather than an import, so it happens here
+                # too, adding only rows that are absent.
+                repaired = _complete_registered_mappings(live, bundle)
+                if repaired:
+                    live.execute("COMMIT")
+                    log.info(
+                        "Completed mappings on an already-imported release",
+                        release_id=existing["id"],
+                        outputs_added=repaired,
+                    )
+                else:
+                    live.execute("ROLLBACK")
+                    log.info("Catalogue release already imported", release_id=existing["id"])
                 return ImportResult(status="already_imported", release_id=existing["id"])
 
             cursor = live.execute(
@@ -278,6 +365,7 @@ def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> Im
             outputs_by_artifact: dict[str, list[sqlite3.Row]] = {}
             for output in bundle.model_outputs:
                 outputs_by_artifact.setdefault(output["artifact_sha256"], []).append(output)
+            outputs_added = 0
             for artifact in bundle.model_artifacts:
                 existing_artifact = live.execute(
                     "SELECT id, mapping_set_sha256 FROM model_artifacts WHERE model_sha256 = ?",
@@ -295,6 +383,19 @@ def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> Im
                             "Bundle carries a different mapping set for already-registered artifact "
                             f"{artifact['model_sha256']}; refusing the release"
                         )
+                    # Same mapping set, so any row the live catalogue lacks is
+                    # absent rather than different. It can hold fewer rows than
+                    # its own digest describes, because outputs nothing could
+                    # resolve were counted in the digest but not stored.
+                    outputs_added += complete_artifact_mapping(
+                        live,
+                        artifact_row_id=int(existing_artifact["id"]),
+                        bundle_rows=[
+                            output
+                            for output in bundle.model_outputs
+                            if str(output["artifact_sha256"]) == str(artifact["model_sha256"])
+                        ],
+                    )
                     continue
                 cursor = live.execute(
                     "INSERT INTO model_artifacts"
@@ -348,6 +449,7 @@ def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> Im
         species_added=added,
         species_matched=matched,
         names_added=names_added,
+        outputs_added=outputs_added,
     )
     return ImportResult(
         status="imported",

--- a/backend/tests/test_mapping_supersession.py
+++ b/backend/tests/test_mapping_supersession.py
@@ -1,0 +1,121 @@
+"""Completing a registered artifact's mapping without rewriting it.
+
+An artifact's `mapping_set_sha256` is computed over the whole source mapping,
+including outputs nothing could resolve. The stored rows were a filtered subset
+of that, so the digest never described what was actually stored.
+
+That only mattered once the unresolved outputs started being recorded. An
+existing install then held 9,293 rows for a 10,000-output model under a digest
+asserting the mapping was identical to a bundle carrying all 10,000, and the
+importer skipped the artifact because the digests matched. The completeness
+work reached fresh installs only.
+
+A matching digest means the source mapping is the same, so a row the live
+catalogue lacks is absent rather than different, and adding it changes no
+identity. A row that would *change* is still refused: that is a mapping
+correction and needs its own supersession policy, not this.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app.services.species_catalog_importer import CatalogImportError, complete_artifact_mapping
+
+
+@pytest.fixture
+def live(tmp_path) -> Path:
+    path = tmp_path / "species_catalog.db"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE model_artifacts (id INTEGER PRIMARY KEY, registry_id TEXT, model_sha256 TEXT,
+            mapping_set_sha256 TEXT, output_width INTEGER, runtime TEXT, model_version TEXT, state TEXT);
+        CREATE TABLE model_output_taxa (model_artifact_id INTEGER, output_index INTEGER, class_kind TEXT,
+            species_id INTEGER, source_label TEXT, PRIMARY KEY (model_artifact_id, output_index));
+        INSERT INTO model_artifacts VALUES (1,'m','sha-model','sha-mapping',3,'onnx',NULL,'installed');
+        INSERT INTO model_output_taxa VALUES (1,0,'species',10,'Prunella modularis');
+        INSERT INTO model_output_taxa VALUES (1,1,'species',20,'Erithacus rubecula');
+        """
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def _bundle_rows():
+    return [
+        {"output_index": 0, "class_kind": "species", "species_id": 10, "source_label": "Prunella modularis"},
+        {"output_index": 1, "class_kind": "species", "species_id": 20, "source_label": "Erithacus rubecula"},
+        {"output_index": 2, "class_kind": "unknown", "species_id": None, "source_label": "Nothing resolved this"},
+    ]
+
+
+def _rows(path: Path):
+    connection = sqlite3.connect(path)
+    try:
+        return connection.execute(
+            "SELECT output_index, class_kind, species_id, source_label FROM model_output_taxa ORDER BY output_index"
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+def test_a_missing_output_row_is_added(live):
+    connection = sqlite3.connect(live)
+    added = complete_artifact_mapping(connection, artifact_row_id=1, bundle_rows=_bundle_rows())
+    connection.commit()
+    connection.close()
+
+    assert added == 1
+    rows = _rows(live)
+    assert len(rows) == 3
+    assert rows[2] == (2, "unknown", None, "Nothing resolved this")
+
+
+def test_rows_already_present_are_left_exactly_as_they_are(live):
+    connection = sqlite3.connect(live)
+    complete_artifact_mapping(connection, artifact_row_id=1, bundle_rows=_bundle_rows())
+    connection.commit()
+    connection.close()
+
+    rows = _rows(live)
+    assert rows[0] == (0, "species", 10, "Prunella modularis")
+    assert rows[1] == (1, "species", 20, "Erithacus rubecula")
+
+
+def test_nothing_to_add_is_not_an_error(live):
+    connection = sqlite3.connect(live)
+    complete_artifact_mapping(connection, artifact_row_id=1, bundle_rows=_bundle_rows())
+    added_again = complete_artifact_mapping(connection, artifact_row_id=1, bundle_rows=_bundle_rows())
+    connection.commit()
+    connection.close()
+    assert added_again == 0
+
+
+def test_a_row_that_would_change_an_identity_is_refused(live):
+    """A correction is not a completion, and must not arrive through this door."""
+    rows = _bundle_rows()
+    rows[0] = {"output_index": 0, "class_kind": "species", "species_id": 999, "source_label": "Prunella modularis"}
+
+    connection = sqlite3.connect(live)
+    try:
+        with pytest.raises(CatalogImportError, match="differs"):
+            complete_artifact_mapping(connection, artifact_row_id=1, bundle_rows=rows)
+    finally:
+        connection.close()
+
+    assert _rows(live)[0] == (0, "species", 10, "Prunella modularis"), "the live row is untouched"
+
+
+def test_a_changed_label_is_also_refused(live):
+    rows = _bundle_rows()
+    rows[1] = {"output_index": 1, "class_kind": "species", "species_id": 20, "source_label": "Something else"}
+
+    connection = sqlite3.connect(live)
+    try:
+        with pytest.raises(CatalogImportError, match="differs"):
+            complete_artifact_mapping(connection, artifact_row_id=1, bundle_rows=rows)
+    finally:
+        connection.close()


### PR DESCRIPTION
Follow-up to #276, which recorded every model output but only reached fresh installs.

## The defect

An artifact's `mapping_set_sha256` is computed over the **whole source mapping**, including outputs nothing could resolve. The rows actually stored were a filtered subset of it. So the digest never described what was stored.

That was harmless until the unresolved outputs started being recorded. A live catalogue then held **9,293 rows for a 10,000-output model** under a digest asserting the mapping was identical to a bundle carrying all 10,000. The importer compares digests, saw a match, and skipped the artifact.

I only found this because the next slice depends on it: I went to check whether the catalogue could reproduce the label files, and it could not, because the rows were still missing on the live install. #276 had verified `mapped_outputs` after deploy, which is computed from a query I had changed in the same PR, so the numbers moved for a different reason and looked right.

## The fix

A matching digest means the source mapping is the same, so a row the live catalogue lacks is **absent rather than different**, and adding it claims no identity the mapping did not already carry. Those rows are added.

It also had to run when the release itself is already held. Completing a mapping is a repair, not an import, and the early return for a known release skipped it entirely.

**A row that would change is refused.** That is a mapping correction, and it needs an explicit supersession policy rather than arriving quietly through this door. Both the identity and the label are compared.

## Verified against a copy of the live catalogue

| | Before | After |
| --- | ---: | ---: |
| `convnext_large_inat21` | 9,293 / 10,000 | **10,000 / 10,000** |
| `eu_medium_focalnet_b` | 683 / 707 | **707 / 707** |
| `flexivit_il_all` | 535 / 550 | **550 / 550** |

2,434 rows added across ten artifacts, and every existing row untouched.

**Coverage reporting is unchanged**, which is the property that matters: identified stays 9,293 / 682 / 534 and `complete` stays `false`, because coverage counts identity rather than rows. No model became activatable.

And the payoff for the next slice:

```
=== catalogue now reproduces labels.txt exactly? ===
   identical: 10 | differing: 0
```

`labels.txt` is no longer load-bearing. Moving the classifier off it is the next change; this is what makes that possible.

## Verified

2,394 backend tests passing, 5 new covering the additive rule, idempotence, and the refusal to rewrite either an identity or a label. `ruff` clean repo-wide, docs consistency passing.

## Risk

Additive only, and guarded. Rows are inserted only where absent and only when the mapping digest matches; anything else is refused. Coverage and activation verdicts are unaffected.