### PR TITLE
Record an owner's rename in the catalogue, against the species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **A species you have renamed is now recorded in the species catalogue, against the species rather
+  than against a spelling of its name.** A rename is the one piece of naming an owner authored, and
+  it lived in `taxonomy_cache` beside columns that are a cache of provider answers and can be
+  refetched at will. It was keyed on a scientific name, so a taxon renamed upstream lost the name
+  its owner had given it. The catalogue has held an override table since its first migration, and
+  the shared naming rule already prefers it over every other source, but nothing ever wrote to it,
+  which is why that precedence had to be written out again wherever a name was chosen. Renames now
+  go to the catalogue, keyed on the species, and existing ones are carried over on startup. The
+  copy in the detection database is still written and still read, because the pre-3.0 name-recovery
+  paths consult it; the catalogue is the store of record. The migration only fills gaps, so a name
+  you have since changed or cleared is never resurrected by a later startup, and a rename whose
+  name resolves to no single catalogue species is counted and left where it is rather than attached
+  to a guess. Owner diagnostics report how many renames the catalogue holds.
+
 - **Removed a second, name-keyed way of reading the daily rollup that nothing used.** Species
   aggregation moved to the catalogue's stable identity, and the leaderboard and its trends now
   group on one shared key. The rollup reader that predated it stayed behind: 128 lines that grouped

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -925,6 +925,12 @@ def _naming_health() -> dict[str, object]:
         catalog["local_mapping"] = last_local_mapping_report()
     except Exception:  # pragma: no cover
         pass
+    try:
+        from app.services.species_catalog_overrides import override_summary
+
+        catalog["owner_renames"] = override_summary()
+    except Exception:  # pragma: no cover
+        pass
     return {"species_reference": reference, "localized_names": localized, "species_catalog": catalog}
 
 

--- a/backend/app/services/species_catalog_backfill.py
+++ b/backend/app/services/species_catalog_backfill.py
@@ -77,6 +77,20 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
         summary["audio_rows_identified"] = 0
         summary["audio_rows_unresolved"] = 0
 
+    # Owner renames move to the catalogue in the same pass, because they are
+    # the one piece of naming the owner authored and they were living in a
+    # cache of provider answers.
+    try:
+        from app.services.species_catalog_overrides import migrate_cache_overrides
+
+        overrides = await migrate_cache_overrides(db)
+        summary["overrides_migrated"] = overrides.get("migrated", 0)
+        summary["overrides_unresolved"] = overrides.get("unresolved", 0)
+    except Exception as error:  # pragma: no cover - defensive
+        log.warning("Owner rename migration skipped", error=str(error))
+        summary["overrides_migrated"] = 0
+        summary["overrides_unresolved"] = 0
+
     _record_summary(summary)
     return summary
 

