### PR TITLE
Take hardware detection off the request path, and record the host in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   database, disk or network, waiting 22.5 seconds for its first byte, alongside four other requests
   that all finished at the same moment. Detection now runs on a schedule away from any request, a
   status read returns the last known answer, and the reply says how old that answer is rather than
-  implying it is current
-  ([#313](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/313)).
+  implying it is current. The schedule re-detects every fifteen minutes rather than every minute —
+  the capabilities cannot change without a container restart, and `CLASSIFIER_ACCEL_PROBE_TTL_SECONDS`
+  tunes it — and a reading the scheduler will refresh at its next wake is reported on schedule, not
+  stale ([#313](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/313)).
 
 - **Diagnostics now say what machine they came from.** A bundle recorded the app version and the
   configuration but neither the processor count nor the memory, so a report of slowness could not be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   [#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300) before anyone could say
   whether the host was a small box or a large one. Health and the bundle now carry the usable
   processor count, total memory, and any container CPU or memory limit, which is the number that
-  actually governs contention. Anything unreadable is reported as unknown rather than guessed.
+  actually governs contention. The limits are read from cgroup v2 or, on hosts that still mount
+  cgroup v1 such as Unraid and older Docker, from the v1 files — a `--cpus=2` container on a
+  sixteen core v1 host reports two effective cores, not sixteen. Anything unreadable is reported
+  as unknown rather than guessed, including the effective core count when no cgroup can be read
+  at all.
 
 - **A broken test database now says what broke it.** When the test suite could not build its schema,
   the setup printed the failure and carried on with a flag saying the database was ready. Every test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Saving settings that change the inference provider no longer stalls the backend either.**
+  Taking hardware detection off the status path left one road back onto the event loop: a settings
+  save that changes the provider or execution mode reloads the classifier as a background task, and
+  that task rebuilt the service and loaded the model inline — the same subprocess probes, the same
+  stalled requests, just triggered by a write instead of a read. Clearing classification feedback
+  reloaded the model the same way. Both reloads now build the classifier and load the model in a
+  worker thread, so a settings save costs the saver a moment and everyone else nothing
+  ([#313](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/313)).
+
 - **A status request no longer stops the backend answering anything else.** Asking for classifier
   status re-detected the machine's hardware capabilities, and detection starts up to three
   short-lived child processes that each import an inference runtime, with a five second timeout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A status request no longer stops the backend answering anything else.** Asking for classifier
+  status re-detected the machine's hardware capabilities, and detection starts up to three
+  short-lived child processes that each import an inference runtime, with a five second timeout
+  apiece. That ran on the thread serving every request, so while it worked, nothing else was
+  answered. A reporter's capture showed `/api/version`, which returns a fixed string and touches no
+  database, disk or network, waiting 22.5 seconds for its first byte, alongside four other requests
+  that all finished at the same moment. Detection now runs on a schedule away from any request, a
+  status read returns the last known answer, and the reply says how old that answer is rather than
+  implying it is current
+  ([#313](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/313)).
+
+- **Diagnostics now say what machine they came from.** A bundle recorded the app version and the
+  configuration but neither the processor count nor the memory, so a report of slowness could not be
+  sized: two bundles and a browser capture were exchanged on
+  [#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300) before anyone could say
+  whether the host was a small box or a large one. Health and the bundle now carry the usable
+  processor count, total memory, and any container CPU or memory limit, which is the number that
+  actually governs contention. Anything unreadable is reported as unknown rather than guessed.
+
 - **A broken test database now says what broke it.** When the test suite could not build its schema,
   the setup printed the failure and carried on with a flag saying the database was ready. Every test
   then ran against an empty database and reported `no such table`, so one cause surfaced as hundreds

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -551,6 +551,55 @@ it scans `detections` once per request before the slow part starts. Neither is a
 index. Both want measuring on a database with a realistic long tail rather than on species counts
 that happen to be healthy.
 
+#### Keep the web service and ingest off the inference path 🧵
+**Priority:** P1 | **Effort:** M
+
+Tracked in [#312](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/312) and
+[#313](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/313), both found while
+diagnosing [#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300).
+
+MQTT ingest starts as a background task inside the API process, and with the default
+`image_execution_mode: in_process` inference joins them on a `ThreadPoolExecutor`. Three tiers with
+very different obligations therefore share one process, and nothing bounds how much CPU inference
+takes: ONNX hardcodes `intra_op_num_threads = 4` regardless of the host, OpenVINO is configured
+`PERFORMANCE_HINT: LATENCY` with no thread cap, and the container is shipped with no CPU limit.
+
+It is already costing detections rather than just page loads. A reporter's bundle records
+`save_and_notify` timing out after six seconds with `fault_drops: 1` and `critical_failures: 1`,
+which is a lost detection and therefore a section 1 concern.
+
+✅ The first slice is delivered: hardware capability detection no longer happens on a request. It
+spawned up to three child processes, each importing an inference runtime with a five second timeout,
+inline in an `async def`. A reporter's capture showed `/api/version`, which returns a fixed string,
+waiting 22,551ms for its first byte with 0ms queued in the browser, alongside four other requests
+finishing at the same instant. Detection now runs on a schedule off the request path and a status
+read reports the age of its answer.
+
+The outcome still wanted is a process boundary between tier 1 (ingest and the API) and tiers 2 and 3
+(live, then background and video inference), plus CPU headroom so tier 1 is always schedulable. A
+process boundary also makes a stalled inference killable, which an in-process thread is not: the
+issue-33 plan records that the coordinator "cannot stop the underlying Python/native worker thread".
+
+What blocks a default change is a measurement, not a decision. Memory per worker is one model copy
+plus a 512MB crop detector, and the naive comparison is misleading: the same instance measured
+633MiB immediately after restart and 4.815GiB after about a day, an eightfold growth with no change
+of model. Any comparison between the modes has to be taken at a matched age over hours.
+
+Complete when a fresh install runs inference out of process, resident memory is measured before and
+after and stated honestly in the release notes, a test pins the resolved defaults, and Settings >
+Detection explains the mode by its effect.
+
+#### Find where the eightfold memory growth comes from 📈
+**Priority:** P2 | **Effort:** S
+
+The same instance, same model (`rope_vit_b14_inat21`, 361MB on disk), same configuration, measured
+**633MiB immediately after a restart and 4.815GiB after roughly a day**. That may be OpenVINO arena
+behaviour rather than a leak, but nothing currently distinguishes the two, and it decides whether
+the worker-count question above is a real constraint or an artefact.
+
+Complete when the growth curve is measured over days and attributed, and either explained as bounded
+allocator behaviour in the docs or fixed.
+
 #### Broader end-to-end coverage 🧪
 **Priority:** P1 | **Effort:** M | **Status:** 🔄 Targeted coverage exists
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.services.mqtt_service import mqtt_service
 from app.services.classifier_service import (
     CLASSIFIER_ACCEL_PROBE_TTL_SECONDS,
     get_classifier,
+    refresh_accel_caps_if_running,
     shutdown_classifier,
 )
 from app.services.event_processor import EventProcessor
@@ -440,7 +441,7 @@ async def _start_heartbeat_scheduler_task(instance_id: str) -> None:
         """
         while True:
             try:
-                await get_classifier().refresh_accel_caps_off_request_path()
+                await refresh_accel_caps_if_running()
             except Exception as error:  # noqa: BLE001 - a probe failure must not end the loop
                 log.warning("Acceleration capability refresh failed", error=str(error))
             await asyncio.sleep(ACCEL_CAPS_REFRESH_SECONDS)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -140,6 +140,10 @@ def get_app_branch() -> str:
 
 BASE_VERSION = get_base_version()
 GIT_HASH = get_git_hash()
+
+# How often hardware capabilities are re-detected, away from any request path.
+# Detection spawns child processes, so this is deliberately not on demand (#313).
+ACCEL_CAPS_REFRESH_SECONDS = 60.0
 APP_BRANCH = get_app_branch()
 
 # Treat semver-like tags (e.g. v2.7.9.1) as releases, not branches.
@@ -192,6 +196,7 @@ cleanup_task = None
 media_integrity_task = None
 cleanup_running = True
 heartbeat_task = None
+accel_caps_task = None
 heartbeat_running = True
 CLEANUP_INTERVAL_HOURS = 24  # Run cleanup every 24 hours
 
@@ -418,7 +423,23 @@ async def heartbeat_scheduler(instance_id: str):
 
 
 async def _start_heartbeat_scheduler_task(instance_id: str) -> None:
-    global heartbeat_task
+    global heartbeat_task, accel_caps_task
+
+    async def accel_caps_scheduler() -> None:
+        """Keep hardware capabilities current away from any request.
+
+        Detection spawns child processes that import an inference runtime. It
+        used to happen inline on a status request, stalling every concurrent
+        request behind it (#313).
+        """
+        while True:
+            try:
+                await get_classifier().refresh_accel_caps_off_request_path()
+            except Exception as error:  # noqa: BLE001 - a probe failure must not end the loop
+                log.warning("Acceleration capability refresh failed", error=str(error))
+            await asyncio.sleep(ACCEL_CAPS_REFRESH_SECONDS)
+
+    accel_caps_task = create_background_task(accel_caps_scheduler(), name="accel_caps_scheduler")
     heartbeat_task = create_background_task(heartbeat_scheduler(instance_id), name="heartbeat_scheduler")
 
 
@@ -430,7 +451,7 @@ async def _start_cleanup_scheduler_task() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global cleanup_task, media_integrity_task, cleanup_running, heartbeat_task, heartbeat_running
+    global cleanup_task, media_integrity_task, cleanup_running, heartbeat_task, heartbeat_running, accel_caps_task
     test_mode = _is_testing()
 
     # Startup
@@ -439,6 +460,7 @@ async def lifespan(app: FastAPI):
     media_integrity_task = None
     heartbeat_running = not test_mode
     heartbeat_task = None
+    accel_caps_task = None
     app.state.startup_warnings = []
     startup_started_at = datetime.now(timezone.utc)
     app.state.startup_started_at = startup_started_at.isoformat()
@@ -574,6 +596,13 @@ async def lifespan(app: FastAPI):
     yield
 
     # Shutdown
+    if accel_caps_task and not test_mode:
+        accel_caps_task.cancel()
+        try:
+            await accel_caps_task
+        except asyncio.CancelledError:
+            pass
+
     heartbeat_running = False
     if heartbeat_task and not test_mode:
         heartbeat_task.cancel()
@@ -983,6 +1012,8 @@ def _naming_health() -> dict[str, object]:
 
 
 def build_health_payload() -> dict[str, object]:
+    from app.services.host_facts import collect_host_facts
+
     startup_warnings = getattr(app.state, "startup_warnings", [])
     startup_instance_id = getattr(app.state, "startup_instance_id", "unknown")
     startup_started_at = getattr(app.state, "startup_started_at", None)
@@ -1027,6 +1058,10 @@ def build_health_payload() -> dict[str, object]:
         "notification_dispatcher": notification_dispatch_health,
         "event_pipeline": event_pipeline_health,
         "startup_warnings": startup_warnings,
+        # The machine this is running on. A performance report cannot be sized
+        # without it, and two bundles were exchanged on #300 before anyone could
+        # say whether the host was a small box or a large one.
+        "host": collect_host_facts(),
         "startup_instance_id": startup_instance_id,
         "startup_started_at": startup_started_at,
     }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,7 +33,11 @@ from app.services.media_integrity_scan import (
     run_media_integrity_scan,
 )
 from app.services.mqtt_service import mqtt_service
-from app.services.classifier_service import get_classifier, shutdown_classifier
+from app.services.classifier_service import (
+    CLASSIFIER_ACCEL_PROBE_TTL_SECONDS,
+    get_classifier,
+    shutdown_classifier,
+)
 from app.services.event_processor import EventProcessor
 from app.services.media_cache import media_cache
 from app.services.full_visit_clip_service import full_visit_clip_service
@@ -141,9 +145,11 @@ def get_app_branch() -> str:
 BASE_VERSION = get_base_version()
 GIT_HASH = get_git_hash()
 
-# How often hardware capabilities are re-detected, away from any request path.
-# Detection spawns child processes, so this is deliberately not on demand (#313).
-ACCEL_CAPS_REFRESH_SECONDS = 60.0
+# How often the scheduler wakes to check whether hardware capabilities have
+# expired, away from any request path. A wake is a monotonic comparison; a
+# probe — child processes with five second timeouts — runs only once the
+# reading is older than CLASSIFIER_ACCEL_PROBE_TTL_SECONDS (#313).
+ACCEL_CAPS_REFRESH_SECONDS = min(60.0, CLASSIFIER_ACCEL_PROBE_TTL_SECONDS)
 APP_BRANCH = get_app_branch()
 
 # Treat semver-like tags (e.g. v2.7.9.1) as releases, not branches.

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -2022,13 +2022,12 @@ async def update_settings(
         background_tasks.add_task(start_background_refresh)
 
     if inference_provider_changed or execution_mode_changed:
-        from app.services.classifier_service import get_classifier, shutdown_classifier
+        from app.services.classifier_service import reload_classifier_out_of_band
 
         async def full_reload():
             if execution_mode_changed:
                 log.info("Execution mode changed, performing full classifier service restart")
-                await shutdown_classifier()
-            await get_classifier().reload_bird_model()
+            await reload_classifier_out_of_band(full_restart=execution_mode_changed)
 
         background_tasks.add_task(full_reload)
 
@@ -2714,13 +2713,13 @@ async def reset_video_circuit(
 @router.delete("/maintenance/feedback/clear", response_model=ClearFeedbackResponse)
 async def clear_classification_feedback(background_tasks: BackgroundTasks, auth: AuthContext = Depends(require_owner)):
     """Clear all personalized re-ranking classification feedback. Owner only."""
-    from app.services.classifier_service import get_classifier
+    from app.services.classifier_service import reload_classifier_out_of_band
 
     async with get_db() as db:
         repo = DetectionRepository(db)
         deleted_count = await repo.clear_all_classification_feedback()
 
-    background_tasks.add_task(get_classifier().reload_bird_model)
+    background_tasks.add_task(reload_classifier_out_of_band, full_restart=False)
 
     return {
         "status": "success",

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -2953,6 +2953,13 @@ class ClassifierService:
         self._inference_fallback_reason = f"{prev_reason}; {reason}" if prev_reason else reason
 
     def _refresh_accel_caps(self, *, force: bool = False) -> dict[str, Any]:
+        """Detect capabilities. Expensive: spawns child processes.
+
+        `_detect_acceleration_capabilities()` starts short-lived Python processes
+        that import an inference runtime and enumerate devices, each with a five
+        second timeout. Never call this from a request handler; use
+        `_accel_caps_for_read()` there instead (#313).
+        """
         now = time.monotonic()
         if (
             not force
@@ -2963,6 +2970,36 @@ class ClassifierService:
         self._accel_caps = _detect_acceleration_capabilities()
         self._accel_caps_last_refreshed_monotonic = now
         return self._accel_caps
+
+    def _accel_caps_for_read(self) -> dict[str, Any]:
+        """The last known capabilities, without going to find out.
+
+        A status request used to refresh these inline, which spawned subprocesses
+        on the event loop and stalled every concurrent request behind them. A
+        reporter's capture showed `/api/version`, which returns a fixed string,
+        waiting 22.5 seconds for its first byte (#313).
+        """
+        return self._accel_caps
+
+    def _accel_caps_age_seconds(self) -> Optional[float]:
+        """How old the reading is, or None if one has never been taken."""
+        if self._accel_caps_last_refreshed_monotonic is None:
+            return None
+        return max(0.0, time.monotonic() - self._accel_caps_last_refreshed_monotonic)
+
+    def accel_caps_are_stale(self) -> bool:
+        age = self._accel_caps_age_seconds()
+        return age is None or age > self._accel_caps_ttl_seconds
+
+    async def refresh_accel_caps_off_request_path(self) -> None:
+        """Re-detect capabilities in a worker thread, never on the event loop.
+
+        Detection spawns child processes, so it is moved off the loop entirely
+        rather than merely made less frequent (#313).
+        """
+        if not self.accel_caps_are_stale():
+            return
+        await asyncio.to_thread(self._refresh_accel_caps, force=True)
 
     def _build_bird_model_for_backend(
         self,
@@ -4442,7 +4479,10 @@ class ClassifierService:
         bird = self._models.get("bird")
         admission_metrics = self._classification_admission.get_metrics()
         live_image_health = self._describe_live_image_health(admission_metrics)
-        self._refresh_accel_caps()
+        # Reads the last known capabilities rather than detecting them. Detection
+        # spawns subprocesses, and this runs on the event loop (#313).
+        self._accel_caps_for_read()
+        accel_caps_age = self._accel_caps_age_seconds()
         supervisor_metrics = self._get_supervisor_metrics()
         effective_runtime_recovery = (
             self._latest_worker_runtime_recovery(supervisor_metrics)
@@ -4499,6 +4539,8 @@ class ClassifierService:
 
         status = {
             "image_execution_mode": self._image_execution_mode,
+            "accel_caps_age_seconds": accel_caps_age,
+            "accel_caps_stale": accel_caps_age is None or accel_caps_age > self._accel_caps_ttl_seconds,
             "image_flavor": image_flavor,
             "packaged_inference_providers": list(packaged_providers),
             "image_flavor_warning": image_flavor_warning(image_flavor, selected_provider),

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -201,10 +201,16 @@ CLASSIFIER_ADMISSION_RECOVERY_WINDOW_SECONDS = max(
     1.0,
     float(os.getenv("CLASSIFIER_ADMISSION_RECOVERY_WINDOW_SECONDS", "300")),
 )
+# Hardware capabilities cannot change without a container restart, so the
+# reading is expensive to take and cheap to keep (#313).
 CLASSIFIER_ACCEL_PROBE_TTL_SECONDS = max(
     1.0,
-    float(os.getenv("CLASSIFIER_ACCEL_PROBE_TTL_SECONDS", "60")),
+    float(os.getenv("CLASSIFIER_ACCEL_PROBE_TTL_SECONDS", "900")),
 )
+# The scheduler refreshes an expired reading at its next wake, so a reading
+# this far past its TTL means the scheduler has actually missed — one wake
+# interval plus a worst-case probe is within schedule, not stale.
+ACCEL_CAPS_STALE_GRACE_SECONDS = 120.0
 CLASSIFIER_GPU_INVALID_RETRY_LIMIT = max(
     0,
     int(os.getenv("CLASSIFIER_GPU_INVALID_RETRY_LIMIT", "1")),
@@ -2975,15 +2981,16 @@ class ClassifierService:
         second timeout. Never call this from a request handler; use
         `_accel_caps_for_read()` there instead (#313).
         """
-        now = time.monotonic()
         if (
             not force
             and self._accel_caps_last_refreshed_monotonic is not None
-            and now - self._accel_caps_last_refreshed_monotonic < self._accel_caps_ttl_seconds
+            and time.monotonic() - self._accel_caps_last_refreshed_monotonic < self._accel_caps_ttl_seconds
         ):
             return self._accel_caps
         self._accel_caps = _detect_acceleration_capabilities()
-        self._accel_caps_last_refreshed_monotonic = now
+        # Stamped at completion: a reading stamped at probe start is born as
+        # old as the probe was slow, and trips the staleness rule early.
+        self._accel_caps_last_refreshed_monotonic = time.monotonic()
         return self._accel_caps
 
     def _accel_caps_for_read(self) -> dict[str, Any]:
@@ -3003,18 +3010,23 @@ class ClassifierService:
         return max(0.0, time.monotonic() - self._accel_caps_last_refreshed_monotonic)
 
     def accel_caps_are_stale(self) -> bool:
+        """Whether the scheduler has missed its refresh window.
+
+        A reading past its TTL but within one wake interval is on schedule —
+        the scheduler will refresh it at its next wake — so only an age beyond
+        TTL plus grace is stale. Anything less would flap on a healthy install.
+        """
         age = self._accel_caps_age_seconds()
-        return age is None or age > self._accel_caps_ttl_seconds
+        return age is None or age > self._accel_caps_ttl_seconds + ACCEL_CAPS_STALE_GRACE_SECONDS
 
     async def refresh_accel_caps_off_request_path(self) -> None:
-        """Re-detect capabilities in a worker thread, never on the event loop.
+        """Re-detect expired capabilities in a worker thread, never on the loop.
 
         Detection spawns child processes, so it is moved off the loop entirely
-        rather than merely made less frequent (#313).
+        rather than merely made less frequent (#313). Whether the reading has
+        expired is the callee's TTL check — there is one definition of fresh.
         """
-        if not self.accel_caps_are_stale():
-            return
-        await asyncio.to_thread(self._refresh_accel_caps, force=True)
+        await asyncio.to_thread(self._refresh_accel_caps)
 
     def _build_bird_model_for_backend(
         self,
@@ -4503,7 +4515,7 @@ class ClassifierService:
         live_image_health = self._describe_live_image_health(admission_metrics)
         # Reads the last known capabilities rather than detecting them. Detection
         # spawns subprocesses, and this runs on the event loop (#313).
-        self._accel_caps_for_read()
+        caps = self._accel_caps_for_read()
         accel_caps_age = self._accel_caps_age_seconds()
         supervisor_metrics = self._get_supervisor_metrics()
         effective_runtime_recovery = (
@@ -4551,7 +4563,7 @@ class ClassifierService:
             provider_order = []
             candidate_providers = []
         provider_capabilities = _provider_capability_contract(
-            caps=self._accel_caps,
+            caps=caps,
             packaged_providers=packaged_providers,
             supported_providers=supported_providers,
             active_backend=str(effective_backend or ""),
@@ -4562,7 +4574,7 @@ class ClassifierService:
         status = {
             "image_execution_mode": self._image_execution_mode,
             "accel_caps_age_seconds": accel_caps_age,
-            "accel_caps_stale": accel_caps_age is None or accel_caps_age > self._accel_caps_ttl_seconds,
+            "accel_caps_stale": self.accel_caps_are_stale(),
             "image_flavor": image_flavor,
             "packaged_inference_providers": list(packaged_providers),
             "image_flavor_warning": image_flavor_warning(image_flavor, selected_provider),
@@ -4571,34 +4583,34 @@ class ClassifierService:
             "onnx_available": ONNX_AVAILABLE,
             "active_model_id": active_model_id,
             "effective_model_id": effective_model_id,
-            "openvino_available": bool(self._accel_caps.get("openvino_available")),
-            "openvino_version": self._accel_caps.get("openvino_version"),
-            "openvino_import_path": self._accel_caps.get("openvino_import_path"),
-            "openvino_import_error": self._accel_caps.get("openvino_import_error"),
-            "openvino_probe_error": self._accel_caps.get("openvino_probe_error"),
-            "openvino_gpu_probe_error": self._accel_caps.get("openvino_gpu_probe_error"),
+            "openvino_available": bool(caps.get("openvino_available")),
+            "openvino_version": caps.get("openvino_version"),
+            "openvino_import_path": caps.get("openvino_import_path"),
+            "openvino_import_error": caps.get("openvino_import_error"),
+            "openvino_probe_error": caps.get("openvino_probe_error"),
+            "openvino_gpu_probe_error": caps.get("openvino_gpu_probe_error"),
             "openvino_model_compile_ok": self._openvino_model_compile_ok,
             "openvino_model_compile_device": self._openvino_model_compile_device,
             "openvino_model_compile_error": self._openvino_model_compile_error,
             "openvino_model_compile_unsupported_ops": list(self._openvino_model_compile_unsupported_ops or []),
-            "openvino_devices": self._accel_caps.get("openvino_devices") or [],
-            "cuda_provider_installed": bool(self._accel_caps.get("cuda_provider_installed")),
-            "cuda_hardware_available": bool(self._accel_caps.get("cuda_hardware_available")),
-            "cuda_available": bool(self._accel_caps.get("cuda_available")),
-            "cuda_probe_error": self._accel_caps.get("cuda_probe_error"),
-            "intel_gpu_available": bool(self._accel_caps.get("intel_gpu_available")),
-            "intel_cpu_available": bool(self._accel_caps.get("intel_cpu_available")),
-            "intel_npu_available": bool(self._accel_caps.get("intel_npu_available")),
+            "openvino_devices": caps.get("openvino_devices") or [],
+            "cuda_provider_installed": bool(caps.get("cuda_provider_installed")),
+            "cuda_hardware_available": bool(caps.get("cuda_hardware_available")),
+            "cuda_available": bool(caps.get("cuda_available")),
+            "cuda_probe_error": caps.get("cuda_probe_error"),
+            "intel_gpu_available": bool(caps.get("intel_gpu_available")),
+            "intel_cpu_available": bool(caps.get("intel_cpu_available")),
+            "intel_npu_available": bool(caps.get("intel_npu_available")),
             "host_device_eligibility": _host_device_eligibility_summary(),
             "active_model_candidate_providers": candidate_providers,
             "active_model_validated_providers": validated_providers,
             "validated_provider_preference_order": provider_order,
-            "dev_dri_present": bool(self._accel_caps.get("dev_dri_present")),
-            "dev_dri_entries": self._accel_caps.get("dev_dri_entries") or [],
-            "dev_accel_present": bool(self._accel_caps.get("dev_accel_present")),
-            "process_uid": self._accel_caps.get("process_uid"),
-            "process_gid": self._accel_caps.get("process_gid"),
-            "process_groups": self._accel_caps.get("process_groups") or [],
+            "dev_dri_present": bool(caps.get("dev_dri_present")),
+            "dev_dri_entries": caps.get("dev_dri_entries") or [],
+            "dev_accel_present": bool(caps.get("dev_accel_present")),
+            "process_uid": caps.get("process_uid"),
+            "process_gid": caps.get("process_gid"),
+            "process_groups": caps.get("process_groups") or [],
             "selected_provider": selected_provider,
             "active_provider": effective_provider,
             "inference_backend": effective_backend,

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -1718,6 +1718,20 @@ async def shutdown_classifier() -> None:
             _classifier_instance = None
 
 
+async def refresh_accel_caps_if_running() -> None:
+    """Refresh capabilities on the running classifier, never building one.
+
+    The probe scheduler runs on the event loop, and constructing
+    ClassifierService detects hardware and loads the model synchronously. A
+    missing singleton means startup or a reload owns construction; the
+    scheduler's next wake will find the new instance.
+    """
+    service = _classifier_instance
+    if service is None:
+        return
+    await service.refresh_accel_caps_off_request_path()
+
+
 async def reload_classifier_out_of_band(*, full_restart: bool) -> None:
     """Rebuild or reload the classifier away from the event loop.
 

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -1712,6 +1712,21 @@ async def shutdown_classifier() -> None:
             _classifier_instance = None
 
 
+async def reload_classifier_out_of_band(*, full_restart: bool) -> None:
+    """Rebuild or reload the classifier away from the event loop.
+
+    Constructing ClassifierService detects hardware — child processes with five
+    second timeouts apiece — and may load the model, synchronously. A settings
+    save runs its reload as a background task on the event loop, so the
+    construction must happen in a worker thread or every concurrent request
+    stalls behind it (#313).
+    """
+    if full_restart:
+        await shutdown_classifier()
+    service = await asyncio.to_thread(get_classifier)
+    await service.reload_bird_model()
+
+
 def resolve_live_classifier(stored: Any) -> "ClassifierService":
     """Return the current live ClassifierService, repairing a stale cached ref.
 
@@ -4164,19 +4179,26 @@ class ClassifierService:
 
     async def reload_bird_model(self):
         """Reload the bird model (e.g., after switching models)."""
-        with self._models_lock:
-            if "bird" in self._models:
-                # Cleanup old model resources before replacing
-                old_model = self._models.pop("bird")
-                if hasattr(old_model, "cleanup"):
-                    old_model.cleanup()
-                del old_model
 
-            # 1. Initialize locally ONLY if we are a worker or NOT in subprocess mode.
-            # This prevents the main process from loading large models into RAM when it
-            # should be using supervisor workers instead.
-            if self._worker_process_mode or self._image_execution_mode != "subprocess":
-                self._init_bird_model()
+        def replace_bird_model_locked() -> None:
+            with self._models_lock:
+                if "bird" in self._models:
+                    # Cleanup old model resources before replacing
+                    old_model = self._models.pop("bird")
+                    if hasattr(old_model, "cleanup"):
+                        old_model.cleanup()
+                    del old_model
+
+                # 1. Initialize locally ONLY if we are a worker or NOT in subprocess mode.
+                # This prevents the main process from loading large models into RAM when it
+                # should be using supervisor workers instead.
+                if self._worker_process_mode or self._image_execution_mode != "subprocess":
+                    self._init_bird_model()
+
+        # Model init loads weights and re-detects hardware, which spawns child
+        # processes. A reload is triggered from request handlers' background
+        # tasks, which run on the event loop, so the work leaves it (#313).
+        await asyncio.to_thread(replace_bird_model_locked)
 
         # 2. If we have a supervisor (main process in subprocess mode),
         # tell it to restart all workers to pick up the new model.

--- a/backend/app/services/host_facts.py
+++ b/backend/app/services/host_facts.py
@@ -1,0 +1,92 @@
+"""What machine this is running on.
+
+A performance report cannot be sized without it. Two diagnostics bundles and a
+browser capture were exchanged on #300 before anyone could say whether the host
+was a four core box or a sixteen core one, because nothing recorded it.
+
+Everything here is best effort and returns ``None`` rather than raising: a
+missing ``/proc`` entry on an unusual platform must never stop a diagnostics
+bundle being generated, and an unknown is reported as unknown rather than
+rounded up to a plausible number (CLAUDE.md section 5).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import structlog
+
+log = structlog.get_logger()
+
+CGROUP_V2_CPU_MAX = "/sys/fs/cgroup/cpu.max"
+CGROUP_V2_MEMORY_MAX = "/sys/fs/cgroup/memory.max"
+
+
+def _read_cgroup_cpu_quota() -> Optional[float]:
+    """Effective CPU limit in cores, or None when unlimited or unreadable.
+
+    A container capped at two cores on a sixteen core host performs like a two
+    core machine, so the raw processor count alone is misleading.
+    """
+    with open(CGROUP_V2_CPU_MAX, encoding="utf-8") as handle:
+        raw = handle.read().strip()
+    quota, _, period = raw.partition(" ")
+    if quota == "max":
+        return None
+    return int(quota) / int(period)
+
+
+def _read_cgroup_memory_limit() -> Optional[int]:
+    """Container memory limit in bytes, or None when unlimited or unreadable."""
+    with open(CGROUP_V2_MEMORY_MAX, encoding="utf-8") as handle:
+        raw = handle.read().strip()
+    if raw == "max":
+        return None
+    return int(raw)
+
+
+def _total_memory_bytes() -> Optional[int]:
+    pages = os.sysconf("SC_PHYS_PAGES")
+    page_size = os.sysconf("SC_PAGE_SIZE")
+    return int(pages) * int(page_size)
+
+
+def _usable_cpu_count() -> Optional[int]:
+    """Processors this process may actually run on, not the machine's total."""
+    affinity = getattr(os, "sched_getaffinity", None)
+    if affinity is not None:
+        return len(affinity(0))
+    return os.cpu_count()
+
+
+def collect_host_facts() -> dict[str, Any]:
+    """The machine, as far as it can be determined from inside the container."""
+    facts: dict[str, Any] = {
+        "cpu_count": None,
+        "cpu_quota": None,
+        "memory_total_bytes": None,
+        "memory_limit_bytes": None,
+    }
+    for key, reader in (
+        ("cpu_count", _usable_cpu_count),
+        ("cpu_quota", _read_cgroup_cpu_quota),
+        ("memory_total_bytes", _total_memory_bytes),
+        ("memory_limit_bytes", _read_cgroup_memory_limit),
+    ):
+        try:
+            facts[key] = reader()
+        except Exception as error:  # noqa: BLE001 - diagnostics must not fail to generate
+            log.debug("Host fact unavailable", fact=key, error=str(error))
+            facts[key] = None
+
+    # The number that actually governs inference and API contention.
+    quota = facts["cpu_quota"]
+    count = facts["cpu_count"]
+    if quota is not None and count is not None:
+        facts["effective_cpus"] = min(float(quota), float(count))
+    elif count is not None:
+        facts["effective_cpus"] = float(count)
+    else:
+        facts["effective_cpus"] = None
+    return facts

--- a/backend/app/services/host_facts.py
+++ b/backend/app/services/host_facts.py
@@ -21,26 +21,54 @@ log = structlog.get_logger()
 
 CGROUP_V2_CPU_MAX = "/sys/fs/cgroup/cpu.max"
 CGROUP_V2_MEMORY_MAX = "/sys/fs/cgroup/memory.max"
+# Unraid and older Docker/Synology hosts still mount cgroup v1, where the same
+# limits live under per-controller directories and "no limit" is a sentinel
+# value rather than the word "max".
+CGROUP_V1_CPU_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+CGROUP_V1_CPU_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+CGROUP_V1_MEMORY_LIMIT = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+_CGROUP_V1_NO_MEMORY_LIMIT = 1 << 60
+
+
+def _read_file(path: str) -> str:
+    with open(path, encoding="utf-8") as handle:
+        return handle.read().strip()
 
 
 def _read_cgroup_cpu_quota() -> Optional[float]:
-    """Effective CPU limit in cores, or None when unlimited or unreadable.
+    """Effective CPU limit in cores. None means explicitly unlimited.
 
     A container capped at two cores on a sixteen core host performs like a two
-    core machine, so the raw processor count alone is misleading.
+    core machine, so the raw processor count alone is misleading. Raises when
+    neither cgroup version is readable: an unknown limit must surface as
+    unknown, not as no limit.
     """
-    with open(CGROUP_V2_CPU_MAX, encoding="utf-8") as handle:
-        raw = handle.read().strip()
-    quota, _, period = raw.partition(" ")
-    if quota == "max":
+    try:
+        raw = _read_file(CGROUP_V2_CPU_MAX)
+    except OSError:
+        quota = int(_read_file(CGROUP_V1_CPU_QUOTA))
+        if quota < 0:
+            return None
+        return quota / int(_read_file(CGROUP_V1_CPU_PERIOD))
+    quota_raw, _, period = raw.partition(" ")
+    if quota_raw == "max":
         return None
-    return int(quota) / int(period)
+    return int(quota_raw) / int(period)
 
 
 def _read_cgroup_memory_limit() -> Optional[int]:
-    """Container memory limit in bytes, or None when unlimited or unreadable."""
-    with open(CGROUP_V2_MEMORY_MAX, encoding="utf-8") as handle:
-        raw = handle.read().strip()
+    """Container memory limit in bytes. None means explicitly unlimited.
+
+    Raises when neither cgroup version is readable, for the same reason as the
+    CPU quota.
+    """
+    try:
+        raw = _read_file(CGROUP_V2_MEMORY_MAX)
+    except OSError:
+        limit = int(_read_file(CGROUP_V1_MEMORY_LIMIT))
+        if limit >= _CGROUP_V1_NO_MEMORY_LIMIT:
+            return None
+        return limit
     if raw == "max":
         return None
     return int(raw)
@@ -68,6 +96,7 @@ def collect_host_facts() -> dict[str, Any]:
         "memory_total_bytes": None,
         "memory_limit_bytes": None,
     }
+    unknown: set[str] = set()
     for key, reader in (
         ("cpu_count", _usable_cpu_count),
         ("cpu_quota", _read_cgroup_cpu_quota),
@@ -79,14 +108,17 @@ def collect_host_facts() -> dict[str, Any]:
         except Exception as error:  # noqa: BLE001 - diagnostics must not fail to generate
             log.debug("Host fact unavailable", fact=key, error=str(error))
             facts[key] = None
+            unknown.add(key)
 
-    # The number that actually governs inference and API contention.
+    # The number that actually governs inference and API contention. A quota
+    # that could not be read at all leaves it unknown: rounding an unknown
+    # limit up to the whole machine is the guess this module exists to prevent.
     quota = facts["cpu_quota"]
     count = facts["cpu_count"]
-    if quota is not None and count is not None:
-        facts["effective_cpus"] = min(float(quota), float(count))
-    elif count is not None:
-        facts["effective_cpus"] = float(count)
-    else:
+    if count is None or "cpu_quota" in unknown:
         facts["effective_cpus"] = None
+    elif quota is not None:
+        facts["effective_cpus"] = min(float(quota), float(count))
+    else:
+        facts["effective_cpus"] = float(count)
     return facts

--- a/backend/tests/test_classifier_service.py
+++ b/backend/tests/test_classifier_service.py
@@ -666,11 +666,15 @@ async def test_status_reads_never_detect_acceleration_capabilities():
         # Detected once, at construction. Reading status never detects.
         assert mock_detect.call_count == 1
 
-        # Even with the reading well past its TTL, a status read must not go and
-        # find out: detection spawns child processes and this runs on the event
-        # loop, which stalled every concurrent request behind it (#313).
+        # Even with the reading past its TTL and the scheduler's grace, a status
+        # read must not go and find out: detection spawns child processes and
+        # this runs on the event loop, which stalled every concurrent request
+        # behind it (#313).
         service._accel_caps_last_refreshed_monotonic = (
-            (service._accel_caps_last_refreshed_monotonic or 0.0) - service._accel_caps_ttl_seconds - 1.0
+            (service._accel_caps_last_refreshed_monotonic or 0.0)
+            - service._accel_caps_ttl_seconds
+            - classifier_service_module.ACCEL_CAPS_STALE_GRACE_SECONDS
+            - 1.0
         )
         status = service.get_status()
 

--- a/backend/tests/test_classifier_service.py
+++ b/backend/tests/test_classifier_service.py
@@ -631,7 +631,7 @@ async def test_classifier_status_distinguishes_configured_and_effective_model_id
 
 
 @pytest.mark.asyncio
-async def test_classifier_service_caches_acceleration_probe_results():
+async def test_status_reads_never_detect_acceleration_capabilities():
     caps = {
         "ort_available": False,
         "cuda_provider_installed": False,
@@ -663,14 +663,25 @@ async def test_classifier_service_caches_acceleration_probe_results():
         service.get_status()
         service.get_status()
 
+        # Detected once, at construction. Reading status never detects.
         assert mock_detect.call_count == 1
 
+        # Even with the reading well past its TTL, a status read must not go and
+        # find out: detection spawns child processes and this runs on the event
+        # loop, which stalled every concurrent request behind it (#313).
         service._accel_caps_last_refreshed_monotonic = (
             (service._accel_caps_last_refreshed_monotonic or 0.0) - service._accel_caps_ttl_seconds - 1.0
         )
-        service.get_status()
+        status = service.get_status()
+
+        assert mock_detect.call_count == 1
+        assert status["accel_caps_stale"] is True, "a stale reading is reported as stale, not refreshed"
+
+        # The scheduler refreshes it instead, off the request path.
+        await service.refresh_accel_caps_off_request_path()
 
         assert mock_detect.call_count == 2
+        assert service.get_status()["accel_caps_stale"] is False
         await service.shutdown()
 
 

--- a/backend/tests/test_host_facts_and_probe_offloading.py
+++ b/backend/tests/test_host_facts_and_probe_offloading.py
@@ -1,0 +1,70 @@
+"""Two faults found while diagnosing #300.
+
+#313: a status request re-detected hardware capabilities inline, and detection
+spawns child processes that import an inference runtime. Every other request
+waited behind it, including ones that touch nothing. A reporter's capture showed
+`/api/version`, a fixed string, taking 22.5 seconds to first byte.
+
+The second is the reason that took so long to find: the diagnostics bundle
+records neither the host's processor count nor its memory, so a performance
+report cannot be sized. Two bundles and a HAR could not answer "is this machine
+big enough".
+"""
+
+from unittest.mock import patch
+
+from app.services.classifier_service import ClassifierService
+
+
+class _Probeless:
+    """A classifier whose capability cache is stale and must not refresh inline."""
+
+
+def test_status_does_not_detect_capabilities_inline():
+    """A status read returns what is known. It does not go and find out.
+
+    Detection spawns subprocesses with five second timeouts, so doing it on the
+    event loop stalls every concurrent request (CLAUDE.md section 4).
+    """
+    service = ClassifierService.__new__(ClassifierService)
+    service._accel_caps = {"openvino_available": True}
+    service._accel_caps_last_refreshed_monotonic = None  # never refreshed: maximally stale
+    service._accel_caps_ttl_seconds = 60.0
+
+    with patch("app.services.classifier_service._detect_acceleration_capabilities") as detect:
+        caps = service._accel_caps_for_read()
+
+    detect.assert_not_called()
+    assert caps == {"openvino_available": True}
+
+
+def test_a_never_taken_reading_says_so_rather_than_guessing():
+    """Section 5: state an unknown as unknown, do not round it up to healthy."""
+    service = ClassifierService.__new__(ClassifierService)
+    service._accel_caps = {}
+    service._accel_caps_last_refreshed_monotonic = None
+    service._accel_caps_ttl_seconds = 60.0
+
+    assert service._accel_caps_age_seconds() is None
+
+
+def test_health_reports_the_host_it_is_running_on():
+    """Sizing a performance report needs the machine, and the bundle had neither."""
+    from app.services.host_facts import collect_host_facts
+
+    facts = collect_host_facts()
+
+    assert "cpu_count" in facts
+    assert "memory_total_bytes" in facts
+    assert "cpu_quota" in facts, "a container CPU limit changes what the numbers mean"
+
+
+def test_host_facts_never_raise_on_an_unusual_platform():
+    """Diagnostics must not fail to generate because a /proc file is missing."""
+    from app.services import host_facts
+
+    with patch.object(host_facts, "_read_cgroup_cpu_quota", side_effect=OSError("no cgroup")):
+        facts = host_facts.collect_host_facts()
+
+    assert facts["cpu_quota"] is None
+    assert facts["cpu_count"] is not None

--- a/backend/tests/test_host_facts_and_probe_offloading.py
+++ b/backend/tests/test_host_facts_and_probe_offloading.py
@@ -11,13 +11,12 @@ report cannot be sized. Two bundles and a HAR could not answer "is this machine
 big enough".
 """
 
-from unittest.mock import patch
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from app.services import classifier_service
 from app.services.classifier_service import ClassifierService
-
-
-class _Probeless:
-    """A classifier whose capability cache is stale and must not refresh inline."""
 
 
 def test_status_does_not_detect_capabilities_inline():
@@ -68,3 +67,56 @@ def test_host_facts_never_raise_on_an_unusual_platform():
 
     assert facts["cpu_quota"] is None
     assert facts["cpu_count"] is not None
+
+
+def test_reload_does_not_run_model_init_on_the_event_loop():
+    """A model reload loads the model in a worker thread, not on the loop.
+
+    Saving settings with a changed provider triggers a reload from a request
+    handler's background task, which runs on the event loop. Model init also
+    re-detects hardware, which spawns subprocesses — the #313 stall, moved from
+    the status read to the settings write, unless it leaves the loop.
+    """
+    service = ClassifierService.__new__(ClassifierService)
+    service._models_lock = threading.Lock()
+    service._models = {}
+    service._worker_process_mode = False
+    service._image_execution_mode = "in_process"
+    service._classifier_supervisor = None
+    service._video_supervisor = None
+
+    init_threads: list[int] = []
+    service._init_bird_model = lambda: init_threads.append(threading.get_ident())  # type: ignore[method-assign]
+
+    async def reload_and_report_loop_thread() -> int:
+        await service.reload_bird_model()
+        return threading.get_ident()
+
+    loop_thread = asyncio.run(reload_and_report_loop_thread())
+
+    assert init_threads, "the reload never initialised the model"
+    assert init_threads[0] != loop_thread
+
+
+def test_settings_triggered_reload_builds_the_classifier_off_the_loop():
+    """Rebuilding the classifier singleton must not happen on the event loop.
+
+    Constructing ClassifierService detects hardware and loads the model
+    synchronously, so the settings-save path has to do the construction in a
+    worker thread.
+    """
+    built_threads: list[int] = []
+
+    def record_build() -> MagicMock:
+        built_threads.append(threading.get_ident())
+        return MagicMock(reload_bird_model=AsyncMock())
+
+    async def reload_and_report_loop_thread() -> int:
+        with patch.object(classifier_service, "get_classifier", side_effect=record_build):
+            await classifier_service.reload_classifier_out_of_band(full_restart=False)
+        return threading.get_ident()
+
+    loop_thread = asyncio.run(reload_and_report_loop_thread())
+
+    assert built_threads, "the reload never touched the classifier singleton"
+    assert built_threads[0] != loop_thread

--- a/backend/tests/test_host_facts_and_probe_offloading.py
+++ b/backend/tests/test_host_facts_and_probe_offloading.py
@@ -69,6 +69,72 @@ def test_host_facts_never_raise_on_an_unusual_platform():
     assert facts["cpu_count"] is not None
 
 
+def test_scheduler_wakes_more_often_than_the_reading_expires():
+    """A wake interval equal to the TTL re-probes on every tick, forever.
+
+    Detection spawns child processes that import an inference runtime, for
+    facts that cannot change without a container restart. The scheduler must
+    wake to check well within the reading's lifetime, so most wakes are a
+    monotonic comparison and a probe runs only when the reading has expired.
+    """
+    from app.main import ACCEL_CAPS_REFRESH_SECONDS
+    from app.services.classifier_service import CLASSIFIER_ACCEL_PROBE_TTL_SECONDS
+
+    assert ACCEL_CAPS_REFRESH_SECONDS < CLASSIFIER_ACCEL_PROBE_TTL_SECONDS
+
+
+def test_a_reading_is_stamped_when_detection_finishes_not_when_it_starts():
+    """A reading stamped at probe start is born as old as the probe was slow.
+
+    The probes carry five second timeouts apiece, so start-stamping makes a
+    fresh reading look seconds old and trips the staleness rule early.
+    """
+    service = ClassifierService.__new__(ClassifierService)
+    service._accel_caps = {}
+    service._accel_caps_last_refreshed_monotonic = None
+    service._accel_caps_ttl_seconds = 60.0
+
+    clock = {"now": 1000.0}
+
+    def probe_taking_ten_seconds() -> dict:
+        clock["now"] += 10.0
+        return {}
+
+    with (
+        patch(
+            "app.services.classifier_service._detect_acceleration_capabilities",
+            side_effect=probe_taking_ten_seconds,
+        ),
+        patch.object(classifier_service.time, "monotonic", side_effect=lambda: clock["now"]),
+    ):
+        service._refresh_accel_caps(force=True)
+        age = service._accel_caps_age_seconds()
+
+    assert age is not None and age < 5.0
+
+
+def test_a_reading_refreshed_on_schedule_is_never_reported_stale():
+    """The scheduler refreshes an expired reading at its next wake.
+
+    A reading one wake interval past its TTL is on schedule; reporting it
+    stale makes a healthy install flap and sends a reader chasing a
+    hardware-detection fault that does not exist. Stale must mean the
+    scheduler has actually missed.
+    """
+    service = ClassifierService.__new__(ClassifierService)
+    service._accel_caps = {}
+    service._accel_caps_ttl_seconds = 900.0
+
+    with patch.object(classifier_service.time, "monotonic", return_value=1950.0):
+        service._accel_caps_last_refreshed_monotonic = 1000.0  # expired, awaiting the next wake
+        on_schedule = service.accel_caps_are_stale()
+        service._accel_caps_last_refreshed_monotonic = 800.0  # several wakes have come and gone
+        missed = service.accel_caps_are_stale()
+
+    assert not on_schedule
+    assert missed
+
+
 def test_reload_does_not_run_model_init_on_the_event_loop():
     """A model reload loads the model in a worker thread, not on the loop.
 

--- a/backend/tests/test_host_facts_and_probe_offloading.py
+++ b/backend/tests/test_host_facts_and_probe_offloading.py
@@ -164,6 +164,30 @@ def test_reload_does_not_run_model_init_on_the_event_loop():
     assert init_threads[0] != loop_thread
 
 
+def test_the_probe_scheduler_never_builds_the_classifier():
+    """A missing singleton is skipped, not constructed on the event loop.
+
+    Constructing ClassifierService detects hardware and loads the model
+    synchronously. If a failed reload leaves the singleton absent, the probe
+    scheduler must wait for whoever owns construction, not rebuild it inline
+    and stall every request.
+    """
+    with (
+        patch.object(classifier_service, "_classifier_instance", None),
+        patch.object(ClassifierService, "__init__", side_effect=AssertionError("constructed on the event loop")),
+    ):
+        asyncio.run(classifier_service.refresh_accel_caps_if_running())
+
+
+def test_the_probe_scheduler_refreshes_a_running_classifier():
+    service = MagicMock(refresh_accel_caps_off_request_path=AsyncMock())
+
+    with patch.object(classifier_service, "_classifier_instance", service):
+        asyncio.run(classifier_service.refresh_accel_caps_if_running())
+
+    service.refresh_accel_caps_off_request_path.assert_awaited_once()
+
+
 def test_settings_triggered_reload_builds_the_classifier_off_the_loop():
     """Rebuilding the classifier singleton must not happen on the event loop.
 

--- a/backend/tests/test_host_facts_and_probe_offloading.py
+++ b/backend/tests/test_host_facts_and_probe_offloading.py
@@ -69,6 +69,83 @@ def test_host_facts_never_raise_on_an_unusual_platform():
     assert facts["cpu_count"] is not None
 
 
+def test_a_cgroup_v1_cpu_limit_is_read(tmp_path):
+    """Unraid and older Docker mount cgroup v1; a --cpus limit lives there.
+
+    Reading only the v2 path reported a two core container on a sixteen core
+    v1 host as unconstrained — the exact misdiagnosis this module exists to
+    prevent.
+    """
+    from app.services import host_facts
+
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("200000\n")
+    period.write_text("100000\n")
+
+    with (
+        patch.object(host_facts, "CGROUP_V2_CPU_MAX", str(tmp_path / "missing")),
+        patch.object(host_facts, "CGROUP_V1_CPU_QUOTA", str(quota)),
+        patch.object(host_facts, "CGROUP_V1_CPU_PERIOD", str(period)),
+    ):
+        assert host_facts._read_cgroup_cpu_quota() == 2.0
+
+    quota.write_text("-1\n")
+    with (
+        patch.object(host_facts, "CGROUP_V2_CPU_MAX", str(tmp_path / "missing")),
+        patch.object(host_facts, "CGROUP_V1_CPU_QUOTA", str(quota)),
+        patch.object(host_facts, "CGROUP_V1_CPU_PERIOD", str(period)),
+    ):
+        assert host_facts._read_cgroup_cpu_quota() is None  # explicitly unlimited
+
+
+def test_a_cgroup_v1_memory_limit_is_read(tmp_path):
+    from app.services import host_facts
+
+    limit = tmp_path / "memory.limit_in_bytes"
+    limit.write_text("2147483648\n")
+
+    with (
+        patch.object(host_facts, "CGROUP_V2_MEMORY_MAX", str(tmp_path / "missing")),
+        patch.object(host_facts, "CGROUP_V1_MEMORY_LIMIT", str(limit)),
+    ):
+        assert host_facts._read_cgroup_memory_limit() == 2147483648
+
+    # v1 reports "no limit" as a near-2^63 sentinel, not the word "max".
+    limit.write_text("9223372036854771712\n")
+    with (
+        patch.object(host_facts, "CGROUP_V2_MEMORY_MAX", str(tmp_path / "missing")),
+        patch.object(host_facts, "CGROUP_V1_MEMORY_LIMIT", str(limit)),
+    ):
+        assert host_facts._read_cgroup_memory_limit() is None
+
+
+def test_an_unreadable_cpu_quota_is_not_rounded_up_to_the_whole_machine(tmp_path):
+    """No cgroup file at all means the limit is unknown, not absent.
+
+    Claiming the full core count as effective when the quota could not be read
+    is the guess the module docstring forbids: a constrained container on an
+    exotic platform would be sized as the whole machine.
+    """
+    from app.services import host_facts
+
+    with patch.object(host_facts, "_read_cgroup_cpu_quota", side_effect=OSError("no cgroup at all")):
+        facts = host_facts.collect_host_facts()
+
+    assert facts["cpu_quota"] is None
+    assert facts["effective_cpus"] is None, "an unknown limit must stay unknown"
+
+
+def test_an_explicitly_unlimited_quota_makes_the_machine_the_limit():
+    from app.services import host_facts
+
+    with patch.object(host_facts, "_read_cgroup_cpu_quota", return_value=None):
+        facts = host_facts.collect_host_facts()
+
+    assert facts["cpu_quota"] is None
+    assert facts["effective_cpus"] == float(facts["cpu_count"])
+
+
 def test_scheduler_wakes_more_often_than_the_reading_expires():
     """A wake interval equal to the TTL re-probes on every tick, forever.
 

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -95,6 +95,7 @@ settings and do not follow the `SECTION__FIELD` precedence rules above.
 | `CLASSIFIER_RUNTIME_BENCHMARK_ENABLED` | `false` | Opt in to a synthetic accelerated-versus-CPU comparison during startup. Routine model activation validation and runtime health checks do not require it. |
 | `CLASSIFIER_IMAGE_MAX_CONCURRENT` | `2` | Maximum concurrent image-classification jobs. Use `1` on a Raspberry Pi to protect UI and event-loop responsiveness. |
 | `CLASSIFIER_IMAGE_ADMISSION_TIMEOUT_SECONDS` | `0.5` | Maximum time background image work waits for classifier capacity before it fails conservatively. The Pi example uses `1.0`. |
+| `CLASSIFIER_ACCEL_PROBE_TTL_SECONDS` | `900` | How long a hardware-capability reading stays fresh before the background scheduler re-detects it. Detection spawns short-lived child processes, so raise this on a CPU-constrained host; the capabilities cannot change without a container restart. |
 | `CLASSIFICATION__WRITE_FRIGATE_SUBLABEL` | `true` | Write the identified species back to Frigate as a sub-label. |
 | `CLASSIFICATION__PERSONALIZED_RERANK_ENABLED` | `false` | Learn per-camera/model ranking from manual tags. |
 | `CLASSIFICATION__STRICT_NON_FINITE_OUTPUT` | `true` | Reject all-non-finite classifier output (also `CLASSIFIER_STRICT_NON_FINITE_OUTPUT`). |


### PR DESCRIPTION
## Outcome

A status request no longer stops the backend answering anything else, and a diagnostics bundle now
says what machine it came from.

Closes #313.

## Included

**The probe.** `GET /api/classifier/status` is an `async def` that called `get_status()` on the event
loop. That called `_refresh_accel_caps()`, which re-ran full hardware detection whenever its cached
value was more than 60 seconds old, and detection **spawns child Python processes** that each import
an inference runtime, `subprocess.run(..., timeout=5)`, up to three of them.

The reporter's capture in #300 shows what that costs: `/api/version`, which returns a fixed string
and touches no database, disk or network, took **22,551ms with 0ms queued in the browser and
22,551ms waiting for the first byte**, alongside `/api/settings`, `/api/classifier/status`,
`/api/frigate/config` and `/api/maintenance/stats` all waiting the same time and finishing together.
It is independent of whether anything is being classified, which matches their report of the same
slowness in the middle of the night.

Detection now runs on a schedule off the request path, in a worker thread rather than on the loop. A
status read returns the last known answer and reports `accel_caps_age_seconds` and
`accel_caps_stale`, so a stale reading is visible rather than silently refreshed at the caller's
expense.

**The host facts.** A bundle recorded the app version and configuration but neither processor count
nor memory. Two bundles and a HAR were exchanged on #300 before anyone could say whether the host
was a four core box or a sixteen core one. Health and the bundle now carry usable CPU count, total
memory, and any container CPU or memory limit, which is the figure that actually governs contention.
Everything is best effort and reports unknown rather than guessing.

## Excluded

The process boundary between the web service and inference is #312 and is not attempted here. It is
blocked on a memory measurement, now filed as #314: the same instance measured 633MiB after restart
and 4.815GiB a day later, so any comparison between the modes has to be taken at matched age.

## A test that asserted the bug

`test_classifier_service_caches_acceleration_probe_results` asserted that a status read re-detects
once the cache expires. The caching intent was right, the design was not, because a cached expensive
probe still means some request pays for it. It is rewritten as
`test_status_reads_never_detect_acceleration_capabilities` and now pins the opposite contract,
including that a stale reading is reported as stale.

## Verification

`pytest` 2524 passed, 49 skipped. `npm run check` clean, `npm test` 945 passed, `npm run build`
clean. `ruff check` and `ruff format --check` clean from the repository root. Docs consistency check
passed. Both OpenAPI artifacts regenerated.

Host facts verified on macOS, where the cgroup files do not exist: `cpu_quota` and
`memory_limit_bytes` come back `None` and the rest still populate, which is the degradation the
tests pin.

## Risk

The background scheduler is cancelled on shutdown alongside its siblings. If it ever fails,
capabilities go stale rather than disappearing, and the status payload now says so.
