### PR TITLE
Map an owner-supplied model's outputs into the species catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- **A model you installed yourself can now be identified by the species catalogue.** Every model in
+  the registry ships a reviewed output mapping, so the catalogue can say what each of its classes
+  is; a model an owner supplied had none, so its detections never gained a canonical identity and
+  its `labels.txt` stayed the only thing that knew what its classes were. Such a model now gets a
+  mapping derived from its own labels, resolved against the live catalogue. It refuses to guess: a
+  label reaches an identity only through an exact catalogue match, and only when every way of
+  reading that label agrees, so a name two species share and a name that is one species' English
+  name and another's scientific name both resolve to nothing rather than to the wrong bird. Every
+  output it cannot name is still recorded, carrying the model's verbatim label, and reported in
+  owner diagnostics under `species_catalog.local_mapping`. A registry model is skipped outright so
+  a mapping derived from a file on disk can never stand in for a reviewed one, an artifact the
+  catalogue already holds is never overwritten, and these labels are never served back as
+  catalogue-verified — they came from the label file this work exists to stop trusting.
+
 ### Changed
 
 - **A model's labels are read from the catalogue rather than its label file.** `labels.txt` is

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -488,6 +488,9 @@ async def lifespan(app: FastAPI):
             startup_progress=72,
         )
         create_background_task(model_manager.ensure_installed_model_configs(), name="model_config_refresh")