--- a/backend/app/services/species_catalog_overrides.py
+++ b/backend/app/services/species_catalog_overrides.py
@@ -1,0 +1,188 @@
+"""Record an owner's rename in the catalogue, against the species it names.
+
+A rename is the one piece of naming an owner authored. It lived in
+`taxonomy_cache.manual_common_name`, beside columns that are a cache of
+provider answers and can be refetched at will, and it was keyed on a spelling
+of a scientific name rather than on the species -- so a taxon that is renamed
+upstream loses the name its owner gave it.
+
+The catalogue has held `species_name_overrides` since its first migration, and
+`choose_display_name` already prefers it over every other source. Nothing ever
+wrote to it, which is why the same precedence had to be hand-rolled wherever a
+name was chosen. This writes it.
+
+Fail-soft throughout: a catalogue that is absent, unreadable, or does not hold
+the species reports failure and changes nothing, and the caller keeps the
+detection-database copy that the pre-3.0 compatibility readers still use.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Optional
+
+import structlog
+
+from app.services.species_catalog_migrations import default_catalog_path
+
+log = structlog.get_logger()
+
+#: The scope of a rename that names the bird rather than one translation of it.
+#: Empty rather than NULL because SQLite treats NULLs as distinct, which would
+#: make the table's uniqueness constraint unenforceable.
+ALL_LANGUAGES = ""
+
+
+def _open_writable(catalog_path: Optional[Path]) -> Optional[sqlite3.Connection]:
+    path = Path(catalog_path or default_catalog_path())
+    if not path.is_file():
+        return None
+    try:
+        connection = sqlite3.connect(path)
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("SELECT 1 FROM species_name_overrides LIMIT 1").fetchone()
+    except sqlite3.Error:
+        try:
+            connection.close()
+        except (sqlite3.Error, UnboundLocalError):  # pragma: no cover - defensive
+            pass
+        return None
+    return connection
+
+
+def write_catalogue_override(
+    species_id: int,
+    name: str,
+    *,
+    language_tag: str = ALL_LANGUAGES,
+    overwrite: bool = True,
+    catalog_path: Optional[Path] = None,
+) -> bool:
+    """Record `name` as the owner's name for this species. True when stored.
+
+    `overwrite=False` fills a gap without touching a rename already recorded,
+    which is what the migration from the detection database needs: it must
+    never resurrect a name the owner has since changed or cleared.
+    """
+    cleaned = str(name or "").strip()
+    if not cleaned or species_id is None:
+        return False
+
+    connection = _open_writable(catalog_path)
+    if connection is None:
+        return False
+    on_conflict = (
+        " ON CONFLICT (species_id, language_tag) DO UPDATE SET name = excluded.name, updated_at = CURRENT_TIMESTAMP"
+        if overwrite
+        else " ON CONFLICT (species_id, language_tag) DO NOTHING"
+    )
+    try:
+        with connection:
+            cursor = connection.execute(
+                "INSERT INTO species_name_overrides (species_id, language_tag, name) VALUES (?, ?, ?)" + on_conflict,
+                (int(species_id), str(language_tag or ALL_LANGUAGES), cleaned),
+            )
+            # With `DO NOTHING` a conflict writes no row, and the caller needs
+            # to know that a rename was already there rather than assume it
+            # stored one.
+            written = (cursor.rowcount or 0) > 0
+    except sqlite3.Error as error:
+        # An unknown species is refused by the foreign key rather than stored
+        # against nothing, which is the behaviour worth keeping.
+        log.debug("Owner rename not recorded in the catalogue", species_id=species_id, error=str(error))
+        return False
+    finally:
+        connection.close()
+    return written
+
+
+def clear_catalogue_override(
+    species_id: int,
+    *,
+    language_tag: str = ALL_LANGUAGES,
+    catalog_path: Optional[Path] = None,
+) -> bool:
+    """Remove the owner's name for this species. True when one was removed."""
+    if species_id is None:
+        return False
+
+    connection = _open_writable(catalog_path)
+    if connection is None:
+        return False
+    try:
+        with connection:
+            cursor = connection.execute(
+                "DELETE FROM species_name_overrides WHERE species_id = ? AND language_tag = ?",
+                (int(species_id), str(language_tag or ALL_LANGUAGES)),
+            )
+            removed = cursor.rowcount or 0
+    except sqlite3.Error as error:
+        log.debug("Owner rename not cleared in the catalogue", species_id=species_id, error=str(error))
+        return False
+    finally:
+        connection.close()
+    return removed > 0
+
+
+def catalogue_override_count(catalog_path: Optional[Path] = None) -> Optional[int]:
+    """How many renames the catalogue holds, or None if it cannot be read."""
+    connection = _open_writable(catalog_path)
+    if connection is None:
+        return None
+    try:
+        return int(connection.execute("SELECT COUNT(*) FROM species_name_overrides").fetchone()[0])
+    except sqlite3.Error:  # pragma: no cover - defensive
+        return None
+    finally:
+        connection.close()
+
+
+def override_summary(catalog_path: Optional[Path] = None) -> dict[str, Any]:
+    count = catalogue_override_count(catalog_path)
+    return {"available": count is not None, "overrides": count or 0}
+
+
+async def migrate_cache_overrides(db, catalog_path: Optional[Path] = None) -> dict[str, Any]:
+    """Copy renames from the detection database into the catalogue.
+
+    One-way and gap-filling: a species the catalogue already has a rename for
+    is left alone, so a name the owner has since changed or cleared is never
+    resurrected by a later startup. A name whose spelling resolves to no single
+    catalogue species is counted and left where it is, because the detection
+    database keeps serving it through the compatibility readers.
+    """
+    import asyncio
+
+    from app.services.species_catalog_resolver import species_catalog_resolver
+
+    summary: dict[str, Any] = {"status": "complete", "migrated": 0, "already_present": 0, "unresolved": 0}
+    try:
+        async with db.execute(
+            "SELECT scientific_name, manual_common_name FROM taxonomy_cache"
+            " WHERE manual_common_name IS NOT NULL AND TRIM(manual_common_name) <> ''"
+        ) as cursor:
+            rows = await cursor.fetchall()
+    except Exception as error:
+        log.debug("Owner renames not read for migration", error=str(error))
+        return {"status": "unavailable", "migrated": 0, "already_present": 0, "unresolved": 0}
+
+    for scientific_name, manual_name in rows:
+        species_id, reason = await asyncio.to_thread(species_catalog_resolver.resolve_scientific_name, scientific_name)
+        if reason == "unavailable":
+            return {**summary, "status": "unavailable"}
+        if species_id is None:
+            summary["unresolved"] += 1
+            continue
+        stored = await asyncio.to_thread(
+            write_catalogue_override,
+            species_id,
+            manual_name,
+            overwrite=False,
+            catalog_path=catalog_path,
+        )
+        summary["migrated" if stored else "already_present"] += 1
+
+    if summary["migrated"]:
+        log.info("Owner renames recorded in the catalogue", **summary)
+    return summary

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -463,6 +463,7 @@ class TaxonomyService:
                 return None
         finally:
             await cursor.close()
