### PR TITLE
Let the view toggle's segments fill the control

### DIFF
--- a/apps/ui/src/lib/components/detection-row.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-row.layout.test.ts
@@ -107,6 +107,10 @@ describe('choosing the Explorer layout', () => {
         expect(eventsPageSource).toContain('data-explorer-view-toggle');
         expect(eventsPageSource).toContain('aria-pressed={explorerView === option.value}');
         expect(eventsPageSource).toContain('explorerViewStore.set(');
+        // The segments stretch to the control's full height: `items-center`
+        // on the container left the active pill collapsed to text height,
+        // since a child's h-full has nothing to measure against a min-h parent.
+        expect(eventsPageSource).toContain('min-h-11 items-stretch');
     });
 
     it('is offered in appearance settings beside the other display choices', () => {

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -1054,7 +1054,7 @@
                     : $_('events.filters.hide_rail', { default: 'Hide filters' })}
             </button>
             <div
-                class="inline-flex min-h-11 items-center rounded-xl border border-slate-200/80 bg-white/90 p-0.5 shadow-sm dark:border-slate-700/60 dark:bg-slate-800/80"
+                class="inline-flex min-h-11 items-stretch rounded-xl border border-slate-200/80 bg-white/90 p-0.5 shadow-sm dark:border-slate-700/60 dark:bg-slate-800/80"
                 role="group"
                 aria-label={$_('settings.explorer_view.label')}
             >
@@ -1064,7 +1064,7 @@
                         aria-pressed={explorerView === option.value}
                         onclick={() => explorerViewStore.set(option.value as 'cards' | 'list')}
                         data-explorer-view-toggle={option.value}
-                        class="inline-flex h-full items-center gap-1.5 rounded-lg px-3 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500
+                        class="inline-flex items-center gap-1.5 rounded-lg px-3 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500
                                {explorerView === option.value
                             ? 'bg-brand-500 text-white'
                             : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}"


### PR DESCRIPTION
The Cards/List segmented control centred its children, so the active pill collapsed to text height (a child's `h-full` has nothing to measure against a `min-h`-only parent) and floated small inside the control — most visibly on a phone. The container now stretches segments to its full height, pinned in the layout test. Verified in the browser at mobile width against live data: the active pill fills the control.

`npm run check` 0/0, `npm test` 945 passed.