### PR TITLE
Let a published mapping replace one this install derived for itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   owner diagnostics under `species_catalog.local_mapping`. A registry model is skipped outright so
   a mapping derived from a file on disk can never stand in for a reviewed one, an artifact the
   catalogue already holds is never overwritten, and these labels are never served back as
-  catalogue-verified — they came from the label file this work exists to stop trusting.
+  catalogue-verified — they came from the label file this work exists to stop trusting. If that
+  model is later published, the reviewed mapping replaces the derived one: a mapping compiled from
+  a file on disk was never authoritative, and refusing the release because it disagreed with one
+  would block every future catalogue update for that owner.
 
 - **Audio detections carry catalogue identity.** Audio correlation was the last read path keyed on
   name text, so a bird heard and a bird seen were joined by a string. BirdNET-Go reports a

--- a/backend/app/services/species_catalog_importer.py
+++ b/backend/app/services/species_catalog_importer.py
@@ -27,6 +27,8 @@ import structlog
 from app.services.species_catalog_migrations import catalog_migration_heads, default_catalog_path
 from app.services.species_catalog_release import release_content_digest
 
+from app.services.species_catalog_compatibility import LOCAL_REGISTRY_PREFIX
+
 log = structlog.get_logger()
 
 
@@ -204,6 +206,13 @@ def _identity_gains(
     class kind moving between anything else. Those are corrections, and a
     correction needs a deliberate supersession rather than a quiet arrival.
     """
+    # An index the catalogue holds and the mapping no longer describes means
+    # the mapping shrank. Recording that mapping's digest while keeping rows it
+    # does not contain would have the catalogue claim a mapping it does not
+    # hold, so it is a difference like any other.
+    if set(held) - {int(row["output_index"]) for row in incoming}:
+        return None
+
     gains: list[tuple[int, int]] = []
     for row in incoming:
         index = int(row["output_index"])
@@ -289,10 +298,17 @@ def _complete_registered_mappings(live: sqlite3.Connection, bundle: "_Bundle") -
         added += complete_artifact_mapping(
             live,
             artifact_row_id=int(row["id"]),
+            # Only rows that carry no identity. This repair runs before any
+            # species mapping is built, so a bundle's species number cannot be
+            # translated to a live one here, and writing it raw would bind an
+            # output to whichever species happens to hold that number in this
+            # catalogue. The rows this exists to restore are exactly the ones
+            # with no identity: outputs nothing could resolve, counted in the
+            # mapping digest but filtered out before they were stored.
             bundle_rows=[
                 output
                 for output in bundle.model_outputs
-                if str(output["artifact_sha256"]) == str(artifact["model_sha256"])
+                if str(output["artifact_sha256"]) == str(artifact["model_sha256"]) and output["species_id"] is None
             ],
         )
     return added
@@ -422,13 +438,30 @@ def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> Im
             outputs_added = 0
             for artifact in bundle.model_artifacts:
                 existing_artifact = live.execute(
-                    "SELECT id, mapping_set_sha256 FROM model_artifacts WHERE model_sha256 = ?",
+                    "SELECT id, mapping_set_sha256, registry_id FROM model_artifacts WHERE model_sha256 = ?",
                     (artifact["model_sha256"],),
                 ).fetchone()
                 if existing_artifact:
                     artifact_row_id = int(existing_artifact["id"])
                     incoming = _mapped_outputs(outputs_by_artifact.get(artifact["model_sha256"], []), id_map)
-                    if existing_artifact["mapping_set_sha256"] != artifact["mapping_set_sha256"]:
+                    locally_derived = str(existing_artifact["registry_id"] or "").startswith(LOCAL_REGISTRY_PREFIX)
+                    if locally_derived:
+                        # This install derived a mapping for a model nobody had
+                        # published, from that model's own labels. A published
+                        # mapping is reviewed and outranks it outright. Refusing
+                        # the release because it disagrees with a local guess
+                        # would block every future catalogue update for this
+                        # owner, which is a far worse failure than replacing a
+                        # mapping that was never authoritative.
+                        log.info(
+                            "Replacing a locally derived mapping with the published one",
+                            model_sha256=artifact["model_sha256"],
+                            was=existing_artifact["registry_id"],
+                        )
+                        live.execute("DELETE FROM model_output_taxa WHERE model_artifact_id = ?", (artifact_row_id,))
+                        live.execute("DELETE FROM model_artifacts WHERE id = ?", (artifact_row_id,))
+                        existing_artifact = None
+                    elif existing_artifact["mapping_set_sha256"] != artifact["mapping_set_sha256"]:
                         # The artifact checksum owns its mapping, so a
                         # same-checksum artifact arriving with a different one
                         # fails the whole import closed per §1 -- unless the
@@ -466,16 +499,17 @@ def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> Im
                                 model_sha256=artifact["model_sha256"],
                                 outputs_named=len(gains),
                             )
-                    # Any row the live catalogue lacks is absent rather than
-                    # different. It can hold fewer rows than its own digest
-                    # describes, because outputs nothing could resolve were
-                    # counted in the digest but not stored.
-                    outputs_added += complete_artifact_mapping(
-                        live,
-                        artifact_row_id=artifact_row_id,
-                        bundle_rows=incoming,
-                    )
-                    continue
+                    if existing_artifact is not None:
+                        # Any row the live catalogue lacks is absent rather
+                        # than different. It can hold fewer rows than its own
+                        # digest describes, because outputs nothing could
+                        # resolve were counted in the digest but not stored.
+                        outputs_added += complete_artifact_mapping(
+                            live,
+                            artifact_row_id=artifact_row_id,
+                            bundle_rows=incoming,
+                        )
+                        continue
                 cursor = live.execute(
                     "INSERT INTO model_artifacts"
                     " (registry_id, model_sha256, mapping_set_sha256, output_width, runtime, model_version, state)"

--- a/backend/app/services/species_catalog_overrides.py
+++ b/backend/app/services/species_catalog_overrides.py
@@ -34,19 +34,29 @@ log = structlog.get_logger()
 ALL_LANGUAGES = ""
 
 
-def _open_writable(catalog_path: Optional[Path]) -> Optional[sqlite3.Connection]:
+def _open(catalog_path: Optional[Path], *, writable: bool) -> Optional[sqlite3.Connection]:
+    """A catalogue connection that holds the override table, or None.
+
+    Reads ask for a read-only handle rather than a write-capable one they do
+    not need: the health surface counts renames on every poll, and taking a
+    writable handle there would contend with an import and would fail outright
+    on a catalogue mounted read-only, reporting nothing available when the data
+    reads perfectly well.
+    """
     path = Path(catalog_path or default_catalog_path())
     if not path.is_file():
         return None
+    connection: Optional[sqlite3.Connection] = None
     try:
-        connection = sqlite3.connect(path)
-        connection.execute("PRAGMA foreign_keys = ON")
+        if writable:
+            connection = sqlite3.connect(path)
+            connection.execute("PRAGMA foreign_keys = ON")
+        else:
+            connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
         connection.execute("SELECT 1 FROM species_name_overrides LIMIT 1").fetchone()
     except sqlite3.Error:
-        try:
+        if connection is not None:
             connection.close()
-        except (sqlite3.Error, UnboundLocalError):  # pragma: no cover - defensive
-            pass
         return None
     return connection
 
@@ -69,7 +79,7 @@ def write_catalogue_override(
     if not cleaned or species_id is None:
         return False
 
-    connection = _open_writable(catalog_path)
+    connection = _open(catalog_path, writable=True)
     if connection is None:
         return False
     on_conflict = (
@@ -107,7 +117,7 @@ def clear_catalogue_override(
     if species_id is None:
         return False
 
-    connection = _open_writable(catalog_path)
+    connection = _open(catalog_path, writable=True)
     if connection is None:
         return False
     try:
@@ -127,7 +137,7 @@ def clear_catalogue_override(
 
 def catalogue_override_count(catalog_path: Optional[Path] = None) -> Optional[int]:
     """How many renames the catalogue holds, or None if it cannot be read."""
-    connection = _open_writable(catalog_path)
+    connection = _open(catalog_path, writable=False)
     if connection is None:
         return None
     try:

--- a/backend/tests/test_species_catalog_importer.py
+++ b/backend/tests/test_species_catalog_importer.py
@@ -430,7 +430,9 @@ def _build_mapped_seed(tmp_path, output_name, *, label):
     return path
 
 
-def _build_two_output_seed(tmp_path, output_name, *, second_resolved, second_label="European robin"):
+def _build_two_output_seed(
+    tmp_path, output_name, *, second_resolved, second_label="European robin", second_present=True
+):
     """Two seeds sharing one artifact checksum, differing only in whether the
     second output resolved to a catalogue identity."""
     import json as json_module
@@ -462,7 +464,7 @@ def _build_two_output_seed(tmp_path, output_name, *, second_resolved, second_lab
                 "label_files": {
                     "labelsha-supersession": {
                         "label_format": "common_name",
-                        "output_width": 2,
+                        "output_width": 2 if second_present else 1,
                         "outputs": [
                             {
                                 "index": 0,
@@ -471,7 +473,7 @@ def _build_two_output_seed(tmp_path, output_name, *, second_resolved, second_lab
                                 "provider": "ioc-world-bird-list",
                                 "taxon": "Cyanistes caeruleus",
                             },
-                            second,
+                            *([second] if second_present else []),
                         ],
                     }
                 },
@@ -556,3 +558,98 @@ def test_an_output_whose_label_changed_is_refused(tmp_path):
         import_release(bundle, catalog_path=live)
 
     assert _outputs(live) == before
+
+
+def _artifact_row(catalog_path):
+    connection = sqlite3.connect(catalog_path)
+    try:
+        return connection.execute(
+            "SELECT registry_id, mapping_set_sha256, output_width FROM model_artifacts"
+        ).fetchone()
+    finally:
+        connection.close()
+
+
+def _register_local_artifact(catalog_path, *, model_sha256, labels):
+    """Stand in for a model the owner installed themselves, mapped by the
+    compatibility importer rather than by a release."""
+    from app.services.species_catalog_compatibility import import_local_model_mapping
+
+    return import_local_model_mapping(
+        model_id="owner_model",
+        model_sha256=model_sha256,
+        labels=labels,
+        runtime="onnx",
+        catalog_path=catalog_path,
+    )
+
+
+def test_a_published_mapping_replaces_one_this_install_derived_for_itself(tmp_path):
+    """A model the owner sideloaded gets a mapping derived from its own labels.
+    If that model is later published, the reviewed mapping has to be able to
+    land: refusing it because it disagrees with a locally derived guess would
+    block every future catalogue release for that owner.
+    """
+    live = _build_two_output_seed(tmp_path, "local_live.db", second_resolved=False)
+    connection = sqlite3.connect(live)
+    try:
+        connection.execute("DELETE FROM model_output_taxa")
+        connection.execute("DELETE FROM model_artifacts")
+        connection.commit()
+    finally:
+        connection.close()
+
+    report = _register_local_artifact(live, model_sha256="d" * 64, labels=["Eurasian Blue Tit", "European Robin"])
+    assert report.verdict == "imported"
+    assert _artifact_row(live)[0].startswith("local:")
+
+    bundle = _build_two_output_seed(tmp_path, "local_bundle.db", second_resolved=True)
+    result = import_release(bundle, catalog_path=live)
+
+    assert result.status == "imported"
+    registry_id, _, _ = _artifact_row(live)
+    # The reviewed mapping now owns the artifact, under its published id.
+    assert registry_id == "supersession_model"
+    assert [row[3] for row in _outputs(live)] == ["Eurasian blue tit", "European robin"]
+
+
+def test_a_mapping_that_drops_outputs_is_refused(tmp_path):
+    """Fewer outputs for the same model checksum is a build defect. Accepting
+    it would leave rows the mapping no longer describes while recording that
+    mapping's digest, so the catalogue would claim a mapping it does not hold.
+    """
+    live = _build_two_output_seed(tmp_path, "shrink_live.db", second_resolved=True)
+    bundle = _build_two_output_seed(tmp_path, "shrink_bundle.db", second_resolved=True, second_present=False)
+    before = _outputs(live)
+    assert len(before) == 2
+
+    with pytest.raises(CatalogImportError, match="different mapping set"):
+        import_release(bundle, catalog_path=live)
+
+    assert _outputs(live) == before
+
+
+def test_repairing_an_already_imported_release_never_writes_a_bundle_species_number(tmp_path):
+    """The repair runs before any species mapping is built, so a bundle's own
+    species numbering cannot be translated. Restoring a row that carries one
+    would bind the output to whichever species holds that number here."""
+    # The same release on both sides, so the import takes the already-imported
+    # repair path. Output 0 carries an identity, output 1 does not.
+    live = _build_two_output_seed(tmp_path, "repair_live.db", second_resolved=False)
+    bundle = _build_two_output_seed(tmp_path, "repair_bundle.db", second_resolved=False)
+
+    connection = sqlite3.connect(live)
+    try:
+        connection.execute("DELETE FROM model_output_taxa")
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = import_release(bundle, catalog_path=live)
+    assert result.status == "already_imported"
+
+    restored = _outputs(live)
+    # Only the identity-free row comes back; the one carrying a species number
+    # is left for a real import to place.
+    assert [row[0] for row in restored] == [1]
+    assert restored[0][1:3] == ("unknown", None)

--- a/backend/tests/test_species_catalog_overrides.py
+++ b/backend/tests/test_species_catalog_overrides.py
@@ -241,3 +241,23 @@ class TestFillingTheCatalogueFromTheDetectionDatabase:
             summary = await migrate_cache_overrides(db, catalog_path=catalog)
 
         assert summary["status"] == "unavailable"
+
+
+class TestNotAskingForMoreAccessThanIsNeeded:
+    def test_renames_can_be_counted_on_a_read_only_catalogue(self, catalog):
+        """Diagnostics count renames on every health poll. Taking a writable
+        handle there would report nothing available on a catalogue mounted
+        read-only, when the data reads perfectly well."""
+        import os
+        import stat
+
+        from app.services.species_catalog_overrides import catalogue_override_count
+
+        write_catalogue_override(1, "Bluetit", catalog_path=catalog)
+        os.chmod(catalog, stat.S_IRUSR)
+        try:
+            assert catalogue_override_count(catalog) == 1
+            # And a write against it fails rather than raising.
+            assert write_catalogue_override(2, "Robin", catalog_path=catalog) is False
+        finally:
+            os.chmod(catalog, stat.S_IRUSR | stat.S_IWUSR)


### PR DESCRIPTION
## Why

I reviewed today's catalogue work rather than assuming it was sound. It found **three ways a release could be refused or corrupted**, and one place asking for more access than it needed. All are in code merged today; none has been released.

## 1. A sideloaded model could block every future catalogue update — the serious one

The compatibility importer ([#287](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/pull/287)) gives a model the owner installed themselves a mapping derived from its own labels, registered under `local:`. If that model was **later published**, `import_release` found the checksum already registered with a different mapping set and failed **the whole release closed**.

Every subsequent catalogue update for that owner would fail, for as long as they kept the model.

A mapping compiled from a file on disk was never authoritative. The reviewed one now replaces it outright.

Reproduced on a copy of a live catalogue, taking a real published model and pretending it had been sideloaded first:

```
owner sideloads mobilenet_v2_birds: imported, 915/965 named locally
  registered as: local:sideloaded

now the project publishes that model in a release:
  Replacing a locally derived mapping with the published one  was=local:sideloaded
  import status: imported
  artifact now: 'mobilenet_v2_birds' width=965  rows=965 identified=905
```

Note the local mapping named *more* outputs (915 vs 905) — and published still wins, because those extra 10 are the split cases where only a declared label format can settle which half of the label to believe.

## 2. A shrinking mapping was accepted silently

`_identity_gains` only walked the incoming rows, so a mapping describing **fewer** outputs than the catalogue holds looked like "no differences". The artifact then recorded that mapping's digest while keeping rows the mapping does not contain — the catalogue claiming a mapping it does not hold. Now refused.

## 3. The repair path could write a bundle's own species numbering

`_complete_registered_mappings` runs on the already-imported path, **before** any species id mapping is built, and passed bundle rows straight to the insert. A bundle numbers species from its own build, so a restored row carrying one would bind that output to whichever species holds that number in the live catalogue.

It now restores only rows that carry **no identity** — which is exactly what that repair exists for: outputs nothing could resolve, counted in the mapping digest but filtered out before they were stored ([#276](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/276)).

## 4. Health took a write handle to count

`catalogue_override_count`, called from `_naming_health` on every poll, opened a **read-write** connection just to run a `COUNT`. On a catalogue mounted read-only that reports nothing available when the data reads perfectly well, and it contends with an import for no reason. Reads are read-only now, with a test that pins it by making the file unwritable.

## Verified on live data

Against a copy of quark's real 34,746-row catalogue, with the final code:

```
live catalogue: imported  rows 34746 -> 34746  gained 175  otherwise changed 0
re-import:      already_imported  rows 34746  identical=True
```

Still 175 identities gained, nothing else changed, and importing the same release twice leaves the rows byte-identical.

## Also checked and found sound

- `_insert_cache` never touches `manual_common_name`, so refreshing a taxonomy lookup cannot wipe an owner's rename.
- A catalogue holding any release or override is never replaced by the seed path, so overrides cannot be orphaned by a species id shift.
- The exact-match taxonomy lookup ([#289](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/pull/289)) was re-tested against the 84 European labels the bundled reference cannot name — the worst case for an exact rule. Of 21 probed: 14 return nothing from iNaturalist either way, 6 still resolve, 1 (`Barn owl`) was binding to the **family** `Tytonidae` and is now correctly rejected, and **0 cases where the old code took the right species and the new rule rejects it.**

## Checks

4 new tests. 2,467 backend tests pass, `ruff check .` and `ruff format --check .` clean repo-wide, docs consistency check passes.