### PR TITLE
Take the taxon that was asked for, not the one that ranks first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -627,6 +627,21 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A bird could be recorded as the wrong species because the taxonomy lookup took whatever ranked
+  first.** iNaturalist's `/v1/taxa?q=` is a search, not a lookup: it ranks by relevance and matches
+  synonyms, so the species asked about is not reliably the first result. The lookup asked for a
+  single result and took it without checking it was the name it had asked for. Measured against the
+  live API with 45 real labels from the flagship model, 3 were wrong: `Buteo buteo` resolved to the
+  subfamily `Buteoninae`, `Clanga clanga` to the genus `Clanga`, and `Circus cyaneus` (Hen Harrier)
+  to `Circus hudsonius`, the Northern Harrier of North America, because the two were split and the
+  older name still matches. A live install had recorded a Goldcrest as a Ruby-crowned Kinglet for
+  the same reason. The lookup now asks for a page of candidates and takes only one whose matched
+  term, scientific name, or English common name is exactly what was asked for; a genuine rename
+  still resolves, because a model trained on `Regulus calendula` asks for that name and the taxon
+  now called `Corthylio calendula` reports matching on precisely it. When nothing on the page is
+  the name asked for, the bundled reference answers and the model's own label stands, rather than a
+  different species being written into history.
+
 - **Filtering the events list by species is no longer dominated by a taxonomy join.** A user
   reported the species filter being noticeably slower than the date and camera filters. The join
   onto `taxonomy_cache` was the cause: its conditions are ORs across different columns wrapped in

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -78,6 +78,42 @@ class TaxonomyLookupUnavailable(Exception):
     """
 
 
+#: `/v1/taxa?q=` is a search, not a lookup: it ranks by relevance and matches
+#: synonyms, so the species asked for is not reliably first. Asking for one
+#: result leaves nothing to check it against. Ten is enough for the exact match
+#: to be on the page in every recorded case while staying one request.
+_LOOKUP_PAGE_SIZE = 10
+
+
+def _fold_for_match(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.casefold().split())
+
+
+def _matching_taxon(results: list, query: str) -> Optional[Dict]:
+    """The first candidate that is actually the name that was asked for.
+
+    A candidate counts when the term it matched on, its scientific name, or its
+    English common name is exactly the query. `matched_term` is what makes a
+    genuine rename work: a model trained on `Regulus calendula` asks for that
+    name, and the taxon now called `Corthylio calendula` reports matching on
+    precisely it. The same field is what rejects the fuzzy hit, because for the
+    query `Regulus regulus` that taxon reports matching on `Regulus calendula`,
+    which is a different bird.
+    """
+    wanted = _fold_for_match(query)
+    if not wanted:
+        return None
+    for taxon in results:
+        if not isinstance(taxon, dict):
+            continue
+        for field in ("matched_term", "name", "preferred_common_name"):
+            if _fold_for_match(taxon.get(field)) == wanted:
+                return taxon
+    return None
+
+
 class TaxonomyService:
     """Service to handle bidirectional scientific <-> common name lookups using iNaturalist."""
 
@@ -301,7 +337,7 @@ class TaxonomyService:
         because "we could not ask" says nothing about whether the taxon exists.
         """
         try:
-            params = {"q": name, "per_page": 1, "locale": "en"}
+            params = {"q": name, "per_page": _LOOKUP_PAGE_SIZE, "locale": "en"}
 
             client = await self._get_client()
             resp = await client.get(self.API_URL, params=params)
@@ -321,7 +357,19 @@ class TaxonomyService:
             if not isinstance(results, list) or not results or not isinstance(results[0], dict):
                 raise ValueError("iNaturalist response has no usable result")
 
-            taxon = results[0]
+            taxon = _matching_taxon(results, name)
+            if taxon is None:
+                # The provider answered and holds nothing it agrees is this
+                # name. Saying so leaves the model's own label standing, which
+                # is the honest outcome; taking the top hit instead recorded a
+                # Goldcrest as a Ruby-crowned Kinglet.
+                log.info(
+                    "iNaturalist returned no result matching the name asked for",
+                    query=name,
+                    candidates=len(results),
+                )
+                return None
+
             scientific_name = taxon.get("name")
             taxa_id = taxon.get("id")
             if not isinstance(scientific_name, str) or not scientific_name.strip():

