### PR TITLE
Stop joining the taxonomy cache to filter by species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Filtering the events list by species is no longer dominated by a taxonomy join.** A user
+  reported the species filter being noticeably slower than the date and camera filters. The join
+  onto `taxonomy_cache` was the cause: its conditions are ORs across different columns wrapped in
+  `LOWER(...)`, a shape no index can serve, so the whole cache was scanned once per detection row
+  and the join forced a `DISTINCT` over every selected column on top. The join only ever resolved a
+  detection whose own scientific name is absent, through its display name, and the alias resolver
+  already produces those names. Measured on a 96,118 row database across five species, total time
+  falls from 541ms to 310ms and the worst case from 247ms to 63ms; two already-fast lookups get
+  slower by roughly 15ms, because resolving the identity up front costs more than the join saved
+  where the join was cheap. The join is kept for a `taxa_id` filter, which still reads the cached
+  taxon id for a detection that has none of its own. Result sets are unchanged, checked across all
+  85 names the data holds.
+
+
 - **An existing install now gets the model output rows it was missing.** An artifact's mapping
   digest is computed over the whole source mapping, including outputs nothing could resolve, while
   the rows actually stored were a filtered subset of it. A live catalogue could therefore hold

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -736,19 +736,17 @@ class DetectionRepository:
         detection_alias: str,
         species_name: str,
     ) -> tuple[str, str, list]:
-        has_taxonomy_cache = await self._table_exists("taxonomy_cache")
+        # No join. Its only job was to reach a detection whose own scientific
+        # name is absent, through its display name, to the species searched
+        # for, and the alias resolver already produces those names. The join
+        # cost a scan of the whole taxonomy cache per detection row, because
+        # its conditions are ORs across different columns wrapped in LOWER(),
+        # which no index can serve.
         join_sql = ""
-        if has_taxonomy_cache:
-            join_sql = (
-                " LEFT JOIN taxonomy_cache tc_filter"
-                f" ON (({detection_alias}.scientific_name IS NOT NULL AND LOWER(tc_filter.scientific_name) = LOWER({detection_alias}.scientific_name))"
-                f" OR ({detection_alias}.scientific_name IS NULL AND (LOWER(tc_filter.scientific_name) = LOWER({detection_alias}.display_name)"
-                f" OR LOWER(tc_filter.common_name) = LOWER({detection_alias}.display_name))))"
-            )
         condition, params = await self._build_canonical_species_condition(
             detection_alias=detection_alias,
             species_name=species_name,
-            has_taxonomy_cache=has_taxonomy_cache,
+            has_taxonomy_cache=False,
         )
 
         # Grouping keys on catalogue identity, so filtering has to follow it or
@@ -1736,7 +1734,12 @@ class DetectionRepository:
         frigate_event: str | None = None,
     ) -> list[Detection]:
         has_taxonomy_cache = await self._table_exists("taxonomy_cache")
-        needs_taxonomy_cache = bool(has_taxonomy_cache and (species or species_any or taxa_id is not None))
+        # The join is kept only for a `taxa_id` filter, which still reads the
+        # cached taxon id for a detection that has none of its own. Species
+        # filtering no longer needs it: the alias resolver supplies the names
+        # the join used to reach, and the join cost a scan of the whole
+        # taxonomy cache per detection row plus a DISTINCT over every column.
+        needs_taxonomy_cache = bool(has_taxonomy_cache and taxa_id is not None)
         query = (
             """
             SELECT """
@@ -1771,7 +1774,7 @@ class DetectionRepository:
             species_condition, species_params = await self._build_canonical_species_condition(
                 detection_alias="d",
                 species_name=species,
-                has_taxonomy_cache=needs_taxonomy_cache,
+                has_taxonomy_cache=False,
             )
             conditions.append(species_condition)
             params.extend(species_params)
@@ -1782,7 +1785,7 @@ class DetectionRepository:
                 clause, clause_params = await self._build_canonical_species_condition(
                     detection_alias="d",
                     species_name=species_name,
-                    has_taxonomy_cache=needs_taxonomy_cache,
+                    has_taxonomy_cache=False,
                 )
                 any_clauses.append(clause)
                 any_params.extend(clause_params)
@@ -1839,7 +1842,12 @@ class DetectionRepository:
     ) -> int:
         """Get total count of detections, optionally filtered."""
         has_taxonomy_cache = await self._table_exists("taxonomy_cache")
