### PR TITLE
Stop the three growth paths feeding resident memory (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Classification work that outlives its lease is now cancelled, not abandoned to run on.** When a
+  classification took longer than its lease the coordinator freed the capacity slot and admitted a
+  replacement, but the overrunning work itself was left awaiting its result, holding its inputs —
+  for image work, a full-resolution frame queued for the executor. On a box that is already behind,
+  every abandonment pinned another frame, so falling behind made the process grow exactly when it
+  could least afford to ([#314](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/314)).
+  A reclaimed lease now cancels the runner; work that completes in the same instant its
+  cancellation is delivered is still ignored as a late completion, exactly as before.
+
 - **Saving settings that change the inference provider no longer stalls the backend either.**
   Taking hardware detection off the status path left one road back onto the event loop: a settings
   save that changes the provider or execution mode reloads the classifier as a background task, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   A reclaimed lease now cancels the runner; work that completes in the same instant its
   cancellation is delivered is still ignored as a late completion, exactly as before.
 
+- **The audio correlation buffer is now bounded and cheap to maintain.** The buffer keeps up to a
+  day of raw BirdNET payloads for audio and visual correlation, and it rebuilt the entire deque on
+  every append and lookup, plus rescanned every entry — rebuilding each one's identity string — to
+  refuse a broker redelivery. At a day of ordinary audio traffic that was billions of throwaway
+  allocations, feeding the steady memory growth in
+  [#314](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/314). Entries are stamped at
+  ingest so the buffer is ordered: expiry now pops from the head, redeliveries are refused by a
+  mirrored identity set in constant time, and a hard backstop caps the buffer during a payload
+  storm. One deliberate trade: after a backwards clock step, an expired entry behind a fresher one
+  is retained until the entries ahead of it expire — bounded by the window — where before it was
+  removed immediately.
+
 - **One OpenVINO inference request now serves every classification.** Each classification and each
   detector pass created a fresh inference request, and with it fresh runtime buffers — allocations
   the runtime and allocator do not hand back, so busy hours turned into resident memory that never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   A reclaimed lease now cancels the runner; work that completes in the same instant its
   cancellation is delivered is still ignored as a late completion, exactly as before.
 
+- **One OpenVINO inference request now serves every classification.** Each classification and each
+  detector pass created a fresh inference request, and with it fresh runtime buffers — allocations
+  the runtime and allocator do not hand back, so busy hours turned into resident memory that never
+  returned ([#314](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/314)). The request
+  is now created once per compiled model and reused, and because a reused request rewrites its
+  output buffer on the next inference, results are copied to the caller instead of aliasing the
+  buffer — which also removes a path where a held result could be silently overwritten.
+
 - **Saving settings that change the inference provider no longer stalls the backend either.**
   Taking hardware detection off the status path left one road back onto the event loop: a settings
   save that changes the provider or execution mode reloads the classifier as a background task, and

--- a/backend/app/services/audio/audio_service.py
+++ b/backend/app/services/audio/audio_service.py
@@ -20,6 +20,13 @@ class AudioDetection:
     sensor_id: Optional[str]
     raw_data: dict
     scientific_name: Optional[str] = None
+    source_event_id: Optional[str] = None
+
+
+# Backstop only: a day of ordinary feeder audio is far below this. It bounds a
+# payload storm inside the retention window so the buffer cannot grow without
+# limit between expiries (#314).
+MAX_BUFFER_ENTRIES = 100_000
 
 
 def _extract_birdnet_id(raw_data: dict | None) -> int | None:
@@ -55,8 +62,11 @@ def _build_source_event_id(sensor_id: str | None, raw_data: dict | None) -> str 
 
 class AudioService:
     def __init__(self):
-        # Store recent audio detections in memory for correlation
+        # Store recent audio detections in memory for correlation. The set
+        # mirrors the buffered source identities so a broker redelivery is
+        # refused in constant time rather than by rescanning a day of entries.
         self._buffer: Deque[AudioDetection] = deque()
+        self._buffered_source_ids: set[str] = set()
         # Get buffer duration from settings (convert hours to minutes)
         buffer_minutes = settings.frigate.audio_buffer_hours * 60
         self._buffer_duration = timedelta(minutes=buffer_minutes)
@@ -244,6 +254,7 @@ class AudioService:
                     except Exception:
                         pass
 
+            source_event_id = _build_source_event_id(sensor_id, data)
             detection = AudioDetection(
                 timestamp=timestamp,
                 species=species,
@@ -251,8 +262,8 @@ class AudioService:
                 sensor_id=sensor_id,
                 raw_data=data,
                 scientific_name=scientific_name,
+                source_event_id=source_event_id,
             )
-            source_event_id = _build_source_event_id(sensor_id, data)
 
             try:
                 async with get_db() as db:
@@ -275,14 +286,14 @@ class AudioService:
                 log.warning("Failed to persist audio detection", error=str(e))
                 if not diagnostic:
                     async with self._lock:
-                        self._append_to_buffer_once(detection, source_event_id=source_event_id)
+                        self._append_to_buffer_once(detection)
                 return False
 
             if diagnostic:
                 return True
 
             async with self._lock:
-                buffered = self._append_to_buffer_once(detection, source_event_id=source_event_id)
+                buffered = self._append_to_buffer_once(detection)
                 log.info(
                     "Audio detection persisted and added to correlation buffer",
                     species=species,
@@ -301,34 +312,43 @@ class AudioService:
             log.error("Failed to process audio detection", error=str(e))
             return False
 
-    def _append_to_buffer_once(self, detection: AudioDetection, *, source_event_id: str | None) -> bool:
+    def _append_to_buffer_once(self, detection: AudioDetection) -> bool:
         """Add one correlation observation without duplicating a broker redelivery."""
         self._cleanup_buffer()
-        if source_event_id and any(
-            _build_source_event_id(existing.sensor_id, existing.raw_data) == source_event_id
-            for existing in self._buffer
-        ):
+        if detection.source_event_id and detection.source_event_id in self._buffered_source_ids:
             return False
+        while len(self._buffer) >= MAX_BUFFER_ENTRIES:
+            self._discard_oldest()
+            log.warning("Audio buffer at capacity, dropped oldest entry", capacity=MAX_BUFFER_ENTRIES)
         self._buffer.append(detection)
+        if detection.source_event_id:
+            self._buffered_source_ids.add(detection.source_event_id)
         return True
 
+    def _discard_oldest(self) -> None:
+        oldest = self._buffer.popleft()
+        if oldest.source_event_id:
+            self._buffered_source_ids.discard(oldest.source_event_id)
+
     def _cleanup_buffer(self):
-        """Remove old detections from buffer."""
+        """Drop entries older than the retention window.
+
+        Entries are stamped with their ingest time, so the deque is ordered and
+        expiry pops from the left instead of rebuilding the whole buffer on
+        every append and lookup, which at a day of audio traffic was pure
+        allocation churn (#314).
+        """
         now = datetime.now(timezone.utc)
+        cutoff_seconds = self._buffer_duration.total_seconds()
         removed_count = 0
-        retained: Deque[AudioDetection] = deque()
-        for detection in self._buffer:
-            ts = detection.timestamp
-            # Ensure timezone-aware comparison
+        while self._buffer:
+            ts = self._buffer[0].timestamp
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)
-            age = (now - ts).total_seconds()
-            if age > self._buffer_duration.total_seconds():
-                removed_count += 1
-                log.debug("Removed old audio detection", species=detection.species, age=age)
-            else:
-                retained.append(detection)
-        self._buffer = retained
+            if (now - ts).total_seconds() <= cutoff_seconds:
+                break
+            self._discard_oldest()
+            removed_count += 1
 
         if removed_count > 0:
             log.info("Cleaned up audio buffer", removed=removed_count, remaining=len(self._buffer))

--- a/backend/app/services/bird_crop_service.py
+++ b/backend/app/services/bird_crop_service.py
@@ -94,6 +94,7 @@ class _OpenVINODetectorSession:
             # silent f16 overflow on Intel GPUs, matching the classifier policy.
             config["INFERENCE_PRECISION_HINT"] = "f32"
         self._compiled = self._core.compile_model(model, self.device, config)
+        self._request = None
         self._input_port = self._compiled.inputs[0]
         self._output_ports = list(self._compiled.outputs)
 
@@ -130,14 +131,18 @@ class _OpenVINODetectorSession:
         if self._input.name not in feeds:
             raise ValueError(f"Missing detector input {self._input.name}")
         with self._lock:
-            request = self._compiled.create_infer_request()
-            values = request.infer({self._input.name: feeds[self._input.name]})
-        outputs: list[np.ndarray] = []
-        for port in self._output_ports:
-            try:
-                outputs.append(np.asarray(values[port]))
-            except Exception:
-                outputs.append(np.asarray(values[_openvino_port_name(port, "")]))
+            # One request serves every detection; a request per call churns
+            # runtime allocations on every frame (#314). The reused request
+            # rewrites its buffers on the next run, so callers get copies.
+            if self._request is None:
+                self._request = self._compiled.create_infer_request()
+            values = self._request.infer({self._input.name: feeds[self._input.name]})
+            outputs: list[np.ndarray] = []
+            for port in self._output_ports:
+                try:
+                    outputs.append(np.array(values[port]))
+                except Exception:
+                    outputs.append(np.array(values[_openvino_port_name(port, "")]))
         return outputs
 
 

--- a/backend/app/services/classification_admission.py
+++ b/backend/app/services/classification_admission.py
@@ -368,6 +368,12 @@ class ClassificationAdmissionCoordinator:
                 )
             if item.on_lease_expired is not None:
                 callbacks.append((item.on_lease_expired, item.work_id, item.lease_token))
+            # The abandoned runner still holds its inputs — for image work, a
+            # full-resolution frame queued in the executor — and the freed slot
+            # admits a replacement, so an uncancelled runner pins memory exactly
+            # when the box is already behind (#314).
+            if item.task is not None:
+                item.task.cancel()
         return callbacks
 
     def _is_live_pressure_active(self) -> bool:

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -2329,6 +2329,7 @@ class OpenVINOModelInstance:
         )
         self.core = None
         self.compiled_model = None
+        self._infer_request = None
         self.input_name: Optional[str] = None
         self.labels: list[str] = []
         self.grouped_labels: list[str] = []
@@ -2479,6 +2480,7 @@ class OpenVINOModelInstance:
                     pass  # Non-fatal; proceed with original dynamic shape
 
             self.compiled_model = self.core.compile_model(model, self.device_name, config=config)
+            self._infer_request = None
             self.input_name = self.compiled_model.inputs[0].get_any_name()
             if self._startup_self_test_enabled and (_is_gpu or _is_npu):
                 # Reused for the NPU as well — validates the compiled model isn't
@@ -2504,6 +2506,7 @@ class OpenVINOModelInstance:
                 diagnostics=exc.diagnostics,
             )
             self.compiled_model = None
+            self._infer_request = None
             self.core = None
             self.loaded = False
             return False
@@ -2577,13 +2580,18 @@ class OpenVINOModelInstance:
         except Exception:
             pass
         with self._lock:
-            infer_request = self.compiled_model.create_infer_request()
-            outputs = infer_request.infer({self.input_name: input_tensor})
-        try:
-            raw = outputs[self.compiled_model.outputs[0]]
-        except Exception:
-            raw = next(iter(outputs.values()))
-        return np.asarray(raw)
+            # One request serves every inference: a request per call churns
+            # runtime allocations on every classification (#314).
+            if self._infer_request is None:
+                self._infer_request = self.compiled_model.create_infer_request()
+            outputs = self._infer_request.infer({self.input_name: input_tensor})
+            try:
+                raw = outputs[self.compiled_model.outputs[0]]
+            except Exception:
+                raw = next(iter(outputs.values()))
+            # The reused request rewrites this buffer on its next inference, so
+            # the caller must own a copy.
+            return np.array(raw)
 
     def _infer_logits(self, image: Image.Image) -> np.ndarray:
         raw = self._infer_output_tensor(image)

--- a/backend/tests/test_audio_buffer_bounds.py
+++ b/backend/tests/test_audio_buffer_bounds.py
@@ -1,0 +1,65 @@
+"""The audio correlation buffer stays bounded and cheap to maintain (#314).
+
+The buffer holds up to a day of raw MQTT payloads. It used to rebuild the whole
+deque on every append and rescan every entry to refuse a broker redelivery, so
+a day of audio traffic meant billions of string operations of pure allocation
+churn, and an entry that never expired was held forever.
+"""
+
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from app.services.audio import audio_service as audio_service_module
+from app.services.audio.audio_service import AudioDetection, AudioService
+
+
+def _service(hours: float = 24.0) -> AudioService:
+    service = AudioService.__new__(AudioService)
+    service._buffer = deque()
+    service._buffered_source_ids = set()
+    service._buffer_duration = timedelta(hours=hours)
+    return service
+
+
+def _detection(source_event_id: str | None, age_seconds: float = 0.0) -> AudioDetection:
+    return AudioDetection(
+        timestamp=datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+        species="Eurasian Wren",
+        confidence=0.9,
+        sensor_id="garden",
+        raw_data={"detectionId": 1},
+        source_event_id=source_event_id,
+    )
+
+
+def test_a_redelivered_message_is_refused():
+    service = _service()
+
+    assert service._append_to_buffer_once(_detection("garden:1")) is True
+    assert service._append_to_buffer_once(_detection("garden:1")) is False
+    assert len(service._buffer) == 1
+
+
+def test_an_expired_entry_leaves_no_trace():
+    """Expiry must release the identity too, or a day-old id blocks forever."""
+    service = _service(hours=1.0)
+
+    assert service._append_to_buffer_once(_detection("garden:1", age_seconds=7200)) is True
+    assert service._append_to_buffer_once(_detection("garden:2")) is True
+
+    assert len(service._buffer) == 1
+    assert service._append_to_buffer_once(_detection("garden:1")) is True
+
+
+def test_the_buffer_never_exceeds_its_backstop():
+    """A payload storm must not grow the buffer without bound within the window."""
+    service = _service()
+
+    with patch.object(audio_service_module, "MAX_BUFFER_ENTRIES", 3):
+        for index in range(5):
+            service._append_to_buffer_once(_detection(f"garden:{index}"))
+
+    assert len(service._buffer) == 3
+    # The evicted identities are released with their entries.
+    assert service._append_to_buffer_once(_detection("garden:0")) is True

--- a/backend/tests/test_audio_service.py
+++ b/backend/tests/test_audio_service.py
@@ -118,19 +118,39 @@ async def test_add_detection_keeps_one_buffer_observation_across_storage_retry(a
 
 
 @pytest.mark.asyncio
-async def test_cleanup_buffer_removes_expired_out_of_order_observations(audio_service):
+async def test_cleanup_buffer_pops_expired_entries_from_the_head(audio_service):
     now = datetime.now(timezone.utc)
     audio_service._buffer_duration = timedelta(minutes=1)
     audio_service._buffer.extend(
         [
+            AudioDetection(now - timedelta(minutes=5), "Old Bird", 0.8, "mic", {}),
             AudioDetection(now, "Recent Bird", 0.8, "mic", {}),
-            AudioDetection(now - timedelta(minutes=5), "Late old Bird", 0.8, "mic", {}),
         ]
     )
 
     audio_service._cleanup_buffer()
 
     assert [item.species for item in audio_service._buffer] == ["Recent Bird"]
+
+
+@pytest.mark.asyncio
+async def test_a_clock_step_straggler_is_dropped_once_it_reaches_the_head(audio_service):
+    """Entries are stamped at ingest, so the buffer is ordered; only a clock
+    step can put an expired stamp behind a fresh one. Such a straggler is
+    retained until the entries ahead of it expire — bounded by the window,
+    never held forever (#314)."""
+    now = datetime.now(timezone.utc)
+    audio_service._buffer_duration = timedelta(minutes=1)
+    fresh_head = AudioDetection(now, "Recent Bird", 0.8, "mic", {})
+    straggler = AudioDetection(now - timedelta(minutes=5), "Late old Bird", 0.8, "mic", {})
+    audio_service._buffer.extend([fresh_head, straggler])
+
+    audio_service._cleanup_buffer()
+    assert len(audio_service._buffer) == 2  # bounded retention, behind a fresh head
+
+    fresh_head.timestamp = now - timedelta(minutes=2)  # the head expires
+    audio_service._cleanup_buffer()
+    assert len(audio_service._buffer) == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_classification_admission.py
+++ b/backend/tests/test_classification_admission.py
@@ -70,7 +70,13 @@ async def test_stale_completion_after_reclaim_is_ignored():
 
     async def first_live():
         first_started.set()
-        await release_first.wait()
+        try:
+            await release_first.wait()
+        except asyncio.CancelledError:
+            # An abandoned runner is cancelled (#314); this one completes in
+            # the same window the cancellation is delivered, and its late
+            # result must still be ignored rather than double-counted.
+            pass
         return "late"
 
     task = asyncio.create_task(
@@ -300,5 +306,48 @@ async def test_submit_tolerates_timeout_race_after_item_was_already_admitted(mon
     )
 
     assert result == "background"
+
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_runner_is_cancelled_not_left_holding_its_work():
+    """Reclaiming a lease must cancel the runner, not just forget it.
+
+    An abandoned runner keeps awaiting its work — for image classification an
+    executor job holding the full-resolution frame — while the freed slot
+    admits a replacement. Under sustained overload that pins one frame per
+    abandonment, indefinitely (#314).
+    """
+    coordinator = ClassificationAdmissionCoordinator(
+        live_capacity=1,
+        background_capacity=1,
+        live_lease_timeout_seconds=0.01,
+        background_lease_timeout_seconds=1.0,
+    )
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def stuck_runner():
+        started.set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    submit_task = asyncio.create_task(
+        coordinator.submit(
+            priority="live",
+            kind="snapshot_classification",
+            runner=stuck_runner,
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    with pytest.raises(ClassificationLeaseExpiredError):
+        await submit_task
+
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
 
     await coordinator.shutdown()

--- a/backend/tests/test_openvino_infer_request_reuse.py
+++ b/backend/tests/test_openvino_infer_request_reuse.py
@@ -1,0 +1,75 @@
+"""One OpenVINO InferRequest per model, not one per inference.
+
+Creating a request per call churns runtime allocations on every single
+classification — device buffers the allocator never returns to the OS — and
+was a prime suspect for resident memory growing eightfold in a day (#314).
+A reused request rewrites its output buffer on the next inference, so the
+result handed to callers must be a copy, never a view of the buffer.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from app.services.bird_crop_service import _OpenVINODetectorSession
+from app.services.classifier_service import OpenVINOModelInstance
+
+
+def _fake_compiled(output_key: str, output_array: np.ndarray) -> MagicMock:
+    compiled = MagicMock()
+    compiled.outputs = [output_key]
+    request = MagicMock()
+    request.infer.return_value = {output_key: output_array}
+    compiled.create_infer_request.return_value = request
+    return compiled
+
+
+def _classifier_instance(output_array: np.ndarray) -> OpenVINOModelInstance:
+    instance = OpenVINOModelInstance.__new__(OpenVINOModelInstance)
+    instance.name = "test"
+    instance._lock = threading.Lock()
+    instance.input_name = "images"
+    instance.compiled_model = _fake_compiled("logits", output_array)
+    instance._infer_request = None
+    instance._preprocess = lambda image: np.zeros((1, 3, 2, 2), dtype=np.float32)
+    return instance
+
+
+def test_one_infer_request_serves_every_classification():
+    instance = _classifier_instance(np.zeros((1, 3), dtype=np.float32))
+
+    instance._infer_output_tensor(object())
+    instance._infer_output_tensor(object())
+
+    assert instance.compiled_model.create_infer_request.call_count == 1
+
+
+def test_classification_output_is_a_copy_not_a_view_of_the_request_buffer():
+    buffer = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+    instance = _classifier_instance(buffer)
+
+    result = instance._infer_output_tensor(object())
+    buffer[:] = 99.0  # the next inference rewrites the request's buffer
+
+    assert not np.shares_memory(result, buffer)
+    assert result[0][0] == 1.0
+
+
+def test_one_infer_request_serves_every_detector_run():
+    buffer = np.array([[0.5]], dtype=np.float32)
+    session = _OpenVINODetectorSession.__new__(_OpenVINODetectorSession)
+    session._lock = threading.Lock()
+    session._compiled = _fake_compiled("det", buffer)
+    session._input = SimpleNamespace(name="images")
+    session._output_ports = ["det"]
+    session._request = None
+
+    feeds = {"images": np.zeros((1, 3, 2, 2), dtype=np.float32)}
+    first = session.run(None, feeds)
+    session.run(None, feeds)
+
+    assert session._compiled.create_infer_request.call_count == 1
+    buffer[:] = 99.0
+    assert not np.shares_memory(first[0], buffer)


### PR DESCRIPTION
## Outcome

Three code paths that grow resident memory under ordinary operation are closed. Together with the attribution now in health (#316) and an external sampling run against a live install, these are the code-level fixes for the growth reported in #314.

## Included

- **Abandoned classification work is cancelled.** A lease reclaim freed the slot and admitted a replacement but left the overrunning task awaiting its result, pinning its inputs — for image work, a full-resolution frame queued in the executor. Cancelling the runner's task also cancels the queued executor job, dropping the frame before a worker picks it up. Late completions that race the cancellation are still ignored, exactly as before.
- **One OpenVINO `InferRequest` per compiled model.** Both the classifier and the crop detector created a request per inference, churning runtime buffers on every frame. The request is now created once and reused under the existing locks, and outputs are copied to callers — a reused request rewrites its buffer on the next inference, so the copy also closes a silent-overwrite path.
- **The audio correlation buffer is bounded and O(1) to maintain.** It rebuilt the whole deque on every append and lookup and rescanned every entry (rebuilding identity strings) to refuse a broker redelivery — billions of throwaway allocations across a day of audio traffic. Expiry now pops from the ordered head, redeliveries are refused by a mirrored identity set, and a 100k-entry backstop caps a payload storm.

## Excluded

- The default execution-mode change (#312) and any verdict on whether growth remains after these fixes — that is what the sampling curve plus the #316 attribution will show at matched ages.

## Behaviour trade, stated plainly

After a backwards clock step, an expired audio entry sitting behind a fresher one is retained until the entries ahead of it expire — bounded by the retention window — where before it was removed immediately. The tests encode this.

## Verification

`pytest`: 2547 passed, 49 skipped after rebasing onto current dev; repo-wide `ruff check` and `ruff format --check` clean. New tests cover lease-cancellation (including the completion-races-cancel window), request reuse and output copying for both OpenVINO call sites, and the buffer's dedupe, expiry-releases-identity, and backstop behaviour.