### PR TITLE
Report where the process's memory sits, so a growth curve can be attributed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   tunes it — and a reading the scheduler will refresh at its next wake is reported on schedule, not
   stale ([#313](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/313)).
 
+- **Health now says where the process's memory sits.** Resident memory was reported growing from
+  633MiB to 4.8GiB over about a day with no change of model, and nothing in the process could say
+  what held it ([#314](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/314)). Health
+  and the diagnostics bundle now report the process's resident memory split by kind — anonymous
+  heap, file-backed, and shared — alongside the Python allocator's live block count and the size of
+  the audio correlation buffer, so a sampled growth curve can be attributed to a holder instead of
+  guessed at. Anything unreadable is reported as unknown.
+
 - **Diagnostics now say what machine they came from.** A bundle recorded the app version and the
   configuration but neither the processor count nor the memory, so a report of slowness could not be
   sized: two bundles and a browser capture were exchanged on

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1020,6 +1020,7 @@ def _naming_health() -> dict[str, object]:
 
 def build_health_payload() -> dict[str, object]:
     from app.services.host_facts import collect_host_facts
+    from app.services.process_memory import collect_process_memory
 
     startup_warnings = getattr(app.state, "startup_warnings", [])
     startup_instance_id = getattr(app.state, "startup_instance_id", "unknown")
@@ -1069,6 +1070,10 @@ def build_health_payload() -> dict[str, object]:
         # without it, and two bundles were exchanged on #300 before anyone could
         # say whether the host was a small box or a large one.
         "host": collect_host_facts(),
+        # Where this process's memory sits. Resident memory grew eightfold in a
+        # day with no change of model (#314), and a curve without attribution
+        # can only be guessed at.
+        "process_memory": collect_process_memory(),
         "startup_instance_id": startup_instance_id,
         "startup_started_at": startup_started_at,
     }

--- a/backend/app/services/audio/audio_service.py
+++ b/backend/app/services/audio/audio_service.py
@@ -67,6 +67,14 @@ class AudioService:
             correlation_window_seconds=settings.frigate.audio_correlation_window_seconds,
         )
 
+    def buffer_size(self) -> int:
+        """How many detections the correlation buffer currently holds.
+
+        The buffer keeps up to a day of raw payloads in memory, so its size is
+        a memory-attribution reading (#314).
+        """
+        return len(self._buffer)
+
     @staticmethod
     def _extract_birdnet_mapping_key(data: dict) -> Optional[str]:
         """Return the canonical BirdNET source key used for camera mapping.

--- a/backend/app/services/process_memory.py
+++ b/backend/app/services/process_memory.py
@@ -1,0 +1,63 @@
+"""Where this process's memory sits.
+
+Container resident memory grew from 633MiB to 4.8GiB over about a day with no
+change of model (#314), and nothing in the process could say what held it.
+These readings split a sampled curve into its holders: kernel-visible RSS by
+kind, the Python allocator's live block count, and the in-process buffers that
+grow with traffic.
+
+Best effort like host_facts: an unreadable value is None, never a guess, and a
+missing /proc on an unusual platform must never break a health read.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger()
+
+PROC_SELF_STATUS = "/proc/self/status"
+
+_STATUS_FIELDS = {
+    "VmRSS": "rss_bytes",
+    "RssAnon": "anonymous_bytes",
+    "RssFile": "file_bytes",
+    "RssShmem": "shmem_bytes",
+}
+
+
+def _read_rss_by_kind() -> dict[str, int]:
+    readings: dict[str, int] = {}
+    with open(PROC_SELF_STATUS, encoding="utf-8") as handle:
+        for line in handle:
+            name, _, value = line.partition(":")
+            key = _STATUS_FIELDS.get(name)
+            if key is not None:
+                readings[key] = int(value.strip().split()[0]) * 1024
+    return readings
+
+
+def collect_process_memory() -> dict[str, Any]:
+    """The process's memory, split by what holds it."""
+    facts: dict[str, Any] = {key: None for key in _STATUS_FIELDS.values()}
+    try:
+        facts.update(_read_rss_by_kind())
+    except Exception as error:  # noqa: BLE001 - a health read must not fail here
+        log.debug("Process memory unavailable", error=str(error))
+
+    # The Python allocator's live block count separates heap growth from
+    # native runtime growth: a climbing RSS with a flat block count is not
+    # Python's doing.
+    facts["python_allocated_blocks"] = sys.getallocatedblocks()
+
+    try:
+        from app.services.audio.audio_service import audio_service
+
+        facts["audio_buffer_entries"] = audio_service.buffer_size()
+    except Exception as error:  # noqa: BLE001 - a health read must not fail here
+        log.debug("Audio buffer size unavailable", error=str(error))
+        facts["audio_buffer_entries"] = None
+    return facts

--- a/backend/tests/test_process_memory_attribution.py
+++ b/backend/tests/test_process_memory_attribution.py
@@ -1,0 +1,73 @@
+"""Attribution readings for #314.
+
+Container resident memory grew from 633MiB to 4.8GiB over about a day with no
+change of model, and nothing in the process could say what held it. Health now
+reports where the memory sits — RSS split by kind, the Python allocator's block
+count, and the size of the audio correlation buffer — so a sampled curve can be
+attributed instead of guessed at.
+"""
+
+from collections import deque
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from app.main import app
+from app.services import process_memory
+from app.services.audio.audio_service import AudioService
+
+
+def test_rss_is_reported_by_kind(tmp_path):
+    status = tmp_path / "status"
+    status.write_text(
+        "Name:\tuvicorn\nVmRSS:\t 1252224 kB\nRssAnon:\t 1000000 kB\nRssFile:\t 200000 kB\nRssShmem:\t 52224 kB\n"
+    )
+
+    with patch.object(process_memory, "PROC_SELF_STATUS", str(status)):
+        facts = process_memory.collect_process_memory()
+
+    assert facts["rss_bytes"] == 1252224 * 1024
+    assert facts["anonymous_bytes"] == 1000000 * 1024
+    assert facts["file_bytes"] == 200000 * 1024
+    assert facts["shmem_bytes"] == 52224 * 1024
+
+
+def test_an_unreadable_platform_reports_unknown_not_zero(tmp_path):
+    """No /proc on this platform must not break a health read (CLAUDE.md section 1)."""
+    with patch.object(process_memory, "PROC_SELF_STATUS", str(tmp_path / "missing")):
+        facts = process_memory.collect_process_memory()
+
+    assert facts["rss_bytes"] is None
+    assert facts["anonymous_bytes"] is None
+    # The Python allocator can always be asked, whatever the platform.
+    assert isinstance(facts["python_allocated_blocks"], int)
+
+
+def test_the_audio_buffer_says_how_big_it_is():
+    """The correlation buffer holds up to a day of raw payloads; its size is a reading, not a guess."""
+    service = AudioService.__new__(AudioService)
+    service._buffer = deque(["one", "two", "three"])
+
+    assert service.buffer_size() == 3
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_health_carries_the_memory_attribution(client: httpx.AsyncClient):
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    memory = response.json()["process_memory"]
+    assert "rss_bytes" in memory
+    assert "anonymous_bytes" in memory
+    assert "shmem_bytes" in memory
+    assert "python_allocated_blocks" in memory
+    assert "audio_buffer_entries" in memory


### PR DESCRIPTION
## Outcome

Health and the diagnostics bundle now report where the process's memory sits: resident memory split by kind (anonymous heap, file-backed, shared), the Python allocator's live block count, and the audio correlation buffer's entry count. A sampled growth curve for #314 can now be attributed to a holder instead of guessed at — a climbing RSS with a flat allocator block count is not Python's doing, and a climbing buffer count is a day of raw payloads doing what it says.

## Scope

- New `backend/app/services/process_memory.py`, wired into `build_health_payload()` beside the host facts.
- `AudioService.buffer_size()` accessor.
- Excluded: any fix for the growth itself. The ranked leak candidates (uncancelled admission tasks, per-inference `InferRequest` creation, the unbounded audio buffer) land separately so each can be judged against the attributed curve.

## Verification

- `pytest`: 2539 passed, 49 skipped. New tests cover the kB parsing, the unreadable-platform path (unknown, not zero), the buffer gauge, and the health payload carrying the block.
- Repo-wide `ruff check` and `ruff format --check` clean.

## Risk

Reads one `/proc/self/status` file per health request and calls `sys.getallocatedblocks()` — microseconds, no subprocesses. On a platform without `/proc` every reading is `null` and the health read succeeds. No schema, migration, or settings changes.