-        needs_taxonomy_cache = bool(has_taxonomy_cache and (species or species_any or taxa_id is not None))
+        # The join is kept only for a `taxa_id` filter, which still reads the
+        # cached taxon id for a detection that has none of its own. Species
+        # filtering no longer needs it: the alias resolver supplies the names
+        # the join used to reach, and the join cost a scan of the whole
+        # taxonomy cache per detection row plus a DISTINCT over every column.
+        needs_taxonomy_cache = bool(has_taxonomy_cache and taxa_id is not None)
         query = f"""
             SELECT {"COUNT(DISTINCT d.id)" if needs_taxonomy_cache else "COUNT(*)"}
             FROM detections d
@@ -1869,7 +1877,7 @@ class DetectionRepository:
             species_condition, species_params = await self._build_canonical_species_condition(
                 detection_alias="d",
                 species_name=species,
-                has_taxonomy_cache=needs_taxonomy_cache,
+                has_taxonomy_cache=False,
             )
             conditions.append(species_condition)
             params.extend(species_params)
@@ -1880,7 +1888,7 @@ class DetectionRepository:
                 clause, clause_params = await self._build_canonical_species_condition(
                     detection_alias="d",
                     species_name=species_name,
-                    has_taxonomy_cache=needs_taxonomy_cache,
+                    has_taxonomy_cache=False,
                 )
                 any_clauses.append(clause)
                 any_params.extend(clause_params)

--- a/backend/tests/test_species_filter_no_join.py
+++ b/backend/tests/test_species_filter_no_join.py
@@ -1,0 +1,57 @@
+"""Filtering by species without joining the taxonomy cache.
+
+A user reported the species filter being noticeably slower than the date and
+camera filters. The cause is the join onto `taxonomy_cache`, whose conditions
+are a set of ORs across different columns wrapped in `LOWER(...)`. SQLite will
+not use an index for that shape, so it scanned all 172 cached rows for each of
+96,118 detections, and the join forced a `DISTINCT` over every selected column
+on top.
+
+The join only ever did one thing: resolve a detection whose own scientific name
+is absent, through its display name, to the species being searched for. The
+alias resolver already produces those names, so the same rows can be found from
+the detection's own columns.
+
+Measured on that database, same instrument, median of five warmed runs:
+24.0ms with the join against 6.1ms without, and the plan changes from a scan
+plus a temporary B-tree to a multi-index OR.
+
+Equivalence was checked across all 85 names the data holds, scientific names,
+display names and hidden labels alike: the two forms return identical rows.
+"""
+
+import inspect
+
+from app.repositories.detection_repository import DetectionRepository
+
+
+def test_the_species_filter_no_longer_joins_the_taxonomy_cache():
+    source = inspect.getsource(DetectionRepository._canonical_species_query_parts)
+    assert "tc_filter" not in source, "the species filter must not join taxonomy_cache"
+    assert "has_taxonomy_cache=False" in source
+
+
+def test_the_events_list_joins_only_for_a_taxon_id_filter():
+    """The join survives for `taxa_id`, which still reads the cached taxon id.
+
+    A detection with no taxon id of its own is found by that filter through the
+    cache, and there is no resolver step for it the way there is for names. The
+    species filter is what stops needing it, and with it the `DISTINCT` that the
+    join made necessary.
+    """
+    source = inspect.getsource(DetectionRepository.get_all)
+    assert "needs_taxonomy_cache = bool(has_taxonomy_cache and taxa_id is not None)" in source
+    assert "species or species_any" not in source.split("needs_taxonomy_cache =")[1][:200]
+
+
+def test_a_species_filter_asks_for_no_join_in_either_read_path():
+    for method in (DetectionRepository.get_all, DetectionRepository.get_count):
+        source = inspect.getsource(method)
+        assert "has_taxonomy_cache=needs_taxonomy_cache" not in source
+        assert "has_taxonomy_cache=False" in source
+
+
+def test_the_alias_resolver_is_still_what_supplies_the_names():
+    """The names the join used to reach are resolved up front instead."""
+    source = inspect.getsource(DetectionRepository._build_canonical_species_condition)
+    assert "resolve_species_aliases" in source


### PR DESCRIPTION
Addresses #258 properly. The indexes in #262 recovered my own regression; this removes the cause.

## The cause

The join onto `taxonomy_cache` has conditions that are ORs across different columns wrapped in `LOWER(...)`. SQLite will not use an index for that shape, so it scanned all 172 cached rows for each of 96,118 detections, and the join forced a `DISTINCT` over every selected column on top.

```
plan, WITH join:            plan, without:
  SCAN d USING INDEX          MULTI-INDEX OR
  SCAN tc LEFT-JOIN             SEARCH d USING idx_detections_lower_scientific
  USE TEMP B-TREE FOR DISTINCT  SEARCH d USING idx_detections_lower_display
                                SEARCH d USING idx_detections_species_id
```

The join only ever did one thing: resolve a detection whose own scientific name is absent, through its display name, to the species being searched for. The alias resolver already produces those names.

## Equivalence, proven before changing anything

Across **all 85 names the data holds** — scientific names, display names and hidden labels — the joined form and the exact condition this emits return **identical rows**. Then, running the real repository code old against new on the same 96,118 row database: **identical result sets**.

## Honest numbers

Real `get_all` calls, median of three warmed runs:

| Species | Before | After |
| --- | ---: | ---: |
| Columba palumbus | 246.7ms | **62.9ms** |
| Turdus merula | 134.2ms | **76.7ms** |
| Prunella modularis | 91.1ms | 78.6ms |
| Erithacus rubecula | 57.4ms | **75.7ms** |
| Unknown Bird | 12.0ms | **15.9ms** |
| **Total** | **541.4ms** | **309.6ms** |

Net 1.7x, worst case 3.9x better. **Two already-fast lookups get about 15ms slower**, because resolving the identity up front costs more than the join saved where the join was cheap. That is the trade, and I would rather state it than average it away.

The win beyond the median is consistency: the spread was 12ms to 247ms and is now 16ms to 79ms. And the filter no longer scales with the size of the taxonomy cache, which the scan did.

Worth noting these figures are far above the raw-SQL measurements because `get_all` selects every column and builds `Detection` objects. That construction, not the join, is now the dominant cost, so this is unlikely to be the last word on #258.

## What is kept

The join survives for a **`taxa_id` filter**, which still reads the cached taxon id for a detection that has none of its own and has no resolver step of its own. Removing it there would have silently narrowed that filter.

## Correcting myself

I previously said the species filter looked "nearly flat with row count", from 19.5ms on 748 rows against 23ms on 96,000. That comparison was invalid: the two were measured with different instruments. Re-measured like for like, same connection, warmed, median of five, the join costs 24.0ms against 6.1ms without it at 96k rows.

## Verified

2,398 backend tests passing, 4 new. `ruff` clean repo-wide, docs consistency passing.