### PR TITLE
Refuse a bundle that declares a different output width

### DIFF
--- a/backend/app/services/species_catalog_importer.py
+++ b/backend/app/services/species_catalog_importer.py
@@ -438,13 +438,25 @@ def import_release(bundle_path: Path, catalog_path: Optional[Path] = None) -> Im
             outputs_added = 0
             for artifact in bundle.model_artifacts:
                 existing_artifact = live.execute(
-                    "SELECT id, mapping_set_sha256, registry_id FROM model_artifacts WHERE model_sha256 = ?",
+                    "SELECT id, mapping_set_sha256, registry_id, output_width FROM model_artifacts"
+                    " WHERE model_sha256 = ?",
                     (artifact["model_sha256"],),
                 ).fetchone()
                 if existing_artifact:
                     artifact_row_id = int(existing_artifact["id"])
                     incoming = _mapped_outputs(outputs_by_artifact.get(artifact["model_sha256"], []), id_map)
                     locally_derived = str(existing_artifact["registry_id"] or "").startswith(LOCAL_REGISTRY_PREFIX)
+                    if not locally_derived and int(existing_artifact["output_width"] or 0) != int(
+                        artifact["output_width"] or 0
+                    ):
+                        # One model checksum, two output counts. Whichever is
+                        # right, the artifact row and its mapping would stop
+                        # describing the same tensor, and the label reader
+                        # compares the two to decide whether it may serve them.
+                        raise CatalogImportError(
+                            "Bundle declares a different output width for already-registered artifact "
+                            f"{artifact['model_sha256']}; refusing the release"
+                        )
                     if locally_derived:
                         # This install derived a mapping for a model nobody had
                         # published, from that model's own labels. A published

--- a/backend/tests/test_species_catalog_importer.py
+++ b/backend/tests/test_species_catalog_importer.py
@@ -623,7 +623,7 @@ def test_a_mapping_that_drops_outputs_is_refused(tmp_path):
     before = _outputs(live)
     assert len(before) == 2
 
-    with pytest.raises(CatalogImportError, match="different mapping set"):
+    with pytest.raises(CatalogImportError, match="refusing the release"):
         import_release(bundle, catalog_path=live)
 
     assert _outputs(live) == before
@@ -653,3 +653,24 @@ def test_repairing_an_already_imported_release_never_writes_a_bundle_species_num
     # is left for a real import to place.
     assert [row[0] for row in restored] == [1]
     assert restored[0][1:3] == ("unknown", None)
+
+
+def test_a_bundle_declaring_a_different_output_width_is_refused(tmp_path):
+    """One model checksum cannot have two output counts. Accepting it would
+    leave the artifact row and its mapping describing different tensors, and
+    the label reader compares the two to decide whether it may serve them."""
+    live = _build_two_output_seed(tmp_path, "width_live.db", second_resolved=False)
+    bundle = _build_two_output_seed(tmp_path, "width_bundle.db", second_resolved=True)
+
+    connection = sqlite3.connect(live)
+    try:
+        connection.execute("UPDATE model_artifacts SET output_width = 7")
+        connection.commit()
+    finally:
+        connection.close()
+    before = _outputs(live)
+
+    with pytest.raises(CatalogImportError, match="different output width"):
+        import_release(bundle, catalog_path=live)
+
+    assert _outputs(live) == before


### PR DESCRIPTION
## Why

One model checksum cannot have two output counts.

The upgrade path added in [#290](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/pull/290) updated `mapping_set_sha256` and left `output_width` alone. If a bundle declared a different width for an already-registered artifact, the artifact row and its mapping would end up describing **different tensors** — and `catalogue_labels_for_model` compares exactly those two numbers to decide whether it may serve a model's labels from the catalogue at all.

## Also catches the shrink case by name

A mapping that simply dropped outputs was already refused by the identity-gain check, but as a generic "different mapping set". It is really a width divergence, and now says so.

## Verified against a live catalogue

The real release still imports with the guard in place:

```
real catalogue with the width guard: imported, identified 32307 -> 32482
```

## Checks

2,471 backend tests pass, `ruff` clean repo-wide.