### PR TITLE
Give the build's pytest gate a hang budget, not a runtime budget

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -186,7 +186,10 @@ jobs:
         run: |
           cd backend
           LOG_FILE=/tmp/backend-tests.log
-          TEST_TIMEOUT_SECONDS=240
+          # A hang detector, not a runtime budget: the suite passed 2,556
+          # tests and was killed mid-file at 240s after a day of added
+          # coverage. Generous enough that only a real hang trips it.
+          TEST_TIMEOUT_SECONDS=480
           HEARTBEAT_INTERVAL_SECONDS=30
           SUMMARY_GRACE_SECONDS=12
           MONITOR_INTERVAL_SECONDS=2


### PR DESCRIPTION
## Outcome

The third and final build failure from tonight's merges: `test-backend` in the build workflow killed a healthy suite mid-file at 93% — 2,556 tests outgrew the 240s cap that PR CI does not impose. The cap exists to catch hangs; 480s keeps that protection at roughly double the suite's current runner time.

## Verification

The dev build after merge is the proof; the two smoke-gate fixes (#320, #321) are already on dev, so this build should be the one that goes green end to end.