### PR TITLE
Let the row preview survive the scroll that opens it, and step aside in selection mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The list row's hover preview now survives the scroll that opens it.** Focusing a thumbnail
+  below the fold scrolls it into view, and the preview closed itself on that very scroll — the
+  keyboard path silently did nothing for exactly the rows that needed scrolling. The panel now
+  follows its row as the page moves and closes only when the row actually leaves the screen. In
+  bulk-select mode the preview steps aside entirely: activating a control announced as "Preview"
+  was toggling the row's selection, so there the thumbnail is decoration and the row's own
+  labelled control owns every activation. The trigger also no longer claims an expanded state
+  for a panel it has no accessible link to, and a very narrow viewport clips the panel's margin
+  rather than its content.
+
 - **Classifier status reports the active model's label count without a resident model.** With
   inference out of the API process by default, the process answering status holds no model, and the
   label count silently read as zero on every default install. The count is a fact about the

--- a/apps/ui/src/lib/components/DetectionPreview.svelte
+++ b/apps/ui/src/lib/components/DetectionPreview.svelte
@@ -18,6 +18,10 @@
         primaryName: string;
         secondaryName?: string | null;
         onopen?: (detection: Detection) => void;
+        /** False renders the thumbnails as decoration: no tab stop, no click.
+         * The Explorer's selection mode owns every activation through the
+         * row overlay, which is labelled for selecting, not previewing. */
+        interactive?: boolean;
     }
 
     let {
@@ -26,7 +30,8 @@
         frameCount = 1,
         primaryName,
         secondaryName = null,
-        onopen
+        onopen,
+        interactive = true
     }: Props = $props();
 
     /**
@@ -88,6 +93,13 @@
         openIndex = index;
     }
 
+    function cancelScheduledClose(): void {
+        if (closeTimer) {
+            clearTimeout(closeTimer);
+            closeTimer = null;
+        }
+    }
+
     function hide(immediate = false): void {
         if (closeTimer) clearTimeout(closeTimer);
         if (immediate) {
@@ -121,16 +133,34 @@
         };
     });
 
-    // Placed in viewport coordinates, so scrolling or resizing would leave the
-    // panel behind. Closing is honest; a panel pointing at the wrong row is not.
+    // Placed in viewport coordinates, so the panel follows its trigger as the
+    // page moves. Closing on the first scroll broke the keyboard path: focusing
+    // a trigger below the fold scrolls it into view, and that scroll landed
+    // right after the panel opened, dismissing it in the same frame. A trigger
+    // scrolled out of sight still closes it - a panel pointing at nothing is
+    // honest to no one.
     $effect(() => {
         if (openIndex === null) return;
-        const close = () => hide(true);
-        window.addEventListener('scroll', close, true);
-        window.addEventListener('resize', close);
+        const index = openIndex;
+        let pending: number | null = null;
+        const follow = () => {
+            if (pending !== null) return;
+            pending = requestAnimationFrame(() => {
+                pending = null;
+                const rect = triggers[index]?.getBoundingClientRect();
+                if (!rect || rect.bottom < 0 || rect.top > window.innerHeight) {
+                    hide(true);
+                    return;
+                }
+                place(index);
+            });
+        };
+        window.addEventListener('scroll', follow, true);
+        window.addEventListener('resize', follow);
         return () => {
-            window.removeEventListener('scroll', close, true);
-            window.removeEventListener('resize', close);
+            if (pending !== null) cancelAnimationFrame(pending);
+            window.removeEventListener('scroll', follow, true);
+            window.removeEventListener('resize', follow);
         };
     });
 
@@ -176,19 +206,7 @@
             onfocusin={() => show(index)}
             role="presentation"
         >
-            <button
-                type="button"
-                bind:this={triggers[index]}
-                class="grid min-h-11 min-w-11 place-items-center rounded-lg focus-ring"
-                aria-expanded={openIndex === index}
-                onclick={() => onopen?.(frame)}
-            >
-                <span class="sr-only">
-                    {$_('dashboard.field_log.preview_trigger', {
-                        values: { species: primaryName },
-                        default: 'Preview {species}'
-                    })}
-                </span>
+            {#snippet thumbnail(frame: Detection)}
                 {#if failed.has(frame.frigate_event)}
                     <span
                         class="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-white bg-slate-100 text-slate-300 dark:border-slate-900 dark:bg-slate-800 dark:text-slate-600"
@@ -210,18 +228,39 @@
                         onerror={() => markFailed(frame.frigate_event)}
                     />
                 {/if}
-            </button>
+            {/snippet}
+
+            {#if interactive}
+                <button
+                    type="button"
+                    bind:this={triggers[index]}
+                    class="grid min-h-11 min-w-11 place-items-center rounded-lg focus-ring"
+                    onclick={() => onopen?.(frame)}
+                >
+                    <span class="sr-only">
+                        {$_('dashboard.field_log.preview_trigger', {
+                            values: { species: primaryName },
+                            default: 'Preview {species}'
+                        })}
+                    </span>
+                    {@render thumbnail(frame)}
+                </button>
+            {:else}
+                <span bind:this={triggers[index]} class="grid min-h-11 min-w-11 place-items-center rounded-lg" aria-hidden="true">
+                    {@render thumbnail(frame)}
+                </span>
+            {/if}
 
             {#if openIndex === index && anchor}
                 <div
                     use:portal
                     style="left: {anchor.x}px; top: {anchor.y}px;"
-                    class="fixed z-[70] w-60 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl shadow-slate-950/20 animate-in fade-in zoom-in-95 motion-reduce:animate-none dark:border-slate-700 dark:bg-slate-900 {anchor.above
+                    class="fixed z-[70] w-60 max-w-[calc(100vw-16px)] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl shadow-slate-950/20 animate-in fade-in zoom-in-95 motion-reduce:animate-none dark:border-slate-700 dark:bg-slate-900 {anchor.above
                         ? '-translate-x-1/2 -translate-y-full'
                         : '-translate-x-1/2'}"
                     role="tooltip"
                     data-detection-preview-panel
-                    onmouseenter={() => show(index)}
+                    onmouseenter={cancelScheduledClose}
                     onmouseleave={() => hide()}
                 >
                     {#if failed.has(frame.frigate_event)}

--- a/apps/ui/src/lib/components/DetectionRow.svelte
+++ b/apps/ui/src/lib/components/DetectionRow.svelte
@@ -123,6 +123,7 @@
          opens on focus as well as hover, and closes on Escape. -->
     <div class="relative z-10 flex justify-center">
         <DetectionPreview
+            interactive={!selectionMode}
             {detection}
             primaryName={primaryName}
             secondaryName={subName}

--- a/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
+++ b/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
@@ -107,7 +107,10 @@ describe('dashboard field desk layout', () => {
         // The pointer must be able to travel into the panel (WCAG 2.2 SC 1.4.13).
         expect(previewSource).toContain('CLOSE_GRACE_MS');
         expect(previewSource).toContain('motion-reduce:animate-none');
-        expect(previewSource).toContain('aria-expanded={openIndex === index}');
+        // A tooltip trigger does not disclose a region it owns: the panel is
+        // portalled to the body with no DOM or aria-controls linkage, so
+        // aria-expanded announced a state that pointed at nothing.
+        expect(previewSource).not.toContain('aria-expanded');
         expect(previewSource).toContain('focus-ring');
     });
 

--- a/apps/ui/src/lib/pages/explorer-filter-rail.layout.test.ts
+++ b/apps/ui/src/lib/pages/explorer-filter-rail.layout.test.ts
@@ -89,9 +89,22 @@ describe('the Explorer list row preview', () => {
         expect(eventsPageSource).toContain('overflow-hidden rounded-2xl');
     });
 
-    it('closes rather than pointing at the wrong row once the page moves', () => {
-        expect(previewSource).toContain("window.addEventListener('scroll', close, true)");
-        expect(previewSource).toContain("window.addEventListener('resize', close)");
+    it('follows its row when the page moves, closing only when the row leaves', () => {
+        // Closing on the first scroll broke the keyboard path: focusing a
+        // trigger below the fold scrolls it into view, and that scroll landed
+        // right after the panel opened, dismissing it in the same frame.
+        expect(previewSource).toContain('requestAnimationFrame');
+        expect(previewSource).toContain("window.addEventListener('scroll', follow, true)");
+        expect(previewSource).toContain("window.addEventListener('resize', follow)");
+        expect(previewSource).not.toContain("window.addEventListener('scroll', close");
+    });
+
+    it('stands aside in selection mode instead of hijacking it', () => {
+        // Activating a control announced as "Preview" must not toggle the
+        // row's selection; in selection mode the row overlay, labelled for
+        // selecting, owns every activation and the thumbnail is decoration.
+        expect(rowSource).toContain('interactive={!selectionMode}');
+        expect(previewSource).toContain('{#if interactive}');
     });
 
     it('flips above the thumbnail when there is no room below', () => {


### PR DESCRIPTION
## Outcome

The remaining Explorer-page findings from this week's review, plus adjacent polish, in one slice:

- **Keyboard preview no longer self-dismisses.** Focusing a below-fold thumbnail scrolls it into view, and the panel closed on that very scroll. It now follows its trigger as the page moves (rAF-throttled) and closes only when the trigger genuinely leaves the viewport.
- **Selection mode owns its activations.** The preview trigger — announced as "Preview {species}" — was toggling row selection in bulk-select mode. There it now renders as decoration (no tab stop, no click), leaving the row's correctly-labelled overlay in charge.
- **Tooltip honesty**: the trigger drops `aria-expanded` (the panel is a body-portalled tooltip with no accessible linkage, so the state pointed at nothing); pointer re-entry into the panel only cancels the scheduled close instead of forcing a re-measure; and the panel takes `max-w-[calc(100vw-16px)]` so a very narrow viewport clips margin, not content.

## Verification

- `npm run check` 0/0; `npm test` 946 passed, with the layout contracts rewritten to pin follow-on-scroll, the selection-mode stand-aside, and the aria removal.
- Browser-verified against live data: opens on hover and focusin, stays open through the scroll that previously killed it, closes when the trigger leaves the viewport. The reposition itself is rAF-driven, which a hidden pane suspends — verified by code and source pin; behaves per-frame in a visible tab.

Note: stacked on the merged #323; diff vs dev is this commit alone.