### PR TITLE
Explorer: one toolbar row for the view controls, and a grid that keeps its promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   model, so the default costs more memory than one shared copy — it buys an interface that stays
   responsive under load and inference that can be restarted rather than waited out.
 
+- **The Explorer's view controls live on one row, in one style.** Hide filters, the Cards/List
+  switch, and Multi-select acted on the same list from two places in two styles: Multi-select sat
+  in the page header while the other two lived inside the filter rail, where the 14rem column
+  wrapped them into a vertical stack. All three now sit together in the header toolbar wearing the
+  shared control style, and the rail keeps just the visit count above its facets. The rail toggle
+  also now names the rail as the region it controls, and the Filters button names the facets panel
+  it opens, so the two no longer publish contradictory expanded states to a screen reader when the
+  rail is collapsed and the panel is open.
+
 ### Fixed
 
 - **A card is now actually always wide enough for its bottom row.** The last release stopped the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A card is now actually always wide enough for its bottom row.** The last release stopped the
+  time-and-score row wrapping up over the bird and promised a card wide enough for one line, but
+  fixed column counts could not keep that promise: with the sidebar and the filter rail open, the
+  three-column range at 768-1279px measured cards of 141-227px against a row that needs about
+  219px in 12-hour locales, and the card's own overflow clipping cut the play button off entirely
+  on an ordinary laptop. The grid now lays out as many columns as fit a minimum card width of
+  16rem, so the guarantee is structural rather than a hope per breakpoint - at some widths that
+  means fewer, larger cards.
+
 - **Classification work that outlives its lease is now cancelled, not abandoned to run on.** When a
   classification took longer than its lease the coordinator freed the capacity slot and admitted a
   replacement, but the overrunning work itself was left awaiting its result, holding its inputs —

--- a/apps/ui/src/lib/components/ExplorerFilters.svelte
+++ b/apps/ui/src/lib/components/ExplorerFilters.svelte
@@ -9,8 +9,6 @@
         species: EventFilterSpecies[];
         cameras: string[];
         filters: EventFilters | null;
-        view?: 'cards' | 'list';
-        onviewchange?: (view: 'cards' | 'list') => void;
         /** Desktop only: the rail folds away and gives its width to the results. */
         collapsed?: boolean;
         oncollapsechange?: (collapsed: boolean) => void;
@@ -45,8 +43,6 @@
         species,
         cameras,
         filters,
-        view = 'cards',
-        onviewchange,
         collapsed = false,
         oncollapsechange,
         datePreset,
@@ -67,6 +63,20 @@
     }: Props = $props();
 
     let panelOpen = $state(false);
+
+    // Collapsing arrives from the header toolbar. The collapsed desktop shares
+    // the phone's Filters button, so the moment the rail folds away the facets
+    // close with it - leaving them open would show the facets under a control
+    // reading "Show filters". Tracking the previous value keeps the valid
+    // collapsed-with-panel-open state, which is what the Filters button opens.
+    let previousCollapsed: boolean | null = null;
+    $effect(() => {
+        const current = collapsed;
+        if (previousCollapsed !== null && current && current !== previousCollapsed) {
+            panelOpen = false;
+        }
+        previousCollapsed = current;
+    });
     let search = $state('');
 
     const totals = $derived(filters?.totals ?? null);
@@ -145,42 +155,6 @@
             })}
         </p>
 
