### PR TITLE
Read a model's labels from the catalogue, not its label file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **A model's labels are read from the catalogue rather than its label file.** `labels.txt` is
+  verified when a model is downloaded and never again, so every inference since has trusted
+  whatever is on disk. The catalogue holds a row per output index carrying the same label,
+  compiled from a file that was proven at install time, so that is where the labels now come from.
+  It is used only when the catalogue holds a complete, contiguous set matching the model's declared
+  output width: a short mapping would truncate a model's classes and a gap would shift every label
+  after it onto the wrong class, so both are refused and the file is read instead. A model the
+  catalogue does not know, or a catalogue that is absent or unreadable, behaves exactly as before.
+  Verified against a live install: the catalogue reproduces all ten installed label files byte for
+  byte, 34,746 labels in total.
+
 ### Fixed
 
 - **Filtering the events list by species is no longer dominated by a taxonomy join.** A user

--- a/backend/app/services/catalogue_labels.py
+++ b/backend/app/services/catalogue_labels.py
@@ -1,0 +1,118 @@
+"""A model's labels, read from the catalogue rather than its label file.
+
+`labels.txt` is verified when a model is downloaded and never again, and every
+inference since has trusted whatever is on disk. The catalogue holds a row per
+output index carrying the model's own label, compiled from a file that was
+proven at install time, so the labels can come from there instead.
+
+Deliberately conservative. Labels are taken from the catalogue only when it
+holds a complete, contiguous set matching the model's declared output width.
+Anything short of that returns nothing and the caller keeps reading the file, so
+a model the catalogue does not know behaves exactly as it does today.
+
+The two failure modes this refuses are the ones that would be silent: a short
+mapping would truncate a model's classes, and a gap in the indices would shift
+every label after it onto the wrong class.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def published_model_sha256(model_id: str, region: Optional[str] = None) -> Optional[str]:
+    """The checksum the registry publishes for a model's weights.
+
+    Mirrors `label_integrity.published_labels_sha256`: region variants carry no
+    id of their own, hanging off a parent under `region_variants`, so the caller
+    has to say which one it means.
+    """
+    from app.services.model_manager import REMOTE_REGISTRY
+
+    wanted = str(model_id or "").strip()
+    if not wanted:
+        return None
+    region_key = str(region or "").strip().lower() or None
+
+    def checksum(entry: object) -> Optional[str]:
+        if not isinstance(entry, dict):
+            return None
+        value = str(entry.get("sha256") or "").strip().lower()
+        return value or None
+
+    for spec in REMOTE_REGISTRY:
+        if not isinstance(spec, dict):
+            continue
+        if str(spec.get("id") or "") == wanted:
+            if region_key:
+                return checksum((spec.get("region_variants") or {}).get(region_key))
+            return checksum(spec)
+        for variant in spec.get("variants", []) or []:
+            if isinstance(variant, dict) and str(variant.get("id") or "") == wanted:
+                return checksum(variant)
+    return None
+
+
+def catalogue_labels_for_model(
+    model_sha256: Optional[str],
+    *,
+    catalog_path: Optional[Path] = None,
+) -> Optional[list[str]]:
+    """Labels in output order, or None to fall back to the label file.
+
+    Never raises: a catalogue that is absent, unreadable or incomplete simply
+    yields nothing, and the caller reads the file as it always has.
+    """
+    checksum = str(model_sha256 or "").strip().lower()
+    if not checksum:
+        return None
+
+    if catalog_path is None:
+        from app.services.species_catalog_store import default_catalog_path
+
+        catalog_path = default_catalog_path()
+
+    try:
+        connection = sqlite3.connect(f"file:{Path(catalog_path)}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return None
+
+    try:
+        artifact = connection.execute(
+            "SELECT id, output_width FROM model_artifacts WHERE LOWER(model_sha256) = ?",
+            (checksum,),
+        ).fetchone()
+        if artifact is None:
+            return None
+        artifact_id, output_width = int(artifact[0]), int(artifact[1] or 0)
+        if output_width <= 0:
+            return None
+
+        rows = connection.execute(
+            "SELECT output_index, source_label FROM model_output_taxa"
+            " WHERE model_artifact_id = ? ORDER BY output_index",
+            (artifact_id,),
+        ).fetchall()
+    except sqlite3.Error as error:
+        log.debug("Species catalogue unreadable for labels", error=str(error))
+        return None
+    finally:
+        connection.close()
+
+    if len(rows) != output_width:
+        return None
+    labels: list[str] = []
+    for expected_index, (index, label) in enumerate(rows):
+        if int(index) != expected_index:
+            return None
+        text = str(label or "").strip()
+        if not text:
+            return None
+        labels.append(text)
+    return labels

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -675,6 +675,56 @@ def _build_classification_results(
     ]
 
 
+def _resolve_model_labels(
+    labels_path: str,
+    label_grouping: dict,
+    *,
+    model_sha256: Optional[str] = None,
+    context: str = "model",
+) -> tuple[list[str], list[str], str]:
+    """Labels and their grouping, preferring the catalogue over the label file.
+
+    `labels.txt` is verified when a model is downloaded and never again, so every
+    inference since has trusted whatever is on disk. The catalogue holds the same
+    labels compiled from a file that was proven at install time.
+
+    The catalogue is used only when it holds a complete, contiguous set matching
+    the model's declared output width; anything short of that falls back to the
+    file, so a model it does not know behaves exactly as it does today.
+
+    Returns the labels, the grouped labels, and which source supplied them.
+    """
+    labels: list[str] = []
+    source = "none"
+
+    if model_sha256:
+        try:
+            from app.services.catalogue_labels import catalogue_labels_for_model
+
+            from_catalogue = catalogue_labels_for_model(model_sha256)
+        except Exception as error:  # pragma: no cover - defensive
+            log.debug("Catalogue labels unavailable", context=context, error=str(error))
+            from_catalogue = None
+        if from_catalogue:
+            labels = normalize_classifier_labels(from_catalogue)
+            source = "catalogue"
+
+    if not labels and os.path.exists(labels_path):
+        try:
+            with open(labels_path, "r", encoding="utf-8", errors="replace") as handle:
+                labels = normalize_classifier_labels(line.strip() for line in handle.readlines() if line.strip())
+            source = "label_file"
+        except Exception as error:
+            log.error("Failed to load labels", context=context, error=str(error))
+            return [], [], "none"
+
+    grouped: list[str] = []
+    strategy = str((label_grouping or {}).get("strategy") or "").strip()
+    if strategy and labels:
+        grouped = build_grouped_classifier_labels(labels, strategy=strategy)
+    return labels, grouped, source
+
+
 def _resolve_grouped_labels(
     labels: list[str],
     *,
@@ -1702,12 +1752,16 @@ class ModelInstance:
         labels_path: str,
         preprocessing: Optional[dict] = None,
         label_grouping: Optional[dict] = None,
+        model_sha256: Optional[str] = None,
     ):
         self.name = name
         self.model_path = model_path
         self.labels_path = labels_path
         self.preprocessing = preprocessing or {}
         self.label_grouping = dict(label_grouping or {})
+        # None means "read the label file", which is what every caller that has
+        # not been given a checksum should keep doing.
+        self.model_sha256 = model_sha256
         self.interpreter = None
         self.labels: list[str] = []
         self.grouped_labels: list[str] = []
@@ -1723,19 +1777,14 @@ class ModelInstance:
             if self.loaded:
                 return True
 
-            # Load labels first
-            if os.path.exists(self.labels_path):
-                try:
-                    with open(self.labels_path, "r", encoding="utf-8", errors="replace") as f:
-                        self.labels = normalize_classifier_labels(
-                            line.strip() for line in f.readlines() if line.strip()
-                        )
-                    strategy = str(self.label_grouping.get("strategy") or "").strip()
-                    if strategy:
-                        self.grouped_labels = build_grouped_classifier_labels(self.labels, strategy=strategy)
-                    log.info(f"Loaded {len(self.labels)} labels for {self.name}")
-                except Exception as e:
-                    log.error(f"Failed to load labels for {self.name}", error=str(e))
+            self.labels, self.grouped_labels, label_source = _resolve_model_labels(
+                self.labels_path,
+                self.label_grouping,
+                model_sha256=self.model_sha256,
+                context=self.name,
+            )
+            if self.labels:
+                log.info(f"Loaded {len(self.labels)} labels for {self.name}", label_source=label_source)
 
             if not os.path.exists(self.model_path):
                 self.error = f"Model file not found: {self.model_path}"
@@ -1997,12 +2046,16 @@ class ONNXModelInstance:
         label_grouping: Optional[dict] = None,
         input_size: int = 384,
         ort_providers: Optional[list[str]] = None,
+        model_sha256: Optional[str] = None,
     ):
         self.name = name
         self.model_path = model_path
         self.labels_path = labels_path
         self.preprocessing = preprocessing or {}
         self.label_grouping = dict(label_grouping or {})
+        # None means "read the label file", which is what any caller without a
+        # checksum should keep doing.
+        self.model_sha256 = model_sha256
         self.input_size = input_size
         self.ort_providers = list(ort_providers or ["CPUExecutionProvider"])
         self.session = None
@@ -2026,17 +2079,14 @@ class ONNXModelInstance:
             log.error("ONNX Runtime not installed")
             return False
 
-        # Load labels first
-        if os.path.exists(self.labels_path):
-            try:
-                with open(self.labels_path, "r", encoding="utf-8", errors="replace") as f:
-                    self.labels = normalize_classifier_labels(line.strip() for line in f.readlines() if line.strip())
-                strategy = str(self.label_grouping.get("strategy") or "").strip()
-                if strategy:
-                    self.grouped_labels = build_grouped_classifier_labels(self.labels, strategy=strategy)
-                log.info(f"Loaded {len(self.labels)} labels for ONNX model {self.name}")
-            except Exception as e:
-                log.error(f"Failed to load labels for {self.name}", error=str(e))
+        self.labels, self.grouped_labels, label_source = _resolve_model_labels(
+            self.labels_path,
+            self.label_grouping,
+            model_sha256=self.model_sha256,
+            context=self.name,
+        )
+        if self.labels:
+            log.info(f"Loaded {len(self.labels)} labels for ONNX model {self.name}", label_source=label_source)
 
         if not os.path.exists(self.model_path):
             self.error = f"ONNX model file not found: {self.model_path}"
@@ -2225,12 +2275,16 @@ class OpenVINOModelInstance:
         input_size: int = 384,
         device_name: str = "CPU",
         startup_self_test_enabled: bool | None = None,
+        model_sha256: Optional[str] = None,
     ):
         self.name = name
         self.model_path = model_path
         self.labels_path = labels_path
         self.preprocessing = preprocessing or {}
         self.label_grouping = dict(label_grouping or {})
+        # None means "read the label file", which is what any caller without a
+        # checksum should keep doing.
+        self.model_sha256 = model_sha256
         self.input_size = input_size
         self.device_name = device_name
         self._startup_self_test_enabled = (
@@ -2337,16 +2391,14 @@ class OpenVINOModelInstance:
             log.error("OpenVINO runtime not installed")
             return False
 
-        if os.path.exists(self.labels_path):
-            try:
-                with open(self.labels_path, "r", encoding="utf-8", errors="replace") as f:
-                    self.labels = normalize_classifier_labels(line.strip() for line in f.readlines() if line.strip())
-                strategy = str(self.label_grouping.get("strategy") or "").strip()
-                if strategy:
-                    self.grouped_labels = build_grouped_classifier_labels(self.labels, strategy=strategy)
-                log.info(f"Loaded {len(self.labels)} labels for OpenVINO model {self.name}")
-            except Exception as e:
-                log.error(f"Failed to load labels for {self.name}", error=str(e))
+        self.labels, self.grouped_labels, label_source = _resolve_model_labels(
+            self.labels_path,
+            self.label_grouping,
+            model_sha256=self.model_sha256,
+            context=self.name,
+        )
+        if self.labels:
+            log.info(f"Loaded {len(self.labels)} labels for OpenVINO model {self.name}", label_source=label_source)
 
         if not os.path.exists(self.model_path):
             self.error = f"ONNX model file not found: {self.model_path}"
@@ -2747,6 +2799,7 @@ class ClassifierService:
         return model_path, labels_path
 
     def _resolve_active_bird_model_spec(self) -> dict[str, Any]:
+        from app.services.catalogue_labels import published_model_sha256
         from app.services.model_manager import model_manager
 
         spec = dict(model_manager.get_active_model_spec() or {})
@@ -2773,6 +2826,10 @@ class ClassifierService:
 
         return {
             "model_id": model_id,
+            # The registry's published checksum for these weights, which is what
+            # the catalogue keys its output mapping on. Resolved here so the
+            # loaders can ask the catalogue for labels instead of the file.
+            "model_sha256": published_model_sha256(model_id, region=spec.get("resolved_region")),
             "model_path": model_path,
             "labels_path": labels_path,
             "input_size": input_size,
@@ -3646,6 +3703,10 @@ class ClassifierService:
         spec = self._resolve_active_bird_model_spec()
         model_path = str(spec["model_path"])
         labels_path = str(spec["labels_path"])
+        # Lets the loaders take labels from the catalogue, which compiled them
+        # from a label file proven at install time, rather than from whatever is
+        # on disk now. Absent or unrecognised, they read the file as before.
+        model_sha256 = spec.get("model_sha256")
         input_size = int(spec["input_size"])
         preprocessing = spec.get("preprocessing")
         runtime = str(spec["runtime"])
@@ -3745,6 +3806,7 @@ class ClassifierService:
                     input_size=input_size,
                     device_name=openvino_device,
                     startup_self_test_enabled=not self._worker_process_mode,
+                    model_sha256=model_sha256,
                 )
                 if bird_model.load():
                     if (

--- a/backend/tests/test_catalogue_labels.py
+++ b/backend/tests/test_catalogue_labels.py
@@ -1,0 +1,166 @@
+"""Reading a model's labels from the catalogue instead of its label file.
+
+`labels.txt` is verified when a model is downloaded and never again, and every
+inference since has trusted it. The catalogue now holds a row per output index
+carrying the model's own label, taken from a file that was proven at install
+time, so the labels can come from there instead.
+
+Verified before writing this: on a live install the catalogue reproduces all ten
+installed label files byte for byte.
+
+It is deliberately conservative. Labels come from the catalogue only when it
+holds a complete, contiguous set matching the model's declared output width, and
+anything short of that falls back to the file, so a model the catalogue does not
+know behaves exactly as it does today.
+"""
+
+import sqlite3
+
+import pytest
+
+from app.services.catalogue_labels import catalogue_labels_for_model, published_model_sha256
+
+
+@pytest.fixture
+def catalogue(tmp_path):
+    path = tmp_path / "species_catalog.db"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE model_artifacts (id INTEGER PRIMARY KEY, registry_id TEXT, model_sha256 TEXT,
+            mapping_set_sha256 TEXT, output_width INTEGER, runtime TEXT, model_version TEXT, state TEXT);
+        CREATE TABLE model_output_taxa (model_artifact_id INTEGER, output_index INTEGER, class_kind TEXT,
+            species_id INTEGER, source_label TEXT, PRIMARY KEY (model_artifact_id, output_index));
+        INSERT INTO model_artifacts VALUES (1,'complete','sha-complete',NULL,3,'onnx',NULL,'installed');
+        INSERT INTO model_output_taxa VALUES (1,0,'species',1,'Prunella modularis');
+        INSERT INTO model_output_taxa VALUES (1,1,'species',2,'Erithacus rubecula');
+        INSERT INTO model_output_taxa VALUES (1,2,'unknown',NULL,'Nothing resolved this');
+        INSERT INTO model_artifacts VALUES (2,'short','sha-short',NULL,4,'onnx',NULL,'installed');
+        INSERT INTO model_output_taxa VALUES (2,0,'species',1,'One');
+        INSERT INTO model_output_taxa VALUES (2,1,'species',2,'Two');
+        INSERT INTO model_artifacts VALUES (3,'gappy','sha-gappy',NULL,3,'onnx',NULL,'installed');
+        INSERT INTO model_output_taxa VALUES (3,0,'species',1,'Zero');
+        INSERT INTO model_output_taxa VALUES (3,2,'species',2,'Two');
+        """
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def test_labels_come_back_in_output_order(catalogue):
+    assert catalogue_labels_for_model("sha-complete", catalog_path=catalogue) == [
+        "Prunella modularis",
+        "Erithacus rubecula",
+        "Nothing resolved this",
+    ]
+
+
+def test_an_output_with_no_identity_still_contributes_its_label(catalogue):
+    """The label is what inference needs; the identity is a separate question."""
+    labels = catalogue_labels_for_model("sha-complete", catalog_path=catalogue)
+    assert labels[2] == "Nothing resolved this"
+
+
+def test_a_short_mapping_is_refused_so_the_file_is_used(catalogue):
+    """Fewer rows than the model's width would silently truncate its classes."""
+    assert catalogue_labels_for_model("sha-short", catalog_path=catalogue) is None
+
+
+def test_a_gap_in_the_indices_is_refused(catalogue):
+    """A missing index would shift every label after it onto the wrong class."""
+    assert catalogue_labels_for_model("sha-gappy", catalog_path=catalogue) is None
+
+
+def test_an_unregistered_model_is_refused(catalogue):
+    assert catalogue_labels_for_model("sha-nobody-knows", catalog_path=catalogue) is None
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_no_checksum_is_refused(catalogue, value):
+    assert catalogue_labels_for_model(value, catalog_path=catalogue) is None
+
+
+def test_a_missing_catalogue_never_raises(tmp_path):
+    assert catalogue_labels_for_model("sha-complete", catalog_path=tmp_path / "absent.db") is None
+
+
+def test_the_registry_checksum_is_resolved_for_a_plain_model():
+    assert published_model_sha256("rope_vit_b14_inat21")
+
+
+def test_the_registry_checksum_is_resolved_for_a_region_variant():
+    """A variant hangs off its parent and has no id of its own."""
+    eu = published_model_sha256("small_birds", region="eu")
+    na = published_model_sha256("small_birds", region="na")
+    assert eu and na and eu != na
+
+
+def test_an_unknown_model_has_no_registry_checksum():
+    assert published_model_sha256("not_a_model") is None
+
+
+def test_the_loader_prefers_the_catalogue_and_says_which_source_it_used(monkeypatch, tmp_path):
+    """The label file stays as the fallback, not the default."""
+    from app.services import classifier_service as module
+
+    labels_file = tmp_path / "labels.txt"
+    labels_file.write_text("From the file\nSecond\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        module, "catalogue_labels_for_model", lambda _sha: ["From the catalogue", "Second"], raising=False
+    )
+    monkeypatch.setattr(
+        "app.services.catalogue_labels.catalogue_labels_for_model",
+        lambda _sha: ["From the catalogue", "Second"],
+    )
+
+    labels, _grouped, source = module._resolve_model_labels(
+        str(labels_file), {}, model_sha256="sha-known", context="test"
+    )
+    assert source == "catalogue"
+    assert labels[0] == "From the catalogue"
+
+
+def test_the_loader_falls_back_to_the_file_when_the_catalogue_declines(monkeypatch, tmp_path):
+    from app.services import classifier_service as module
+
+    labels_file = tmp_path / "labels.txt"
+    labels_file.write_text("From the file\n", encoding="utf-8")
+    monkeypatch.setattr("app.services.catalogue_labels.catalogue_labels_for_model", lambda _sha: None)
+
+    labels, _grouped, source = module._resolve_model_labels(
+        str(labels_file), {}, model_sha256="sha-unknown", context="test"
+    )
+    assert source == "label_file"
+    assert labels == ["From the file"]
+
+
+def test_a_loader_with_no_checksum_reads_the_file(tmp_path):
+    """Every caller that has not been given a checksum behaves as before."""
+    from app.services import classifier_service as module
+
+    labels_file = tmp_path / "labels.txt"
+    labels_file.write_text("From the file\n", encoding="utf-8")
+
+    labels, _grouped, source = module._resolve_model_labels(str(labels_file), {}, context="test")
+    assert source == "label_file"
+    assert labels == ["From the file"]
+
+
+def test_a_catalogue_that_raises_never_stops_a_model_loading(monkeypatch, tmp_path):
+    from app.services import classifier_service as module
+
+    labels_file = tmp_path / "labels.txt"
+    labels_file.write_text("From the file\n", encoding="utf-8")
+
+    def explode(_sha):
+        raise RuntimeError("catalogue on fire")
+
+    monkeypatch.setattr("app.services.catalogue_labels.catalogue_labels_for_model", explode)
+
+    labels, _grouped, source = module._resolve_model_labels(
+        str(labels_file), {}, model_sha256="sha-known", context="test"
+    )
+    assert source == "label_file"
+    assert labels == ["From the file"]