--- a/backend/tests/test_taxonomy_service.py
+++ b/backend/tests/test_taxonomy_service.py
@@ -220,3 +220,145 @@ async def test_lookup_inaturalist_rejects_an_inconsistent_success_payload(taxono
     with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
         with pytest.raises(TaxonomyLookupUnavailable):
             await taxonomy_service._lookup_inaturalist("Blue Tit")
+
+
+def _taxa_response(results):
+    """An iNaturalist `/v1/taxa` success payload carrying *results*."""
+    response = AsyncMock()
+    response.raise_for_status = lambda: None
+    response.json = lambda: {"total_results": len(results), "results": list(results)}
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+    return client
+
+
+def _taxon(taxa_id, name, common, matched_term, rank="species"):
+    return {
+        "id": taxa_id,
+        "name": name,
+        "preferred_common_name": common,
+        "matched_term": matched_term,
+        "rank": rank,
+        "default_photo": {"square_url": f"https://example.invalid/{taxa_id}.jpg"},
+    }
+
+
+#: Recorded from `GET /v1/taxa?q=Regulus regulus` on 2026-08-24. The first hit
+#: is a different bird on a different continent: it ranks above the exact match
+#: because `Regulus calendula` is a synonym of the far more observed
+#: Ruby-crowned Kinglet. Goldcrest, the bird actually asked about, is fourth.
+_REGULUS_REGULUS_PAGE = [
+    _taxon(1289388, "Corthylio calendula", "Ruby-crowned Kinglet", "Regulus calendula"),
+    _taxon(19660, "Regulus", "Firecrests, Goldcrests, and Allies", "Regulus", rank="genus"),
+    _taxon(117100, "Regulus satrapa", "Golden-crowned Kinglet", "Regulus satrapa"),
+    _taxon(793469, "Regulus regulus", "Goldcrest", "Regulus regulus"),
+]
+
+
+@pytest.mark.asyncio
+async def test_a_fuzzy_first_hit_that_matched_a_different_name_is_not_taken(taxonomy_service):
+    """iNaturalist's `q=` is a search, not a lookup, and its first result is
+    whatever ranks highest -- not necessarily the species asked for. Taking it
+    unchecked recorded a Goldcrest at a British feeder as a Ruby-crowned
+    Kinglet, a bird of North America.
+    """
+    client = _taxa_response(_REGULUS_REGULUS_PAGE)
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
+        result = await taxonomy_service._lookup_inaturalist("Regulus regulus")
+
+    assert result["scientific_name"] == "Regulus regulus"
+    assert result["common_name"] == "Goldcrest"
+    assert result["taxa_id"] == 793469
+
+
+@pytest.mark.asyncio
+async def test_a_query_that_is_itself_a_synonym_still_resolves_to_the_accepted_taxon(taxonomy_service):
+    """Rejecting the fuzzy hit must not reject a real rename. A model trained
+    on the older name asks for `Regulus calendula`, and that is exactly the
+    term this taxon matched on, so it is the right answer."""
+    client = _taxa_response(
+        [
+            _taxon(1289388, "Corthylio calendula", "Ruby-crowned Kinglet", "Regulus calendula"),
+            _taxon(
+                1289786,
+                "Corthylio calendula calendula",
+                "Northern Ruby-crowned Kinglet",
+                "Regulus calendula calendula",
+                rank="subspecies",
+            ),
+        ]
+    )
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
+        result = await taxonomy_service._lookup_inaturalist("Regulus calendula")
+
+    assert result["scientific_name"] == "Corthylio calendula"
+    assert result["taxa_id"] == 1289388
+
+
+@pytest.mark.asyncio
+async def test_a_common_name_query_resolves_to_the_species_not_the_genus(taxonomy_service):
+    """Recorded from `q=Ruby-crowned Kinglet`: the genus ranks first because
+    its plural common name matched. A genus is not a species, and enrichment
+    that returns one loses the bird."""
+    client = _taxa_response(
+        [
+            _taxon(1289298, "Corthylio", "Ruby-crowned Kinglets", "Ruby-crowned Kinglets", rank="genus"),
+            _taxon(1289388, "Corthylio calendula", "Ruby-crowned Kinglet", "Ruby-crowned Kinglet"),
+        ]
+    )
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
+        result = await taxonomy_service._lookup_inaturalist("Ruby-crowned Kinglet")
+
+    assert result["scientific_name"] == "Corthylio calendula"
+    assert result["taxa_id"] == 1289388
+
+
+@pytest.mark.asyncio
+async def test_an_exact_first_hit_is_still_taken(taxonomy_service):
+    client = _taxa_response(
+        [
+            _taxon(144849, "Cyanistes caeruleus", "Eurasian Blue Tit", "Cyanistes caeruleus"),
+            _taxon(
+                722264,
+                "Cyanistes caeruleus caeruleus",
+                "Common Blue Tit",
+                "Cyanistes caeruleus caeruleus",
+                rank="subspecies",
+            ),
+        ]
+    )
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
+        result = await taxonomy_service._lookup_inaturalist("Cyanistes caeruleus")
+
+    assert result["taxa_id"] == 144849
+
+
+@pytest.mark.asyncio
+async def test_a_page_holding_nothing_that_was_asked_for_reports_no_match(taxonomy_service):
+    """Better to name the bird what the model called it than to name it
+    something else. No match here leaves the model's own label standing."""
+    client = _taxa_response(
+        [
+            _taxon(19660, "Regulus", "Firecrests, Goldcrests, and Allies", "Regulus", rank="genus"),
+            _taxon(117100, "Regulus satrapa", "Golden-crowned Kinglet", "Regulus satrapa"),
+        ]
+    )
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
+        assert await taxonomy_service._lookup_inaturalist("Regulus madeirensis") is None
+
+
+@pytest.mark.asyncio
+async def test_the_lookup_asks_for_more_than_one_candidate(taxonomy_service):
+    """A single-result page cannot be checked: if the one result is wrong there
+    is nothing to fall back to."""
+    client = _taxa_response(_REGULUS_REGULUS_PAGE)
+
+    with patch.object(taxonomy_service, "_get_client", AsyncMock(return_value=client)):
+        await taxonomy_service._lookup_inaturalist("Regulus regulus")
+
+    assert client.get.await_args.kwargs["params"]["per_page"] > 1


### PR DESCRIPTION
## Outcome

A bird could be recorded as **the wrong species**, and often as a genus or subfamily rather than a species at all, because the taxonomy lookup took whatever iNaturalist ranked first without checking it was the name it had asked for.

## How it was found

Live shadow resolution on quark reported a disagreement: detection 764 stored `Corthylio calendula` / Ruby-crowned Kinglet, a North American bird, at a British feeder. The catalogue said the model's winning output was Goldcrest.

The classifier was right. `category_name` on that row is `Regulus regulus` and the recorded output index 4179 is Goldcrest in both the label file and the catalogue — verified aligned, 10,000 contiguous rows, byte-identical at every position. The name was replaced afterwards, during enrichment.

`/v1/taxa?q=` is a **search**, not a lookup. Asked for `Regulus regulus` it returns 74 results, and the first is:

```
[0] id=1289388 name='Corthylio calendula' common='Ruby-crowned Kinglet' matched_term='Regulus calendula'
[3] id=793469  name='Regulus regulus'     common='Goldcrest'            matched_term='Regulus regulus'
```

Ruby-crowned Kinglet outranks Goldcrest because `Regulus calendula` is its synonym and it is far more observed. The code requested `per_page=1` and took `results[0]`.

## Measured against the live API

45 real bird labels from the flagship model, run through the old selection and the new one:

| | |
|---|---:|
| first hit was already right | 42 |
| **first hit was a different taxon** | **3** |
| no exact match on the page | 0 |

The three, with three distinct failure modes:

- `Buteo buteo` (Common Buzzard) took **`Buteoninae`** — a subfamily
- `Clanga clanga` (Greater Spotted Eagle) took **`Clanga`** — a genus
- `Circus cyaneus` (Hen Harrier) took **`Circus hudsonius`** — a different species, split from it, on another continent

Buzzards and Hen Harriers are not exotic. About **7% of species were being misnamed or under-resolved**, and zero were over-rejected.

## The fix

Ask for a page of candidates and take only one whose `matched_term`, scientific name, or English common name is **exactly** the query.

`matched_term` is what makes this work in both directions. It rejects the fuzzy hit — for query `Regulus regulus` that taxon reports matching on `Regulus calendula`, a different bird — while still allowing a genuine rename: a model trained on the older `Regulus calendula` asks for that name, and the taxon now called `Corthylio calendula` reports matching on precisely it.

When nothing on the page is the name asked for, the lookup says so. The bundled IOC reference then answers, and it is deliberately not cached, so a later lookup can still supply a taxon id. The model's own label stands rather than a different species being written into history.

## Scope

Included: the selection in `_lookup_inaturalist`, and a `_matching_taxon` helper that is pure and directly tested.

Excluded: the one already-wrong row on the live install is not repaired here — that is user data and a separate decision. The other `results[0]` uses in the codebase were checked and are score-sorted classifier output, not external search results.

## Checks

Six new tests, all built from **recorded real payloads** rather than invented ones, covering the fuzzy hit, the genuine synonym, the genus-outranks-species case, an exact first hit, no match on the page, and that more than one candidate is requested.

2,446 backend tests pass, `ruff check .` and `ruff format --check .` clean repo-wide, docs consistency check passes.