-        <!--
-            Desktop only, since a phone already has the Filters button below.
-            It sits next to the count rather than after the view toggle, because
-            the toggle group is pushed right by `ml-auto`: in the rail that right
-            edge is 14rem away, and collapsed it is the far side of the screen,
-            so the control travelled the width of the window as you used it.
-        -->
-        <button
-            class="btn btn-ghost hidden min-h-11 px-3 py-2 text-xs lg:inline-flex"
-            aria-expanded={!collapsed}
-            aria-controls="explorer-facets"
-            onclick={() => {
-                // Collapsing has to close the panel too. The collapsed desktop
-                // shares the phone's Filters button, so leaving that open would
-                // fold the rail away and leave the facets on screen, under a
-                // control now reading "Show filters".
-                panelOpen = false;
-                oncollapsechange?.(!collapsed);
-            }}
-            data-explorer-rail-toggle
-        >
-            <svg
-                class="h-3.5 w-3.5 transition-transform duration-200 {collapsed ? '' : 'rotate-180'}"
-                viewBox="0 0 20 20"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                aria-hidden="true"
-            >
-                <path d="M12 5 7 10l5 5" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-            {collapsed
-                ? $_('events.filters.show_rail', { default: 'Show filters' })
-                : $_('events.filters.hide_rail', { default: 'Hide filters' })}
-        </button>
-
         {#each tokens as token (token.key)}
             <button
                 class="inline-flex min-h-11 items-center gap-1.5 rounded-full bg-brand-50 px-3 py-1 text-xs font-semibold text-brand-800 transition-colors hover:bg-brand-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-brand-950/40 dark:text-brand-200 dark:hover:bg-brand-950/70"
@@ -193,31 +167,10 @@
             </button>
         {/each}
 
-        <div class="ml-auto inline-flex items-center rounded-full border border-slate-200 p-0.5 dark:border-slate-700" role="group" aria-label={$_('settings.explorer_view.label')}>
-            {#each [{ value: 'cards', label: $_('settings.explorer_view.cards') }, { value: 'list', label: $_('settings.explorer_view.list') }] as option (option.value)}
-                <button
-                    type="button"
-                    aria-pressed={view === option.value}
-                    onclick={() => onviewchange?.(option.value as 'cards' | 'list')}
-                    data-explorer-view-toggle={option.value}
-                    class="inline-flex min-h-11 items-center gap-1.5 rounded-full px-3 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500
-                           {view === option.value
-                        ? 'bg-brand-500 text-white'
-                        : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}"
-                >
-                    {#if option.value === 'cards'}
-                        <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
-                    {:else}
-                        <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
-                    {/if}
-                    {option.label}
-                </button>
-            {/each}
-        </div>
-
         <button
             class="btn btn-secondary min-h-11 px-3 py-2 text-xs {collapsed ? '' : 'lg:hidden'}"
             aria-expanded={panelOpen}
+            aria-controls="explorer-facets"
             onclick={() => (panelOpen = !panelOpen)}
             data-explorer-filter-toggle
         >

--- a/apps/ui/src/lib/components/detection-card-badges.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-card-badges.layout.test.ts
@@ -44,11 +44,15 @@ describe('detection card overlay badges', () => {
         expect(detectionCardSource).not.toMatch(/absolute bottom-3 left-3[^"]*flex-wrap/);
     });
 
-    it('keeps a card wide enough for that one line', () => {
-        // Four columns beside the 14rem filter rail gave a 168px card at 1024px,
-        // which is narrower than the row it has to carry.
-        expect(eventsPageSource).toContain('md:grid-cols-3 2xl:grid-cols-4');
-        expect(eventsPageSource).not.toContain('lg:grid-cols-4 gap-4');
+    it('keeps a card wide enough for that one line, at every width', () => {
+        // Fixed column counts could not keep the promise: with the sidebar and
+        // the filter rail open, the three-column range at 768-1279px measured
+        // 141-227px cards against a row needing ~219px in 12-hour locales, and
+        // the card's overflow-hidden clipped the play button entirely. A
+        // minimum card width makes the guarantee structural instead of a
+        // breakpoint-by-breakpoint hope.
+        expect(eventsPageSource).toContain('grid-cols-[repeat(auto-fill,minmax(16rem,1fr))]');
+        expect(eventsPageSource).not.toMatch(/md:grid-cols-3|2xl:grid-cols-4/);
     });
 
     it('marks a ready full-visit clip on the play button, not beside it', () => {

--- a/apps/ui/src/lib/components/detection-row.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-row.layout.test.ts
@@ -102,10 +102,11 @@ describe('choosing the Explorer layout', () => {
 
     it('can also be switched from the Explorer itself', () => {
         // Settings is where you set the default; the toggle is where you are
-        // when you decide the cards are too big to scroll.
-        expect(filtersSource).toContain('data-explorer-view-toggle');
-        expect(filtersSource).toContain('aria-pressed={view === option.value}');
-        expect(eventsPageSource).toContain('explorerViewStore.set(next)');
+        // when you decide the cards are too big to scroll. It lives in the
+        // header toolbar beside Multi-select, in the same control style.
+        expect(eventsPageSource).toContain('data-explorer-view-toggle');
+        expect(eventsPageSource).toContain('aria-pressed={explorerView === option.value}');
+        expect(eventsPageSource).toContain('explorerViewStore.set(');
     });
 
     it('is offered in appearance settings beside the other display choices', () => {

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -1270,7 +1270,10 @@
                 {/each}
             </div>
         {:else}
-            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 2xl:grid-cols-4 gap-4">
+            <!-- A minimum card width keeps the overlay row's one-line guarantee
+                 structural: fixed column counts measured 141-227px cards beside
+                 the open sidebar and filter rail, clipping the play button. -->
+            <div class="grid grid-cols-[repeat(auto-fill,minmax(16rem,1fr))] gap-4">
                 {#each visibleEvents as event, index (eventKey(event))}
                     <DetectionCard 
                         detection={event} 

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -1030,12 +1030,58 @@
 <div class="space-y-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
         <p class="text-xs text-slate-500 -mt-2">{$_('events.classification_legend')}</p>
-        <div class="flex items-center gap-3">
-            <div class="text-sm text-slate-500">{$_('events.total_count', { values: { count: totalCount } })}</div>
+        <div class="flex flex-wrap items-center gap-2">
+            <div class="mr-1 text-sm text-slate-500">{$_('events.total_count', { values: { count: totalCount } })}</div>
+            <button
+                class="btn btn-secondary hidden min-h-11 px-3 py-2 text-xs lg:inline-flex"
+                aria-expanded={!explorerFiltersStore.collapsed}
+                aria-controls="explorer-filter-rail"
+                onclick={() => explorerFiltersStore.set(!explorerFiltersStore.collapsed)}
+                data-explorer-rail-toggle
+            >
+                <svg
+                    class="h-3.5 w-3.5 transition-transform duration-200 {explorerFiltersStore.collapsed ? '' : 'rotate-180'}"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    aria-hidden="true"
+                >
+                    <path d="M12 5 7 10l5 5" stroke-linecap="round" stroke-linejoin="round"></path>
+                </svg>
+                {explorerFiltersStore.collapsed
+                    ? $_('events.filters.show_rail', { default: 'Show filters' })
+                    : $_('events.filters.hide_rail', { default: 'Hide filters' })}
+            </button>
+            <div
+                class="inline-flex min-h-11 items-center rounded-xl border border-slate-200/80 bg-white/90 p-0.5 shadow-sm dark:border-slate-700/60 dark:bg-slate-800/80"
+                role="group"
+                aria-label={$_('settings.explorer_view.label')}
+            >
+                {#each [{ value: 'cards', label: $_('settings.explorer_view.cards') }, { value: 'list', label: $_('settings.explorer_view.list') }] as option (option.value)}
+                    <button
+                        type="button"
+                        aria-pressed={explorerView === option.value}
+                        onclick={() => explorerViewStore.set(option.value as 'cards' | 'list')}
+                        data-explorer-view-toggle={option.value}
+                        class="inline-flex h-full items-center gap-1.5 rounded-lg px-3 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500
+                               {explorerView === option.value
+                            ? 'bg-brand-500 text-white'
+                            : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}"
+                    >
+                        {#if option.value === 'cards'}
+                            <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+                        {:else}
+                            <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+                        {/if}
+                        {option.label}
+                    </button>
+                {/each}
+            </div>
             {#if authStore.hasOwnerAccess}
                 <button
                     type="button"
-                    class="btn px-3 py-2 text-xs {selectionMode
+                    class="btn min-h-11 px-3 py-2 text-xs {selectionMode
                         ? 'border border-brand-300 bg-brand-100 text-brand-700 dark:border-brand-400/60 dark:bg-brand-500/20 dark:text-brand-100'
                         : 'btn-secondary'}"
                     onclick={toggleSelectionMode}
@@ -1101,10 +1147,8 @@
             : 'lg:grid-cols-[14rem_minmax(0,1fr)]'}"
         data-explorer-layout
     >
-        <div class={explorerFiltersStore.collapsed ? '' : 'lg:sticky lg:top-4'}>
+        <div id="explorer-filter-rail" class={explorerFiltersStore.collapsed ? '' : 'lg:sticky lg:top-4'}>
         <ExplorerFilters
-            view={explorerView}
-            onviewchange={(next) => explorerViewStore.set(next)}
             collapsed={explorerFiltersStore.collapsed}
             oncollapsechange={(next) => explorerFiltersStore.set(next)}
             species={displaySpecies}

--- a/apps/ui/src/lib/pages/explorer-filter-rail.layout.test.ts
+++ b/apps/ui/src/lib/pages/explorer-filter-rail.layout.test.ts
@@ -12,38 +12,46 @@ describe('collapsing the Explorer filter rail', () => {
         expect(eventsPageSource).toContain("'lg:grid-cols-[14rem_minmax(0,1fr)]'");
     });
 
-    it('offers the control on desktop only, since a phone already has one', () => {
-        expect(filtersSource).toContain('data-explorer-rail-toggle');
-        expect(filtersSource).toContain('hidden min-h-11 px-3 py-2 text-xs lg:inline-flex');
+    it('sits in the header toolbar beside the view switch and Multi-select', () => {
+        // Inside the rail, the toolbar controls wrapped vertically down a 14rem
+        // column while Multi-select sat alone in the header: three ways of
+        // acting on the same list in two places and two styles. One row now.
+        const railToggleAt = eventsPageSource.indexOf('data-explorer-rail-toggle');
+        const viewToggleAt = eventsPageSource.indexOf('data-explorer-view-toggle');
+        const multiSelectAt = eventsPageSource.indexOf('common.multi_select');
+        expect(railToggleAt).toBeGreaterThan(-1);
+        expect(viewToggleAt).toBeGreaterThan(railToggleAt);
+        expect(multiSelectAt).toBeGreaterThan(viewToggleAt);
+        expect(filtersSource).not.toContain('data-explorer-rail-toggle');
+        expect(filtersSource).not.toContain('data-explorer-view-toggle');
+    });
+
+    it('offers the rail control on desktop only, since a phone already has one', () => {
+        expect(eventsPageSource).toContain('btn btn-secondary hidden min-h-11 px-3 py-2 text-xs lg:inline-flex');
         // The existing Filters button is what a phone uses, and what a collapsed
         // desktop uses too, so it stops hiding itself at lg when collapsed.
         expect(filtersSource).toContain("{collapsed ? '' : 'lg:hidden'}");
     });
 
-    it('says which state it is in, not just which way the chevron points', () => {
-        expect(filtersSource).toContain('aria-expanded={!collapsed}');
-        expect(filtersSource).toContain('aria-controls="explorer-facets"');
-        expect(filtersSource).toContain("events.filters.show_rail");
-        expect(filtersSource).toContain("events.filters.hide_rail");
+    it('says which state it is in, and which region it actually controls', () => {
+        expect(eventsPageSource).toContain('aria-expanded={!explorerFiltersStore.collapsed}');
+        expect(eventsPageSource).toContain('aria-controls="explorer-filter-rail"');
+        expect(eventsPageSource).toContain('id="explorer-filter-rail"');
+        expect(eventsPageSource).toContain('events.filters.show_rail');
+        expect(eventsPageSource).toContain('events.filters.hide_rail');
+        // The facets panel belongs to the Filters button alone, so the two
+        // controls no longer publish contradictory expanded states for one
+        // region when the rail is collapsed and the panel is open.
+        expect(filtersSource).not.toContain('aria-controls="explorer-facets"\n            aria-expanded={!collapsed}');
+        expect(filtersSource).toMatch(/aria-controls="explorer-facets"[\s\S]{0,200}data-explorer-filter-toggle/);
     });
 
     it('does not fold the rail away while leaving the facets on screen', () => {
-        // The collapsed desktop shares the phone's Filters button, so collapsing
-        // with that panel open would contradict the control's own label.
-        expect(filtersSource).toContain('panelOpen = false;\n                oncollapsechange?.(!collapsed);');
-    });
-
-    it('keeps the control in one place instead of walking across the screen', () => {
-        // The view toggle is pushed right by `ml-auto`. In the rail that right
-        // edge is 14rem away; collapsed it is the far side of the window, so a
-        // control placed after the toggle travelled the width of the screen as
-        // you used it. It sits beside the result count, which does not move.
-        const countAt = filtersSource.indexOf('events.filters.result_count');
-        const railToggleAt = filtersSource.indexOf('data-explorer-rail-toggle');
-        const autoMarginAt = filtersSource.indexOf('class="ml-auto');
-        expect(countAt).toBeGreaterThan(-1);
-        expect(railToggleAt).toBeGreaterThan(countAt);
-        expect(railToggleAt).toBeLessThan(autoMarginAt);
+        // Collapsing arrives from the header now, so the rail closes its own
+        // panel when the collapse lands - while keeping collapsed-with-panel-
+        // open valid, since that is exactly what the Filters button opens.
+        expect(filtersSource).toContain('previousCollapsed');
+        expect(filtersSource).toContain('panelOpen = false');
     });
 
     it('remembers the choice on the device that made it', () => {


### PR DESCRIPTION
## Outcome

Two Explorer fixes, one commit each.

- **The grid lays out by minimum card width (16rem), not column counts.** Fixed column counts could not keep the last release's one-line promise: with the sidebar and filter rail open, the three-column range at 768-1279px measured 141-227px cards against a bottom row needing ~219px in 12-hour locales, and the card's overflow clipping cut the play button off entirely. The guarantee is structural now; at some widths that means fewer, larger cards.
- **Hide filters, Cards/List, and Multi-select share one header row and one style.** They acted on the same list from two places in two styles, with the rail-bound pair wrapping vertically down the 14rem column. The move also resolves the screen-reader contradiction between the two filter toggles: the rail toggle now controls the rail region it actually collapses, the Filters button declares the facets panel it opens, and collapsing closes the facets without breaking the valid collapsed-with-panel-open state.

## Verification

- `npm run check`: 0 errors, 0 warnings. `npm test`: 945 passed, with the layout-test contracts updated to pin the new toolbar location, style, and aria relationships.
- Verified in a browser against live data: collapse/expand round trip, the collapsed-desktop Filters panel, both view layouts, and the aria states in the DOM for the previously-contradictory collapsed-plus-panel-open case.

## Excluded

The remaining review findings (keyboard preview focus-scroll race, sticky unsaved accessibility preview, selection-mode preview trigger, near-inert Reduce Motion) follow on this branch's successor.