### PR TITLE
Cover the glue that mirrors a rename into the catalogue

### DIFF
--- a/backend/tests/test_taxonomy_service.py
+++ b/backend/tests/test_taxonomy_service.py
@@ -362,3 +362,78 @@ async def test_the_lookup_asks_for_more_than_one_candidate(taxonomy_service):
         await taxonomy_service._lookup_inaturalist("Regulus regulus")
 
     assert client.get.await_args.kwargs["params"]["per_page"] > 1
+
+
+@pytest.mark.asyncio
+async def test_setting_a_rename_records_it_against_the_resolved_species(taxonomy_service):
+    """The detection database keeps its copy for the pre-3.0 readers, and the
+    catalogue gets the same rename keyed on the species it names."""
+    written: list[tuple[int, str]] = []
+    cursor = AsyncMock()
+    cursor.rowcount = 1
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=cursor)
+
+    with (
+        patch(
+            "app.services.species_catalog_resolver.species_catalog_resolver.resolve_scientific_name",
+            return_value=(4242, "resolved"),
+        ),
+        patch(
+            "app.services.species_catalog_overrides.write_catalogue_override",
+            side_effect=lambda species_id, name: written.append((species_id, name)) or True,
+        ),
+        patch.object(taxonomy_service, "get_common_name_override", AsyncMock(return_value={"ok": True})),
+    ):
+        await taxonomy_service.set_common_name_override("Cyanistes caeruleus", "Bluetit", db)
+
+    assert written == [(4242, "Bluetit")]
+
+
+@pytest.mark.asyncio
+async def test_clearing_a_rename_clears_it_in_the_catalogue_too(taxonomy_service):
+    cleared: list[int] = []
+    cursor = AsyncMock()
+    cursor.rowcount = 1
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=cursor)
+
+    with (
+        patch(
+            "app.services.species_catalog_resolver.species_catalog_resolver.resolve_scientific_name",
+            return_value=(4242, "resolved"),
+        ),
+        patch(
+            "app.services.species_catalog_overrides.clear_catalogue_override",
+            side_effect=lambda species_id: cleared.append(species_id) or True,
+        ),
+        patch.object(taxonomy_service, "get_common_name_override", AsyncMock(return_value={"ok": True})),
+    ):
+        await taxonomy_service.clear_common_name_override("Cyanistes caeruleus", db)
+
+    assert cleared == [4242]
+
+
+@pytest.mark.asyncio
+async def test_a_rename_of_a_name_the_catalogue_cannot_place_is_still_saved(taxonomy_service):
+    """The owner's decision is already stored by the time the catalogue is
+    asked. A name it cannot resolve is a naming gap, never a lost rename."""
+    cursor = AsyncMock()
+    cursor.rowcount = 1
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=cursor)
+
+    with (
+        patch(
+            "app.services.species_catalog_resolver.species_catalog_resolver.resolve_scientific_name",
+            return_value=(None, "unknown"),
+        ),
+        patch(
+            "app.services.species_catalog_overrides.write_catalogue_override",
+            side_effect=AssertionError("must not be called without a resolved species"),
+        ),
+        patch.object(taxonomy_service, "get_common_name_override", AsyncMock(return_value={"ok": True})),
+    ):
+        result = await taxonomy_service.set_common_name_override("Troglodytidae", "Wrens", db)
+
+    assert result == {"ok": True}


### PR DESCRIPTION
## Why

[#294](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/pull/294) tested the override store and the migration. It did not test the ten lines joining the API write path to them — `_mirror_override_to_catalogue`, which resolves the name to a species and calls the store.

That is the piece a user's rename actually travels through, and the interesting case is the one where resolution fails: the rename is **already saved** by then, so nothing may be written against a guess and nothing may raise.

## Three tests

- A rename is recorded against the **resolved species id**, not the name.
- Clearing clears it in the catalogue too.
- A name the catalogue cannot place — `Troglodytidae`, a family, which is genuinely among the 14 unresolvable cached names on a live install — is still saved, and the store is **never called**. The test asserts this by making the store raise if touched.

## Checks

2,470 backend tests pass, `ruff` clean repo-wide.