+        from app.services.species_catalog_compatibility import start_background_local_mapping_import
+
+        create_background_task(start_background_local_mapping_import(), name="local_model_mapping_import")
         await _run_lifecycle_phase(
             app,
             "telemetry_start",
@@ -914,6 +917,12 @@ def _naming_health() -> dict[str, object]:
         from app.services.species_catalog_backfill import last_backfill_summary
 
         catalog["backfill"] = last_backfill_summary()
+    except Exception:  # pragma: no cover
+        pass
+    try:
+        from app.services.species_catalog_compatibility import last_local_mapping_report
+
+        catalog["local_mapping"] = last_local_mapping_report()
     except Exception:  # pragma: no cover
         pass
     return {"species_reference": reference, "localized_names": localized, "species_catalog": catalog}

--- a/backend/app/services/catalogue_labels.py
+++ b/backend/app/services/catalogue_labels.py
@@ -23,6 +23,8 @@ from typing import Optional
 
 import structlog
 
+from app.services.species_catalog_compatibility import LOCAL_REGISTRY_PREFIX
+
 log = structlog.get_logger()
 
 
@@ -85,13 +87,19 @@ def catalogue_labels_for_model(
 
     try:
         artifact = connection.execute(
-            "SELECT id, output_width FROM model_artifacts WHERE LOWER(model_sha256) = ?",
+            "SELECT id, output_width, registry_id FROM model_artifacts WHERE LOWER(model_sha256) = ?",
             (checksum,),
         ).fetchone()
         if artifact is None:
             return None
         artifact_id, output_width = int(artifact[0]), int(artifact[1] or 0)
         if output_width <= 0:
+            return None
+        # A locally derived mapping was read out of this model's own
+        # `labels.txt`. Serving it back as catalogue labels would launder the
+        # file this path exists to stop trusting, and would report a
+        # verification that never happened.
+        if str(artifact[2] or "").startswith(LOCAL_REGISTRY_PREFIX):
             return None
 
         rows = connection.execute(

--- a/backend/app/services/model_taxon_map.py
+++ b/backend/app/services/model_taxon_map.py
@@ -132,6 +132,39 @@ def _hierarchy_scientific(text: str) -> Optional[str]:
     return f"{genus[:1].upper()}{genus[1:]} {species.lower()}"
 
 
+#: A trailing `(…)` qualifier: the common half of a paired label, or the
+#: plumage note the NABirds files append to one.
+_TRAILING_PARENTHETICAL = re.compile(r"\s*\([^()]*\)\s*$")
+_APOSTROPHES = str.maketrans("", "", "'\u2019")
+
+
+def paired_common_name(label: Optional[str]) -> Optional[str]:
+    """The bracketed half of a paired label, or None when there is no pair.
+
+    Says nothing about whether that half is a common name: `Cassin's Finch`
+    and `Female/juvenile` both live there. The caller decides by looking the
+    text up, never by its shape.
+    """
+    if not isinstance(label, str):
+        return None
+    paired = _PAIRED.match(label.strip())
+    if not paired:
+        return None
+    return paired.group("common").strip() or None
+
+
+def normalize_common_name(name: str) -> str:
+    """Fold a common name to the form two sources can be compared in.
+
+    Drops a trailing qualifier, apostrophes, and case, and collapses runs of
+    whitespace, so `Cassin\u2019s Finch` and `Cassins finch` meet. Deliberately
+    conservative: it never reorders or drops words, because `Great Grey Owl`
+    and `Grey Great Owl` are not the same claim.
+    """
+    stripped = _TRAILING_PARENTHETICAL.sub("", name)
+    return " ".join(stripped.translate(_APOSTROPHES).casefold().split())
+
+
 def default_map_path() -> Path:
     configured = os.environ.get("DB_PATH")
     if configured:

--- a/backend/app/services/species_catalog_compatibility.py
+++ b/backend/app/services/species_catalog_compatibility.py
@@ -1,0 +1,446 @@
+"""Derive a catalogue mapping for a model the owner installed themselves.
+
+Every model in the registry ships a reviewed mapping in the release bundle, so
+the catalogue can say what each of its outputs is. A model the owner supplied
+has none: the resolver reports `unregistered`, no detection from it ever gains
+a canonical identity, and its `labels.txt` stays the only thing that knows what
+its classes are.
+
+This closes that gap the only way that is honest without a reviewer: by
+resolving the model's own labels against the live catalogue and recording what
+resolves. An output that no source can name, or that two readings disagree
+about, is written as `unknown` carrying the model's verbatim label — the same
+row shape a published mapping uses for its own gaps — and returned in a report
+rather than guessed at.
+
+Three properties keep it safe to run unattended:
+
+* it never touches an artifact the catalogue already holds, so a reviewed
+  mapping cannot be overwritten by one derived from a file on disk;
+* a label reaches an identity only through an exact catalogue match, and only
+  when every reading that reaches one agrees, so a collision resolves to
+  nothing rather than to the wrong bird;
+* the artifact is recorded as locally derived, so the label reader refuses to
+  serve these labels back as catalogue-verified.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import re
+import sqlite3
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+import aiofiles
+import structlog
+
+from app.utils.classifier_labels import normalize_classifier_labels
+from app.services.model_taxon_map import (
+    normalize_common_name,
+    paired_common_name,
+    scientific_name_from_label,
+)
+from app.services.species_catalog_migrations import default_catalog_path
+
+log = structlog.get_logger()
+
+#: Marks an artifact whose mapping was derived here rather than reviewed and
+#: published. No registry identifier contains a colon, so the namespace cannot
+#: collide with one.
+LOCAL_REGISTRY_PREFIX = "local:"
+
+#: Enough unresolved outputs to see the shape of the problem without turning a
+#: diagnostic payload into a copy of the label file.
+_UNRESOLVED_SAMPLE = 20
+
+_CHECKSUM = re.compile(r"^[0-9a-f]{64}$")
+_AMBIGUOUS = object()
+
+#: `Malus \u00d7domestica` and `Malus domestica` are the same plant. Folded on the
+#: way in to a lookup and never on the way into the table, so a catalogue
+#: holding both spellings keeps them as the two entries it says they are.
+_HYBRID_SIGNS = str.maketrans("", "", "\u00d7")
+
+_BACKGROUND_LABELS = frozenset({"background", "none", "no bird"})
+_UNKNOWN_LABELS = frozenset({"unknown", "unidentified"})
+
+
+@dataclass(frozen=True)
+class LocalMappingReport:
+    """What the importer did, and everything it could not name.
+
+    `verdict` is one of `imported`, `already_mapped`, `unavailable` or
+    `refused`. The counts describe the outputs written; `unresolved_outputs`
+    samples the ones with no identity so an owner can see which classes their
+    model will never contribute to species history.
+    """
+
+    verdict: str
+    model_sha256: str
+    registry_id: Optional[str] = None
+    output_width: int = 0
+    resolved: int = 0
+    unresolved: int = 0
+    background: int = 0
+    mapping_set_sha256: Optional[str] = None
+    unresolved_outputs: list[dict[str, Any]] = field(default_factory=list)
+    reason: Optional[str] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "model_sha256": self.model_sha256,
+            "registry_id": self.registry_id,
+            "output_width": self.output_width,
+            "resolved": self.resolved,
+            "unresolved": self.unresolved,
+            "background": self.background,
+            "unresolved_outputs": list(self.unresolved_outputs),
+            "reason": self.reason,
+        }
+
+
+class _LiveCatalogResolver:
+    """Name lookups over one open catalogue, built for a single import.
+
+    Deliberately not the long-lived resolver: this one carries English common
+    names, which the detection path has no use for, and it is discarded as soon
+    as the mapping is written.
+    """
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._scientific: dict[str, Any] = {}
+        self._common: dict[str, Any] = {}
+
+        for scientific, species_id in connection.execute(
+            "SELECT scientific_name, species_id FROM species_concepts ORDER BY species_id"
+        ):
+            self._put(self._scientific, str(scientific).casefold(), int(species_id))
+        for alias, species_id in connection.execute(
+            "SELECT alias, species_id FROM species_aliases"
+            " WHERE resolution = 'resolved' AND species_id IS NOT NULL ORDER BY species_id"
+        ):
+            self._put(self._scientific, str(alias).casefold(), int(species_id))
+        for name, species_id in connection.execute(
+            "SELECT name, species_id FROM species_names WHERE language_tag = 'en' ORDER BY species_id"
+        ):
+            self._put(self._common, str(name).casefold(), int(species_id))
+            self._put(self._common, normalize_common_name(str(name)), int(species_id))
+
+    @staticmethod
+    def _put(table: dict[str, Any], key: str, species_id: int) -> None:
+        if not key:
+            return
+        current = table.get(key)
+        if current is None:
+            table[key] = species_id
+        elif current != species_id:
+            table[key] = _AMBIGUOUS
+
+    def _lookup(self, table: dict[str, Any], *keys: Optional[str]) -> tuple[Optional[int], bool]:
+        ambiguous = False
+        for key in keys:
+            if not key:
+                continue
+            value = table.get(key.casefold())
+            if value is _AMBIGUOUS:
+                ambiguous = True
+                continue
+            if value is not None:
+                return int(value), ambiguous
+        return None, ambiguous
+
+    def scientific(self, text: Optional[str]) -> tuple[Optional[int], bool]:
+        if not text:
+            return None, False
+        folded = " ".join(text.translate(_HYBRID_SIGNS).split())
+        return self._lookup(self._scientific, text, folded)
+
+    def common(self, text: Optional[str]) -> tuple[Optional[int], bool]:
+        if not text:
+            return None, False
+        return self._lookup(self._common, text, normalize_common_name(text))
+
+
+def _readings(text: str, label_format: Optional[str]) -> list[tuple[str, Optional[str]]]:
+    """Every way this label may honestly be read, given what the caller knows.
+
+    A declared format is obeyed exactly, because the declaration exists to stop
+    the shape of a line being trusted. Without one — the owner-supplied case,
+    where nobody has declared anything — the label is read every way at once
+    and the readings have to agree before an identity is recorded.
+    """
+    if label_format == "common_name":
+        return [("common", text)]
+    if label_format == "detector_classes":
+        return []
+    if label_format is not None:
+        return [("scientific", scientific_name_from_label(text, label_format=label_format))]
+    return [
+        ("common", text),
+        ("scientific", text),
+        ("scientific", scientific_name_from_label(text)),
+        ("common", paired_common_name(text)),
+    ]
+
+
+def _identify(text: str, label_format: Optional[str], resolver: _LiveCatalogResolver) -> tuple[Optional[int], str]:
+    confident: set[int] = set()
+    saw_ambiguous = False
+    for kind, candidate in _readings(text, label_format):
+        lookup = resolver.scientific if kind == "scientific" else resolver.common
+        species_id, ambiguous = lookup(candidate)
+        saw_ambiguous = saw_ambiguous or ambiguous
+        if species_id is not None:
+            confident.add(species_id)
+
+    if len(confident) == 1:
+        return confident.pop(), "resolved"
+    if len(confident) > 1:
+        return None, "conflicting identities"
+    if saw_ambiguous:
+        return None, "ambiguous"
+    return None, "no catalogue identity"
+
+
+def _mapping_digest(rows: Sequence[tuple[int, str, Optional[int], str]]) -> str:
+    digest = hashlib.sha256()
+    for index, kind, species_id, label in rows:
+        digest.update(f"{index}\t{kind}\t{'' if species_id is None else species_id}\t{label}\n".encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _open_catalog(catalog_path: Optional[Path]) -> Optional[sqlite3.Connection]:
+    path = Path(catalog_path or default_catalog_path())
+    if not path.is_file():
+        return None
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("SELECT 1 FROM model_artifacts LIMIT 1").fetchone()
+    except sqlite3.Error:
+        connection.close()
+        return None
+    return connection
+
+
+def import_local_model_mapping(
+    *,
+    model_id: str,
+    model_sha256: str,
+    labels: Sequence[str],
+    runtime: str,
+    label_format: Optional[str] = None,
+    catalog_path: Optional[Path] = None,
+) -> LocalMappingReport:
+    """Give an unregistered model a catalogue mapping built from its labels."""
+    checksum = str(model_sha256 or "").strip().lower()
+    cleaned = [str(label).strip() for label in labels]
+
+    if not _CHECKSUM.match(checksum):
+        return LocalMappingReport(verdict="refused", model_sha256=checksum, reason="model checksum is not a sha256")
+    if not cleaned or not all(cleaned):
+        return LocalMappingReport(verdict="refused", model_sha256=checksum, reason="label set is empty or has a blank")
+    if not str(model_id or "").strip():
+        return LocalMappingReport(verdict="refused", model_sha256=checksum, reason="model identifier is empty")
+
+    connection = _open_catalog(catalog_path)
+    if connection is None:
+        return LocalMappingReport(verdict="unavailable", model_sha256=checksum, reason="no readable species catalogue")
+
+    registry_id = f"{LOCAL_REGISTRY_PREFIX}{str(model_id).strip()}"
+    try:
+        existing = connection.execute(
+            "SELECT registry_id FROM model_artifacts WHERE LOWER(model_sha256) = ?", (checksum,)
+        ).fetchone()
+        if existing is not None:
+            return LocalMappingReport(
+                verdict="already_mapped",
+                model_sha256=checksum,
+                registry_id=str(existing[0]),
+                reason="the catalogue already holds this artifact",
+            )
+
+        resolver = _LiveCatalogResolver(connection)
+        rows: list[tuple[int, str, Optional[int], str]] = []
+        unresolved_outputs: list[dict[str, Any]] = []
+        resolved = background = unresolved = 0
+
+        for index, label in enumerate(cleaned):
+            folded = label.casefold()
+            if folded in _BACKGROUND_LABELS:
+                rows.append((index, "background", None, label))
+                background += 1
+                continue
+            if folded in _UNKNOWN_LABELS:
+                rows.append((index, "unknown", None, label))
+                continue
+
+            species_id, reason = _identify(label, label_format, resolver)
+            if species_id is not None:
+                rows.append((index, "species", species_id, label))
+                resolved += 1
+                continue
+
+            rows.append((index, "unknown", None, label))
+            unresolved += 1
+            if len(unresolved_outputs) < _UNRESOLVED_SAMPLE:
+                unresolved_outputs.append({"index": index, "label": label, "reason": reason})
+
+        digest = _mapping_digest(rows)
+        with connection:
+            cursor = connection.execute(
+                "INSERT INTO model_artifacts"
+                " (registry_id, model_sha256, mapping_set_sha256, output_width, runtime, state)"
+                " VALUES (?, ?, ?, ?, ?, 'installed')",
+                (registry_id, checksum, digest, len(rows), str(runtime or "unknown")),
+            )
+            connection.executemany(
+                "INSERT INTO model_output_taxa (model_artifact_id, output_index, class_kind, species_id, source_label)"
+                " VALUES (?, ?, ?, ?, ?)",
+                [(cursor.lastrowid, index, kind, species_id, label) for index, kind, species_id, label in rows],
+            )
+    except sqlite3.Error as error:
+        log.warning("Local model mapping not imported", model_id=model_id, error=str(error))
+        return LocalMappingReport(verdict="refused", model_sha256=checksum, reason=str(error))
+    finally:
+        connection.close()
+
+    report = LocalMappingReport(
+        verdict="imported",
+        model_sha256=checksum,
+        registry_id=registry_id,
+        output_width=len(rows),
+        resolved=resolved,
+        unresolved=unresolved,
+        background=background,
+        mapping_set_sha256=digest,
+        unresolved_outputs=unresolved_outputs,
+    )
+    log.info(
+        "Derived a catalogue mapping for a locally installed model",
+        registry_id=registry_id,
+        outputs=report.output_width,
+        resolved=resolved,
+        unresolved=unresolved,
+    )
+    return report
+
+
+_report_lock = threading.Lock()
+_last_report: Optional[LocalMappingReport] = None
+
+
+def last_local_mapping_report() -> Optional[dict[str, Any]]:
+    """The most recent local import, for diagnostics, or None if none ran."""
+    with _report_lock:
+        return _last_report.as_dict() if _last_report else None
+
+
+def _record_report(report: LocalMappingReport) -> None:
+    global _last_report
+    with _report_lock:
+        _last_report = report
+
+
+async def _read_label_file(labels_path: str) -> list[str]:
+    """The model's labels, parsed exactly as the loader parses them.
+
+    Sharing `normalize_classifier_labels` is the point: a mapping whose width
+    disagreed with the tensor the model actually produces would bind every
+    output after the disagreement to the wrong class.
+    """
+    if not labels_path:
+        return []
+    # A missing file raises here rather than being probed for first: the probe
+    # is blocking I/O, and the open has to handle the race anyway.
+    try:
+        async with aiofiles.open(labels_path, "r", encoding="utf-8", errors="replace") as handle:
+            content = await handle.read()
+    except OSError as error:
+        log.debug("Label file unreadable for local mapping", path=labels_path, error=str(error))
+        return []
+    return normalize_classifier_labels(line.strip() for line in content.splitlines() if line.strip())
+
+
+#: A model that is still loading has nothing to map yet. Startup does not wait
+#: for it, so the import waits instead, and gives up rather than polling for
+#: the life of the process.
+_MODEL_WAIT_ATTEMPTS = 20
+_MODEL_WAIT_SECONDS = 6.0
+
+_NO_MODEL_LOADED = "no model is loaded"
+
+
+def _skipped(reason: str) -> LocalMappingReport:
+    return LocalMappingReport(verdict="skipped", model_sha256="", reason=reason)
+
+
+async def import_mapping_for_installed_model(
+    catalog_path: Optional[Path] = None,
+) -> LocalMappingReport:
+    """Map the loaded model's outputs when the registry publishes none for it.
+
+    A registry model is skipped outright. Its mapping is reviewed and arrives
+    in the release bundle, and one derived from a file on disk must never stand
+    in for one that was checked — not even while the reviewed one is missing.
+    """
+    from app.services.catalogue_labels import published_model_sha256
+    from app.services.classifier_service import get_classifier
+    from app.services.model_manager import model_manager
+
+    spec = dict(model_manager.get_active_model_spec() or {})
+    model_id = str(spec.get("model_id") or "").strip()
+    if not model_id:
+        return _skipped("no model is selected")
+    if published_model_sha256(model_id, spec.get("resolved_region")):
+        return _skipped("the registry publishes a mapping for this model")
+
+    checksum = str(get_classifier().active_model_sha256() or "")
+    if not checksum:
+        return _skipped(_NO_MODEL_LOADED)
+
+    labels = await _read_label_file(str(spec.get("labels_path") or ""))
+    if not labels:
+        return _skipped("the model has no readable label file")
+
+    return await asyncio.to_thread(
+        import_local_model_mapping,
+        model_id=model_id,
+        model_sha256=checksum,
+        labels=labels,
+        runtime=str(spec.get("runtime") or "unknown"),
+        catalog_path=catalog_path,
+    )
+
+
+async def start_background_local_mapping_import() -> None:
+    """Run the compatibility import detached from startup; never fatal.
+
+    Waits for the classifier to finish loading rather than racing it, because
+    the checksum this keys on only exists once the model file has been read.
+    """
+    report = _skipped(_NO_MODEL_LOADED)
+    try:
+        for attempt in range(_MODEL_WAIT_ATTEMPTS):
+            report = await import_mapping_for_installed_model()
+            if report.reason != _NO_MODEL_LOADED:
+                break
+            if attempt + 1 < _MODEL_WAIT_ATTEMPTS:
+                await asyncio.sleep(_MODEL_WAIT_SECONDS)
+    except Exception as error:  # pragma: no cover - defensive
+        report = LocalMappingReport(verdict="refused", model_sha256="", reason=str(error))
+        log.warning("Local model mapping import failed", error=str(error))
+
+    _record_report(report)
+    if report.verdict == "imported" and report.unresolved:
+        log.info(
+            "Some outputs of the installed model have no catalogue identity",
+            registry_id=report.registry_id,
+            unresolved=report.unresolved,
+            of=report.output_width,
+        )

--- a/backend/scripts/build_model_output_mappings.py
+++ b/backend/scripts/build_model_output_mappings.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import re
 import sqlite3
 import sys
 import tempfile
@@ -39,14 +38,13 @@ if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
 
 from app.services.model_registry_inventory import registry_artifacts  # noqa: E402
+from app.services.model_taxon_map import normalize_common_name as _normalize_common  # noqa: E402
 from app.services.model_taxon_map import scientific_name_from_label  # noqa: E402
 
 DEFAULT_OUTPUT = _BACKEND_DIR / "app" / "assets" / "model_output_mappings.json"
 DEFAULT_REPORT = _BACKEND_DIR.parent / "docs" / "reviews" / "2026-08-20-model-output-mapping-coverage.md"
 
 _AMBIGUOUS = object()
-_TRAILING_PARENTHETICAL = re.compile(r"\s*\([^()]*\)\s*$")
-_APOSTROPHES = str.maketrans("", "", "'’")
 _HYBRID_SIGNS = str.maketrans("", "", "×")
 
 
@@ -58,11 +56,6 @@ class OutputRow:
     provider: Optional[str] = None
     taxon: Optional[str] = None
     unresolved: Optional[str] = None
-
-
-def _normalize_common(name: str) -> str:
-    stripped = _TRAILING_PARENTHETICAL.sub("", name)
-    return " ".join(stripped.translate(_APOSTROPHES).casefold().split())
 
 
 class CatalogResolver:

--- a/backend/tests/test_model_output_mappings.py
+++ b/backend/tests/test_model_output_mappings.py
@@ -439,3 +439,17 @@ def test_the_committed_assets_build_a_fully_mapped_catalogue(tmp_path):
         " AND NOT EXISTS (SELECT 1 FROM species s WHERE s.species_id = t.species_id)",
     )
     assert orphans == [(0,)]
+
+
+def test_the_mapping_build_and_the_compatibility_importer_normalise_alike():
+    """One normaliser, two callers. The published mappings and a locally
+    derived one have to agree on when two spellings are the same name; two
+    copies of the rule could drift and quietly stop agreeing."""
+    import build_model_output_mappings as build_module
+
+    from app.services.model_taxon_map import normalize_common_name
+
+    assert build_module._normalize_common is normalize_common_name
+    assert normalize_common_name("Cassin\u2019s Finch") == "cassins finch"
+    assert normalize_common_name("Lesser Goldfinch (Female/juvenile)") == "lesser goldfinch"
+    assert normalize_common_name("  Great   Grey  Owl ") == "great grey owl"

--- a/backend/tests/test_species_catalog_compatibility.py
+++ b/backend/tests/test_species_catalog_compatibility.py
@@ -1,0 +1,428 @@
+"""Giving an owner-supplied model a catalogue mapping built from its own labels.
+
+Phase 5's compatibility path. Every model in the registry ships a reviewed
+mapping in the release bundle; a model the owner installed themselves has
+none, so the resolver reports `unregistered` and its detections never gain a
+canonical identity. This importer derives a mapping for such a model by
+resolving its label file against the live catalogue, records every output it
+could not name rather than guessing one, and marks the result as locally
+derived so nothing downstream mistakes it for a reviewed release mapping.
+"""
+
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import build_species_catalog_seed as seed_builder  # noqa: E402
+
+from app.services.catalogue_labels import catalogue_labels_for_model  # noqa: E402
+from app.services.species_catalog_compatibility import (  # noqa: E402
+    LOCAL_REGISTRY_PREFIX,
+    import_local_model_mapping,
+)
+
+REFERENCE_SCHEMA = """
+CREATE TABLE reference_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE taxon (id INTEGER PRIMARY KEY, scientific_name TEXT NOT NULL, common_name TEXT);
+CREATE TABLE taxon_name (
+    taxon_id INTEGER NOT NULL, locale TEXT NOT NULL, common_name TEXT NOT NULL,
+    PRIMARY KEY (taxon_id, locale)
+) WITHOUT ROWID;
+"""
+
+#: `Goldcrest` is deliberately both one species' English name and another's
+#: scientific name. Real catalogues collide less absurdly — a resurrected genus,
+#: a common name reused as a binomial — but the importer has to survive the
+#: collision whatever produced it, so the fixture states it outright.
+TAXA = [
+    (1, "Cyanistes caeruleus", "Eurasian Blue Tit"),
+    (2, "Erithacus rubecula", "European Robin"),
+    (3, "Haemorhous cassinii", "Cassin's Finch"),
+    (4, "Spinus psaltria", "Lesser Goldfinch"),
+    (5, "Regulus regulus", "Goldcrest"),
+    (6, "Goldcrest", "Not A Real Bird"),
+    (7, "Sylvia atricapilla", "Garden Warbler"),
+    (8, "Sylvia borin", "Garden Warbler"),
+]
+
+PUBLISHED_MODEL_SHA = "b" * 64
+LOCAL_MODEL_SHA = "a1b2" + "c" * 60
+
+
+@pytest.fixture
+def catalog(tmp_path):
+    pinned = hashlib.sha256(b"compatibility ioc").hexdigest()
+    reference = tmp_path / "reference.db"
+    connection = sqlite3.connect(reference)
+    try:
+        connection.executescript(REFERENCE_SCHEMA)
+        connection.execute("INSERT INTO reference_meta VALUES ('source_sha256', ?)", (pinned,))
+        connection.executemany("INSERT INTO taxon VALUES (?, ?, ?)", TAXA)
+        connection.commit()
+    finally:
+        connection.close()
+
+    manifest = tmp_path / "sources.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "frozen_on": "2026-08-23",
+                "sources": [
+                    {
+                        "id": "ioc-world-bird-list",
+                        "name": "IOC",
+                        "role": "bird-vernacular-names",
+                        "version": "14.2-test",
+                        "url": "https://www.worldbirdnames.org/",
+                        "licence": "CC-BY-3.0",
+                        "citation": "IOC World Bird List.",
+                        "redistribution": "bundled",
+                        "content_sha256": pinned,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    mappings = tmp_path / "mappings.json"
+    mappings.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "label_files": {
+                    "labelsha-published": {
+                        "label_format": "common_name",
+                        "output_width": 2,
+                        "outputs": [
+                            {
+                                "index": 0,
+                                "kind": "species",
+                                "label": "Eurasian blue tit",
+                                "provider": "ioc-world-bird-list",
+                                "taxon": "Cyanistes caeruleus",
+                            },
+                            {
+                                "index": 1,
+                                "kind": "species",
+                                "label": "European robin",
+                                "provider": "ioc-world-bird-list",
+                                "taxon": "Erithacus rubecula",
+                            },
+                        ],
+                    }
+                },
+                "artifacts": [
+                    {
+                        "artifact_id": "published_model",
+                        "model_sha256": PUBLISHED_MODEL_SHA,
+                        "labels_sha256": "labelsha-published",
+                        "runtime": "onnx",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    path = tmp_path / "catalog.db"
+    seed_builder.build(reference, path, manifest_path=manifest, model_mappings_path=mappings)
+    return path
+
+
+def rows_for(catalog_path, model_sha256):
+    connection = sqlite3.connect(catalog_path)
+    try:
+        return connection.execute(
+            "SELECT output_index, class_kind, species_id, source_label FROM model_output_taxa"
+            " JOIN model_artifacts ON model_artifacts.id = model_output_taxa.model_artifact_id"
+            " WHERE LOWER(model_sha256) = ? ORDER BY output_index",
+            (model_sha256.lower(),),
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+def import_labels(catalog_path, labels, model_sha256=LOCAL_MODEL_SHA, model_id="owner_model", **kwargs):
+    return import_local_model_mapping(
+        model_id=model_id,
+        model_sha256=model_sha256,
+        labels=labels,
+        runtime="onnx",
+        catalog_path=catalog_path,
+        **kwargs,
+    )
+
+
+class TestResolution:
+    def test_common_name_labels_gain_a_catalogue_identity(self, catalog):
+        report = import_labels(catalog, ["Eurasian Blue Tit", "European Robin"])
+
+        assert report.verdict == "imported"
+        assert report.resolved == 2
+        assert report.unresolved == 0
+        assert [(row[1], row[2]) for row in rows_for(catalog, LOCAL_MODEL_SHA)] == [("species", 1), ("species", 2)]
+
+    def test_scientific_name_labels_gain_a_catalogue_identity(self, catalog):
+        report = import_labels(catalog, ["Cyanistes caeruleus", "Erithacus rubecula"])
+
+        assert report.resolved == 2
+        assert [row[2] for row in rows_for(catalog, LOCAL_MODEL_SHA)] == [1, 2]
+
+    def test_a_paired_label_resolves_through_either_half(self, catalog):
+        """`Haemorhous cassinii (Cassin's Finch)` announces itself: both halves
+        name the same bird, so the two readings agree."""
+        report = import_labels(catalog, ["Haemorhous cassinii (Cassin's Finch)"])
+
+        assert report.resolved == 1
+        assert rows_for(catalog, LOCAL_MODEL_SHA)[0][2] == 3
+
+    def test_a_plumage_qualified_common_name_binds_to_its_species(self, catalog):
+        """The NABirds shape. `Lesser Goldfinch (Female/juvenile)` wears the
+        paired form without carrying a scientific name, and the label path has
+        always been wrong to read the left half as one. It is still that
+        species, and the label text is kept verbatim."""
+        report = import_labels(catalog, ["Lesser Goldfinch (Female/juvenile)"])
+
+        assert report.resolved == 1
+        index, kind, species_id, source_label = rows_for(catalog, LOCAL_MODEL_SHA)[0]
+        assert (kind, species_id) == ("species", 4)
+        assert source_label == "Lesser Goldfinch (Female/juvenile)"
+
+    def test_background_and_unknown_classes_are_recorded_as_themselves(self, catalog):
+        report = import_labels(catalog, ["Background", "Unknown", "European Robin"])
+
+        assert (report.resolved, report.unresolved) == (1, 0)
+        assert [row[1] for row in rows_for(catalog, LOCAL_MODEL_SHA)] == ["background", "unknown", "species"]
+        assert report.background == 1
+
+
+class TestRefusingToGuess:
+    def test_a_label_no_source_can_name_is_recorded_without_an_identity(self, catalog):
+        report = import_labels(catalog, ["European Robin", "Nonexistent Fantasybird"])
+
+        assert (report.resolved, report.unresolved) == (1, 1)
+        index, kind, species_id, source_label = rows_for(catalog, LOCAL_MODEL_SHA)[1]
+        assert (kind, species_id, source_label) == ("unknown", None, "Nonexistent Fantasybird")
+        assert report.unresolved_outputs == [
+            {"index": 1, "label": "Nonexistent Fantasybird", "reason": "no catalogue identity"}
+        ]
+
+    def test_two_readings_that_disagree_resolve_to_neither(self, catalog):
+        """`Goldcrest` is species 5's English name and species 6's scientific
+        name. One reading being confident is not enough when another reading is
+        equally confident about a different bird."""
+        report = import_labels(catalog, ["Goldcrest"])
+
+        assert (report.resolved, report.unresolved) == (0, 1)
+        assert rows_for(catalog, LOCAL_MODEL_SHA)[0][1:3] == ("unknown", None)
+        assert report.unresolved_outputs[0]["reason"] == "conflicting identities"
+
+    def test_a_name_two_species_share_resolves_to_neither(self, catalog):
+        """Species 7 and 8 are both called `Garden Warbler` here. A name that
+        does not pick one bird cannot be recorded as picking one."""
+        report = import_labels(catalog, ["Garden Warbler"])
+
+        assert (report.resolved, report.unresolved) == (0, 1)
+        assert report.unresolved_outputs[0]["reason"] == "ambiguous"
+
+    def test_a_declared_format_is_honoured_over_the_evidence(self, catalog):
+        """When the caller states the file holds common names, a line is read
+        only that way — the declaration exists precisely to stop the shape of a
+        line being trusted."""
+        report = import_labels(catalog, ["Cyanistes caeruleus"], label_format="common_name")
+
+        assert (report.resolved, report.unresolved) == (0, 1)
+
+
+class TestProtectingWhatIsAlreadyThere:
+    def test_a_published_mapping_is_never_replaced(self, catalog):
+        before = rows_for(catalog, PUBLISHED_MODEL_SHA)
+
+        report = import_labels(catalog, ["Garden Warbler", "Nonexistent"], model_sha256=PUBLISHED_MODEL_SHA)
+
+        assert report.verdict == "already_mapped"
+        assert rows_for(catalog, PUBLISHED_MODEL_SHA) == before
+
+    def test_re_running_the_import_changes_nothing(self, catalog):
+        first = import_labels(catalog, ["Eurasian Blue Tit", "European Robin"])
+        rows = rows_for(catalog, LOCAL_MODEL_SHA)
+
+        second = import_labels(catalog, ["Eurasian Blue Tit", "European Robin"])
+
+        assert (first.verdict, second.verdict) == ("imported", "already_mapped")
+        assert rows_for(catalog, LOCAL_MODEL_SHA) == rows
+
+    def test_a_missing_catalogue_is_reported_not_raised(self, tmp_path):
+        report = import_labels(tmp_path / "nowhere.db", ["European Robin"])
+
+        assert report.verdict == "unavailable"
+
+    @pytest.mark.parametrize(
+        "labels, model_sha256",
+        [
+            ([], LOCAL_MODEL_SHA),
+            (["European Robin"], "not-a-checksum"),
+            (["European Robin"], ""),
+            (["   "], LOCAL_MODEL_SHA),
+        ],
+    )
+    def test_an_input_that_cannot_be_trusted_is_refused(self, catalog, labels, model_sha256):
+        report = import_labels(catalog, labels, model_sha256=model_sha256)
+
+        assert report.verdict == "refused"
+        assert rows_for(catalog, model_sha256 or LOCAL_MODEL_SHA) == []
+
+
+class TestProvenance:
+    def test_the_artifact_is_marked_as_locally_derived(self, catalog):
+        import_labels(catalog, ["European Robin"], model_id="my_own_model")
+
+        connection = sqlite3.connect(catalog)
+        try:
+            registry_id, state, width = connection.execute(
+                "SELECT registry_id, state, output_width FROM model_artifacts WHERE LOWER(model_sha256) = ?",
+                (LOCAL_MODEL_SHA,),
+            ).fetchone()
+        finally:
+            connection.close()
+
+        assert registry_id == f"{LOCAL_REGISTRY_PREFIX}my_own_model"
+        assert (state, width) == ("installed", 1)
+
+    def test_a_locally_derived_mapping_is_not_served_as_catalogue_labels(self, catalog):
+        """The labels came out of `labels.txt`. Handing them back as if the
+        catalogue had verified them would launder the file we are trying to
+        stop trusting."""
+        import_labels(catalog, ["Eurasian Blue Tit", "European Robin"])
+
+        assert catalogue_labels_for_model(LOCAL_MODEL_SHA, catalog_path=catalog) is None
+        assert catalogue_labels_for_model(PUBLISHED_MODEL_SHA, catalog_path=catalog) == [
+            "Eurasian blue tit",
+            "European robin",
+        ]
+
+    def test_the_report_carries_a_digest_of_what_was_written(self, catalog):
+        report = import_labels(catalog, ["European Robin"])
+
+        connection = sqlite3.connect(catalog)
+        try:
+            stored = connection.execute(
+                "SELECT mapping_set_sha256 FROM model_artifacts WHERE LOWER(model_sha256) = ?",
+                (LOCAL_MODEL_SHA,),
+            ).fetchone()[0]
+        finally:
+            connection.close()
+
+        assert stored == report.mapping_set_sha256
+        assert len(stored) == 64
+
+    def test_the_unresolved_sample_is_capped_but_the_count_is_not(self, catalog):
+        labels = [f"Fantasybird {index}" for index in range(40)]
+
+        report = import_labels(catalog, labels)
+
+        assert report.unresolved == 40
+        assert len(report.unresolved_outputs) == 20
+        assert report.unresolved_outputs[0]["index"] == 0
+
+
+class TestWiring:
+    """What the startup pass does with a real installed model."""
+
+    @pytest.fixture
+    def installed(self, catalog, tmp_path, monkeypatch):
+        from app.services import species_catalog_compatibility as module
+
+        labels_path = tmp_path / "labels.txt"
+        labels_path.write_text("Eurasian Blue Tit\n\nEuropean Robin\n", encoding="utf-8")
+
+        state = {
+            "spec": {
+                "model_id": "owner_model",
+                "labels_path": str(labels_path),
+                "runtime": "onnx",
+            },
+            "checksum": LOCAL_MODEL_SHA,
+            "published": None,
+        }
+
+        class _ModelManager:
+            def get_active_model_spec(self):
+                return state["spec"]
+
+        class _Classifier:
+            def active_model_sha256(self):
+                return state["checksum"]
+
+        monkeypatch.setattr("app.services.model_manager.model_manager", _ModelManager())
+        monkeypatch.setattr("app.services.classifier_service.get_classifier", lambda: _Classifier())
+        monkeypatch.setattr(
+            "app.services.catalogue_labels.published_model_sha256", lambda model_id, region=None: state["published"]
+        )
+        monkeypatch.setattr(module, "_MODEL_WAIT_ATTEMPTS", 2)
+        monkeypatch.setattr(module, "_MODEL_WAIT_SECONDS", 0)
+        return state
+
+    @pytest.mark.asyncio
+    async def test_an_owner_supplied_model_is_mapped_from_its_label_file(self, catalog, installed):
+        from app.services.species_catalog_compatibility import import_mapping_for_installed_model
+
+        report = await import_mapping_for_installed_model(catalog_path=catalog)
+
+        assert (report.verdict, report.resolved, report.output_width) == ("imported", 2, 2)
+        assert [row[2] for row in rows_for(catalog, LOCAL_MODEL_SHA)] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_a_registry_model_is_left_to_its_published_mapping(self, catalog, installed):
+        from app.services.species_catalog_compatibility import import_mapping_for_installed_model
+
+        installed["published"] = "b" * 64
+
+        report = await import_mapping_for_installed_model(catalog_path=catalog)
+
+        assert report.verdict == "skipped"
+        assert rows_for(catalog, LOCAL_MODEL_SHA) == []
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_written_before_the_model_has_loaded(self, catalog, installed):
+        from app.services.species_catalog_compatibility import import_mapping_for_installed_model
+
+        installed["checksum"] = None
+
+        report = await import_mapping_for_installed_model(catalog_path=catalog)
+
+        assert (report.verdict, report.reason) == ("skipped", "no model is loaded")
+        assert rows_for(catalog, LOCAL_MODEL_SHA) == []
+
+    @pytest.mark.asyncio
+    async def test_the_background_pass_gives_up_rather_than_polling_forever(self, catalog, installed):
+        from app.services.species_catalog_compatibility import (
+            last_local_mapping_report,
+            start_background_local_mapping_import,
+        )
+
+        installed["checksum"] = None
+
+        await start_background_local_mapping_import()
+
+        assert last_local_mapping_report()["reason"] == "no model is loaded"
+
+    @pytest.mark.asyncio
+    async def test_a_label_file_the_loader_would_reject_maps_nothing(self, catalog, installed, tmp_path):
+        from app.services.species_catalog_compatibility import import_mapping_for_installed_model
+
+        empty = tmp_path / "empty.txt"
+        empty.write_text("\n\n", encoding="utf-8")
+        installed["spec"]["labels_path"] = str(empty)
+
+        report = await import_mapping_for_installed_model(catalog_path=catalog)
+
+        assert (report.verdict, report.reason) == ("skipped", "the model has no readable label file")

--- a/docs/plans/2026-08-12-versioned-species-catalogue-design.md
+++ b/docs/plans/2026-08-12-versioned-species-catalogue-design.md
@@ -297,6 +297,41 @@ the current taxonomy joins.
 label-file reads; all model flavours pass image smoke tests; the full Definition of Done and `3.0`
 migration evidence are green.
 
+#### The compatibility importer, as shipped
+
+`species_catalog_compatibility.py` derives a mapping for a model the registry does not publish, by
+resolving that model's own labels against the live catalogue. It runs once per startup, detached
+from it, after waiting for the classifier to load the model whose checksum the mapping is keyed on.
+
+It resolves a label only by exact catalogue match — a scientific name, a recorded resolved synonym,
+or an English vernacular name, each also compared in a folded form that drops a trailing qualifier,
+apostrophes and case. Where no format is declared, the label is read every way at once: as a common
+name, as a scientific name, through the two self-announcing shapes `scientific_name_from_label`
+accepts without a declaration, and through the bracketed half of a paired label. An identity is
+recorded only when every reading that reaches one reaches the *same* one. Two readings that
+disagree, and a name more than one species holds, both resolve to nothing. A declared format is
+obeyed exactly, because the declaration exists to stop the shape of a line being trusted.
+
+Four rules keep it safe to run unattended:
+
+- **A registry model is skipped.** Its mapping is reviewed and arrives in the release bundle. One
+  derived from a file on disk must never stand in for one that was checked, not even while the
+  reviewed one is missing.
+- **An artifact the catalogue already holds is never touched**, so a published mapping cannot be
+  overwritten by a derived one.
+- **Every unresolved output still gets a row**, carrying the model's verbatim label and the kind
+  `unknown` — the same shape a published mapping uses for its own gaps — so coverage counts
+  identity rather than the presence of a row, and the label text no longer lives only in
+  `labels.txt`.
+- **The artifact is recorded as locally derived**, under the reserved `local:` registry namespace,
+  and `catalogue_labels_for_model` refuses to serve its labels. Handing them back as catalogue
+  labels would launder the file this work exists to stop trusting, and would report a verification
+  that never happened.
+
+The report — outputs written, resolved, unresolved, and a capped sample of the unresolved ones with
+the reason each failed — is returned by the importer and surfaced in owner diagnostics under
+`species_catalog.local_mapping`.
+
 ## Safety and second-order effects
 
 - **Taxonomic change is not historical correction.** A later split or lump must not silently


### PR DESCRIPTION
## Outcome

A model the owner installed themselves can now be identified by the species catalogue. Every model in the registry ships a reviewed output mapping; a model outside it had none, so the resolver reported `unregistered`, its detections never gained a canonical identity, and its `labels.txt` stayed the only thing that knew what its classes were.

Such a model now gets a mapping derived from its own labels, resolved against the live catalogue, plus an explicit report of everything that could not be named. This is the compatibility importer Phase 5 requires before label-file authority can be retired.

## How it refuses to guess

A label reaches an identity only through an exact catalogue match — a scientific name, a recorded resolved synonym, or an English vernacular name, each also compared folded (trailing qualifier, apostrophes, case, hybrid sign).

With no declared format the label is read **every way at once** — as a common name, as a scientific name, through the two shapes `scientific_name_from_label` accepts without a declaration, and through the bracketed half of a paired label — and an identity is recorded only when every reading that reaches one reaches the **same** one. A declared format is obeyed exactly, because the declaration exists to stop the shape of a line being trusted.

So both of these resolve to nothing rather than to the wrong bird:

- a name two species share;
- a name that is one species' English name and another's scientific name.

## Verification against the reviewed mappings

Four real label files were run against a copy of the live catalogue from quark as if each were owner-supplied, then compared index by index with the reviewed mapping the catalogue already holds:

| model | outputs | resolved | agree | disagree | reviewed only | derived only |
|---|---:|---:|---:|---:|---:|---:|
| `convnext_large_inat21` | 10,000 | 9,337 (93.4%) | 9,293 | **0** | 0 | 44 |
| `mobilenet_v2_birds` | 965 | 915 (94.8%) | 852 | **0** | 10 | 63 |
| `eu_medium_focalnet_b` | 707 | 682 (96.5%) | 682 | **0** | 0 | 0 |
| `convnext_v1_tiny_eu_common` | 707 | 682 (96.5%) | 682 | **0** | 0 | 0 |

**11,509 outputs where both named a species, zero disagreements.**

The ten the reviewed mapping named and this one refused are all the same thing — a label whose two halves name different IOC species after a split:

- `Circus cyaneus (Northern Harrier)` — `Northern Harrier` is now `Circus hudsonius`
- `Pyrocephalus rubinus (Vermilion Flycatcher)` — now `Pyrocephalus obscurus`
- `Anas crecca (Green-winged Teal)` — now `Anas carolinensis`
- `Lanius excubitor (Northern Shrike)` — now `Lanius borealis`

The label contradicts itself under IOC 14.2. The reviewed mapping settles it because a reviewer declared the scientific half authoritative; without that declaration, believing either half would be a guess.

The 107 outputs the derived mapping named and the reviewed ones did not are recorded Catalogue of Life synonyms (`Accipiter gentilis` → `Astur gentilis`, `Psilorhinus morio` → `Cyanocorax morio`). Those synonyms are in the live catalogue but postdate the compiled `model_output_mappings.json`, so the published mappings look stale by that much — worth rebuilding separately, not in this PR.

## Safety

- **A registry model is skipped outright.** Its mapping is reviewed and arrives in the release bundle; a mapping derived from a file on disk must never stand in for one that was checked, not even while the reviewed one is missing.
- **An artifact the catalogue already holds is never touched**, so a published mapping cannot be overwritten.
- **Every unresolved output still gets a row** carrying the verbatim label and the kind `unknown` — the shape a published mapping uses for its own gaps — so coverage keeps counting identity, not the presence of a row.
- **These labels are never served back as catalogue labels.** The artifact is recorded under the reserved `local:` registry namespace and `catalogue_labels_for_model` refuses it. Serving them would launder the file this work exists to stop trusting and report a verification that never happened.
- Runs detached from startup, waits for the classifier rather than racing it, gives up after two minutes rather than polling forever, and never raises.

## Scope

Included: the importer, its report, the startup pass, the `species_catalog.local_mapping` diagnostics field, the `catalogue_labels_for_model` guard, and one shared common-name normaliser now used by both the build script and the importer (with a test that they cannot drift apart).

Excluded: no schema change, no migration, no change to how registry models are mapped or labelled, and `labels.txt` is still shipped and still read for anything unmapped.

## Checks

2,440 backend tests pass (26 new), `ruff check .` and `ruff format --check .` clean repo-wide, docs consistency check passes.