### PR DESCRIPTION
Phase 5. `labels.txt` stops being what inference trusts.

## Why

`labels.txt` is verified when a model is downloaded and never again. Every inference since has trusted whatever is on disk, and a file altered afterwards is read as authoritative with its names written into detection history.

The catalogue holds a row per output index carrying the same label, compiled from a file that **was** proven at install time. That is a better source, and it only became possible once every output had a row (#276) and existing installs actually received them (#278).

## Proven before writing the wiring

Against the live install, the catalogue reproduces **all ten installed label files byte for byte**:

```
convnext_large_inat21      10000 labels  IDENTICAL to the file
rope_vit_b14_inat21        10000 labels  IDENTICAL to the file
mobilenet_v2_birds           965 labels  IDENTICAL to the file
...
identical=10 differing/declined=0 skipped=0
```

34,746 labels in total.

## Conservative by construction

The catalogue is used only when it holds a **complete, contiguous** set matching the model's declared output width. The two failure modes worth refusing are both silent:

- a **short** mapping would truncate a model's classes
- a **gap** in the indices would shift every label after it onto the wrong class

Both are refused and the file is read instead. Each has a test.

The checksum is threaded through the resolved model spec and **defaults to `None` everywhere else**, so a caller without one, a model the catalogue does not know, or a catalogue that is absent or unreadable all read the file exactly as before. A catalogue that raises never stops a model loading.

## Also

The three loaders carried near-identical label-reading blocks. They now share one, which is where the preference lives, and it reports which source supplied the labels so the log says `label_source=catalogue` or `label_source=label_file`.

## What this does not do

It does not delete `labels.txt` or stop shipping it. A model **not** registered in the catalogue still needs it, and Phase 5's compatibility importer for owner-supplied models should land before the file becomes genuinely optional. This removes the dependency for registered models; it does not remove the file.

## Verified

2,414 backend tests passing, 16 new covering ordering, unresolved outputs still contributing their label, short and gapped mappings, an unregistered model, a missing catalogue, region-variant checksum resolution, and each fallback path. `ruff` clean repo-wide, docs consistency passing.

## Risk

Low, and the fallback is the safety net. The only way this changes behaviour is if the catalogue's labels differ from the file's, and they are verified identical for every installed model.