### PR TITLE
Teach the flavor smoke test the lazy subprocess default

### DIFF
--- a/tests/e2e/monolith_runtime_flavor_smoke.sh
+++ b/tests/e2e/monolith_runtime_flavor_smoke.sh
@@ -24,7 +24,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-docker_args=(run --detach --name "$container_name")
+# The default execution mode loads models lazily in worker processes, so the
+# classification below pays a cold worker spawn. Emulated platforms need more
+# patience than the production defaults allow.
+docker_args=(
+  run --detach --name "$container_name"
+  -e CLASSIFICATION__WORKER_READY_TIMEOUT_SECONDS=240
+  -e CLASSIFIER_BACKGROUND_IMAGE_LEASE_TIMEOUT_SECONDS=300
+)
 if [[ -n "$platform" ]]; then
   docker_args+=(--platform "$platform")
 fi
@@ -73,7 +80,11 @@ import json
 import sys
 
 status = json.load(sys.stdin)
-if status.get("loaded") is not True:
+if status.get("image_execution_mode") == "subprocess":
+    # The default mode holds no model in the API process; workers load their
+    # own copy on first use. The classification below is the load proof.
+    pass
+elif status.get("loaded") is not True:
     error = status.get("error") or "unknown error"
     raise SystemExit(f"classifier not loaded: {error}")
 if not status.get("effective_model_id"):
@@ -87,11 +98,21 @@ from PIL import Image
 
 Image.new("RGB", (224, 224), color=(96, 128, 96)).save("/tmp/yawamf-smoke.png")
 '
-classification="$(
-  docker exec "$container_name" \
-    curl -fsS -F image=@/tmp/yawamf-smoke.png \
-    http://127.0.0.1:8080/api/classifier/classify
-)"
+# The first request pays the cold worker spawn and may outlive its lease on an
+# emulated platform; the pool persists, so a retry classifies immediately.
+classification=""
+for attempt in 1 2 3; do
+  if classification="$(
+    docker exec "$container_name" \
+      curl -fsS --max-time 360 -F image=@/tmp/yawamf-smoke.png \
+      http://127.0.0.1:8080/api/classifier/classify
+  )" && printf '%s' "$classification" \
+    | docker exec -i "$container_name" python -c 'import json,sys; raise SystemExit(0 if json.load(sys.stdin).get("status") == "ok" else 1)'; then
+    break
+  fi
+  echo "classification attempt $attempt did not succeed; the worker may still be spawning" >&2
+  sleep 15
+done
 printf '%s' "$classification" | docker exec -i "$container_name" python -c '
 import json
 import sys


### PR DESCRIPTION
## Outcome

The dev image build failed at the runtime-flavor smoke gate on every flavor after #318: the smoke contract asserted `loaded: true` at boot, and the new default deliberately loads nothing in the API process — workers spawn on first use.

## Change

- The status assertion is mode-aware: in `subprocess` mode the API process holding no model is the correct state; `effective_model_id` and the label count are still asserted up front.
- The classification round-trip becomes the load proof, made patient enough for a cold worker spawn on an emulated platform: `CLASSIFICATION__WORKER_READY_TIMEOUT_SECONDS=240` and `CLASSIFIER_BACKGROUND_IMAGE_LEASE_TIMEOUT_SECONDS=300` on the smoke container, a 360s curl budget, and up to three attempts — the first may outlive its lease while the pool it spawned lives on.

## Verification

`bash -n` clean; the real verification is the next dev build, since only build-and-push exercises this script. If the emulated RPi flavor still can't spawn a worker inside these budgets, the next lever is a bigger ready budget there specifically.