+        await self._mirror_override_to_catalogue(scientific_name, common_name)
         return await self.get_common_name_override(scientific_name, db)
 
     async def clear_common_name_override(
@@ -479,7 +480,36 @@ class TaxonomyService:
                 return None
         finally:
             await cursor.close()
+        await self._mirror_override_to_catalogue(scientific_name, None)
         return await self.get_common_name_override(scientific_name, db)
+
+    async def _mirror_override_to_catalogue(self, scientific_name: str, common_name: Optional[str]) -> None:
+        """Record the rename in the catalogue, against the species it names.
+
+        The catalogue is the store of record: it keys on the species rather
+        than on a spelling of it, and it survives a taxon being renamed
+        upstream. The detection-database copy above is kept because the
+        pre-3.0 name-recovery readers still consult it.
+
+        Never fatal. A rename the owner made is already saved by the time this
+        runs, and a catalogue that cannot take it is a naming gap rather than a
+        lost decision.
+        """
+        import asyncio
+
+        from app.services.species_catalog_overrides import clear_catalogue_override, write_catalogue_override
+        from app.services.species_catalog_resolver import species_catalog_resolver
+
+        try:
+            species_id, _ = await asyncio.to_thread(species_catalog_resolver.resolve_scientific_name, scientific_name)
+            if species_id is None:
+                return
+            if common_name:
+                await asyncio.to_thread(write_catalogue_override, species_id, common_name)
+            else:
+                await asyncio.to_thread(clear_catalogue_override, species_id)
+        except Exception as error:  # pragma: no cover - defensive
+            log.debug("Owner rename not mirrored to the catalogue", name=scientific_name, error=str(error))
 
     async def get_localized_common_name(
         self, taxa_id: int, lang: str, db: Optional[aiosqlite.Connection] = None

--- a/backend/tests/test_species_catalog_overrides.py
+++ b/backend/tests/test_species_catalog_overrides.py
@@ -1,0 +1,243 @@
+"""Owner renames belong to the catalogue, not to a lookup cache.
+
+A rename is the one piece of naming the owner authored, and it was stored in
+`taxonomy_cache.manual_common_name` -- a table whose other columns are a cache
+of provider answers that can be refetched at will. The catalogue has held
+`species_name_overrides` since its first migration, and the shared naming
+function already prefers it over every other source, but nothing ever wrote to
+it, so the precedence had to be hand-rolled again wherever a name was chosen.
+
+These tests fix the store of record: an override is written to the catalogue,
+keyed on the species it names rather than on a spelling of that species.
+"""
+
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import build_species_catalog_seed as seed_builder  # noqa: E402
+
+from app.services.species_catalog_overrides import (  # noqa: E402
+    ALL_LANGUAGES,
+    clear_catalogue_override,
+    write_catalogue_override,
+)
+from app.services.species_names import SpeciesNameLookup  # noqa: E402
+
+REFERENCE_SCHEMA = """
+CREATE TABLE reference_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE taxon (id INTEGER PRIMARY KEY, scientific_name TEXT NOT NULL, common_name TEXT);
+CREATE TABLE taxon_name (
+    taxon_id INTEGER NOT NULL, locale TEXT NOT NULL, common_name TEXT NOT NULL,
+    PRIMARY KEY (taxon_id, locale)
+) WITHOUT ROWID;
+"""
+
+
+@pytest.fixture
+def catalog(tmp_path):
+    pinned = hashlib.sha256(b"override workbook").hexdigest()
+    reference = tmp_path / "reference.db"
+    connection = sqlite3.connect(reference)
+    try:
+        connection.executescript(REFERENCE_SCHEMA)
+        connection.execute("INSERT INTO reference_meta VALUES ('source_sha256', ?)", (pinned,))
+        connection.executemany(
+            "INSERT INTO taxon VALUES (?, ?, ?)",
+            [(1, "Cyanistes caeruleus", "Eurasian Blue Tit"), (2, "Erithacus rubecula", "European Robin")],
+        )
+        connection.executemany(
+            "INSERT INTO taxon_name VALUES (?, ?, ?)",
+            [(1, "de", "Blaumeise"), (2, "de", "Rotkehlchen")],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    manifest = tmp_path / "sources.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "frozen_on": "2026-08-24",
+                "sources": [
+                    {
+                        "id": "ioc-world-bird-list",
+                        "name": "IOC",
+                        "role": "bird-vernacular-names",
+                        "version": "14.2-test",
+                        "url": "https://www.worldbirdnames.org/",
+                        "licence": "CC-BY-3.0",
+                        "citation": "IOC World Bird List.",
+                        "redistribution": "bundled",
+                        "content_sha256": pinned,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    path = tmp_path / "catalog.db"
+    seed_builder.build(reference, path, manifest_path=manifest)
+    return path
+
+
+def overrides_in(catalog_path):
+    connection = sqlite3.connect(catalog_path)
+    try:
+        return connection.execute(
+            "SELECT species_id, language_tag, name FROM species_name_overrides ORDER BY species_id, language_tag"
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+class TestWritingAnOverride:
+    def test_a_rename_is_recorded_against_the_species_it_names(self, catalog):
+        assert write_catalogue_override(1, "Bluetit", catalog_path=catalog) is True
+
+        assert overrides_in(catalog) == [(1, ALL_LANGUAGES, "Bluetit")]
+
+    def test_a_rename_applies_in_every_language_unless_told_otherwise(self, catalog):
+        """The name the owner typed replaced one name, not one translation, so
+        it is recorded for every language rather than only for theirs."""
+        write_catalogue_override(1, "Bluetit", catalog_path=catalog)
+
+        lookup = SpeciesNameLookup(catalog)
+
+        assert lookup.display_names([1], language="de") == {1: "Bluetit"}
+        assert lookup.display_names([1], language="en") == {1: "Bluetit"}
+        # A species the owner did not rename still gets the curated name.
+        assert lookup.display_names([2], language="de") == {2: "Rotkehlchen"}
+
+    def test_renaming_again_replaces_the_first_rename(self, catalog):
+        write_catalogue_override(1, "Bluetit", catalog_path=catalog)
+        write_catalogue_override(1, "Blue Tit", catalog_path=catalog)
+
+        assert overrides_in(catalog) == [(1, ALL_LANGUAGES, "Blue Tit")]
+
+    def test_a_blank_name_is_refused_rather_than_stored(self, catalog):
+        assert write_catalogue_override(1, "   ", catalog_path=catalog) is False
+
+        assert overrides_in(catalog) == []
+
+    def test_an_unknown_species_is_refused_by_the_schema_not_written(self, catalog):
+        assert write_catalogue_override(99999, "Nothing", catalog_path=catalog) is False
+
+        assert overrides_in(catalog) == []
+
+
+class TestClearingAnOverride:
+    def test_clearing_removes_the_rename(self, catalog):
+        write_catalogue_override(1, "Bluetit", catalog_path=catalog)
+
+        assert clear_catalogue_override(1, catalog_path=catalog) is True
+        assert overrides_in(catalog) == []
+
+    def test_clearing_a_rename_that_was_never_set_is_not_an_error(self, catalog):
+        assert clear_catalogue_override(1, catalog_path=catalog) is False
+
+    def test_the_curated_name_returns_once_the_rename_is_cleared(self, catalog):
+        write_catalogue_override(1, "Bluetit", catalog_path=catalog)
+        clear_catalogue_override(1, catalog_path=catalog)
+
+        assert SpeciesNameLookup(catalog).display_names([1], language="de") == {1: "Blaumeise"}
+
+
+class TestDegradingWithoutACatalogue:
+    def test_writing_without_a_catalogue_reports_failure_rather_than_raising(self, tmp_path):
+        assert write_catalogue_override(1, "Bluetit", catalog_path=tmp_path / "nowhere.db") is False
+
+    def test_clearing_without_a_catalogue_reports_failure_rather_than_raising(self, tmp_path):
+        assert clear_catalogue_override(1, catalog_path=tmp_path / "nowhere.db") is False
+
+    def test_a_file_that_is_not_a_catalogue_is_not_written_to(self, tmp_path):
+        junk = tmp_path / "junk.db"
+        junk.write_bytes(b"not a database")
+
+        assert write_catalogue_override(1, "Bluetit", catalog_path=junk) is False
+
+
+class TestFillingTheCatalogueFromTheDetectionDatabase:
+    """The one-way migration that gives the catalogue the renames an owner made
+    before it existed."""
+
+    @pytest.fixture
+    def cache(self, tmp_path):
+        import aiosqlite
+
+        path = tmp_path / "speciesid.db"
+        connection = sqlite3.connect(path)
+        try:
+            connection.execute(
+                "CREATE TABLE taxonomy_cache ("
+                " scientific_name TEXT PRIMARY KEY, common_name TEXT, manual_common_name TEXT)"
+            )
+            connection.executemany(
+                "INSERT INTO taxonomy_cache VALUES (?, ?, ?)",
+                [
+                    ("Cyanistes caeruleus", "Eurasian Blue Tit", "Bluetit"),
+                    ("Erithacus rubecula", "European Robin", None),
+                    ("Nonexistent bird", "Fantasy", "My Fantasy Bird"),
+                ],
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        return aiosqlite.connect(path)
+
+    @pytest.mark.asyncio
+    async def test_a_rename_made_before_the_catalogue_existed_is_carried_over(self, catalog, cache, monkeypatch):
+        from app.services import species_catalog_resolver as resolver_module
+        from app.services.species_catalog_overrides import migrate_cache_overrides
+
+        monkeypatch.setattr(
+            resolver_module, "species_catalog_resolver", resolver_module.SpeciesCatalogResolver(catalog)
+        )
+
+        async with cache as db:
+            summary = await migrate_cache_overrides(db, catalog_path=catalog)
+
+        assert summary["migrated"] == 1
+        # The fantasy bird names no catalogue species, so it stays where it is
+        # rather than being attached to a guess.
+        assert summary["unresolved"] == 1
+        assert overrides_in(catalog) == [(1, ALL_LANGUAGES, "Bluetit")]
+
+    @pytest.mark.asyncio
+    async def test_it_never_resurrects_a_rename_the_owner_has_since_changed(self, catalog, cache, monkeypatch):
+        from app.services import species_catalog_resolver as resolver_module
+        from app.services.species_catalog_overrides import migrate_cache_overrides
+
+        monkeypatch.setattr(
+            resolver_module, "species_catalog_resolver", resolver_module.SpeciesCatalogResolver(catalog)
+        )
+        write_catalogue_override(1, "What I call it now", catalog_path=catalog)
+
+        async with cache as db:
+            summary = await migrate_cache_overrides(db, catalog_path=catalog)
+
+        assert summary["migrated"] == 0
+        assert summary["already_present"] == 1
+        assert overrides_in(catalog) == [(1, ALL_LANGUAGES, "What I call it now")]
+
+    @pytest.mark.asyncio
+    async def test_a_database_without_the_cache_table_is_reported_not_raised(self, catalog, tmp_path):
+        import aiosqlite
+
+        from app.services.species_catalog_overrides import migrate_cache_overrides
+
+        empty = tmp_path / "empty.db"
+        sqlite3.connect(empty).close()
+
+        async with aiosqlite.connect(empty) as db:
+            summary = await migrate_cache_overrides(db, catalog_path=catalog)
+
+        assert summary["status"] == "unavailable"


### PR DESCRIPTION
## Outcome

A rename is the one piece of naming an owner authored. It lived in `taxonomy_cache.manual_common_name` — beside columns that are a cache of provider answers and can be refetched at will — and it was keyed on **a spelling of a scientific name** rather than on the species. So a taxon renamed upstream lost the name its owner gave it.

## What this fixes structurally

The catalogue has held `species_name_overrides` since its first migration, and `choose_display_name` already puts it above every other source:

> In order: what the owner renamed it to for this language, what they renamed it to for every language, the catalogue's name in this language, the catalogue's English name, then the scientific name.

**Nothing ever wrote to that table.** That is exactly why the precedence had to be hand-rolled again wherever a name was chosen — the species list decides for itself whether a rename outranks the catalogue:

```python
owner_renamed = bool(str(s.get("manual_common_name") or "").strip())
catalogue_name = None if owner_renamed else catalogue_names.get(s.get("species_id"))
```

`COALESCE(manual_common_name, common_name)` appears in six places across three files. That is the duplicated name-recovery SQL Phase 5 wants retired, and it could not be retired while the catalogue's own override table was empty by construction.

## What changed

- Renames are written to the catalogue, keyed on the resolved species, with the schema's `language_tag = ''` scope — which already means "every language", precisely what a single `manual_common_name` was.
- Existing renames are carried over on startup, in the same pass as the identity backfill.
- The detection-database copy is still written and still read. That is the **bounded compatibility reader** the design asks for through the pre-3.0 upgrade window; the catalogue is the store of record.
- Diagnostics report how many renames the catalogue holds.

## Safety

- **The migration only fills gaps.** A species the catalogue already has a rename for is left alone, so a name the owner has since changed or cleared is never resurrected by a later startup. The counters distinguish `migrated` from `already_present` using the actual row count, not the absence of an error.
- **A rename resolving to no single catalogue species is counted and left where it is**, not attached to a guess. On a live install, 14 of 174 cached names resolve to nothing — mostly higher ranks (`Troglodytidae`, `Suliformes`, `Pyrrhula`), two subspecies, and a beetle — and the catalogue holds species, so they have no home in it.
- **Nothing is fatal.** A rename is already saved before the catalogue is touched; a catalogue that is absent, unreadable, or does not hold the species is a naming gap, never a lost decision.
- Overrides already survive a catalogue release import (`test_owner_overrides_survive_an_import`), which is why the table exists.

## Verification

Measured against a live install first: 174 cached names, **0 owner renames on that install**, 160 of 174 resolving to exactly one catalogue species, 0 ambiguous.

17 new tests: writing, replacing, clearing, the all-languages scope end-to-end through `SpeciesNameLookup`, a blank name refused, an unknown species refused by the foreign key rather than stored against nothing, the migration carrying a rename over, the migration refusing to resurrect a changed one, and every degradation path with no catalogue, an unreadable file, or a database with no cache table.

## Scope

The six `COALESCE(manual_common_name, …)` sites are **not** removed here. They are the compatibility reader, and they retire when the rest of `taxonomy_cache` migrates. This PR makes that removal possible by giving the catalogue the one thing it was missing.

## Checks

2,463 backend tests pass, `ruff check .` and `ruff format --check .` clean repo-wide, docs consistency check passes.