### PR TITLE
Make Reduce Motion real, and stop an abandoned preview sticking app-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,21 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Reduce Motion now actually reduces motion.** The setting applied a `reduced-motion` class that
+  no stylesheet carried a rule for, so a control described as disabling animations changed exactly
+  one sparkline — the same defect the zen mode toggle was removed for. The class now applies the
+  same suppression as the `prefers-reduced-motion` media rules, because the in-app setting must
+  work for a reader whose operating-system preference it cannot see, and the scripts that gate
+  their own motion (the footer, the species collage) honour the class as well as the media query.
+
+- **An abandoned accessibility preview no longer sticks to the whole app.** Flipping High Contrast,
+  the dyslexia font, or Reduce Motion in Settings previewed live by toggling classes on the
+  document root with nothing to undo it: leave the page without saving and the preview stayed, on
+  every page, until a reload. The editor now publishes its unsaved state and clears it on the way
+  out, and the app root — the one owner of those classes — applies the preview while it exists and
+  the saved value the moment it does not. Opening the tab also no longer strips a saved-on setting
+  while the settings are still loading.
+
 - **The list row's hover preview now survives the scroll that opens it.** Focusing a thumbnail
   below the fold scrolls it into view, and the preview closed itself on that very scroll — the
   keyboard path silently did nothing for exactly the rows that needed scrolling. The panel now

--- a/apps/ui/src/App.accessibility-reach.test.ts
+++ b/apps/ui/src/App.accessibility-reach.test.ts
@@ -1,7 +1,18 @@
+// Node types are intentionally absent from the browser tsconfig (see
+// code-quality-no-any.test.ts); this stylesheet audit runs under Vitest's
+// Node environment.
+// @ts-expect-error -- node:fs resolves at runtime, not in the app tsconfig
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import appSource from './App.svelte?raw';
 import authStoreSource from './lib/stores/auth.svelte.ts?raw';
 import settingsPageSource from './lib/pages/Settings.svelte?raw';
+import accessibilityEditorSource from './lib/components/settings/AccessibilitySettings.svelte?raw';
+import footerSource from './lib/components/Footer.svelte?raw';
+import collageSource from './lib/components/TopSpeciesCollage.svelte?raw';
+
+// Vitest stubs CSS imports, so the stylesheet is read straight from disk.
+const appCss = readFileSync(new URL('./app.css', import.meta.url), 'utf-8');
 
 /**
  * High contrast, the dyslexia font and reduced motion are applied from the
@@ -10,16 +21,36 @@ import settingsPageSource from './lib/pages/Settings.svelte?raw';
  * and the owner has no way to give it to them.
  */
 describe('accessibility choices reaching a public visitor', () => {
-    it('falls back to the public status payload when settings are unreadable', () => {
-        expect(appSource).toContain(
-            'settingsStore.settings?.accessibility_high_contrast ?? authStore.highContrast'
-        );
-        expect(appSource).toContain(
-            'settingsStore.settings?.accessibility_dyslexia_font ?? authStore.dyslexiaFont'
-        );
-        expect(appSource).toContain(
-            'settingsStore.settings?.accessibility_reduced_motion ?? authStore.reducedMotion'
-        );
+    it('falls back through preview, saved value, then the public payload', () => {
+        expect(appSource).toContain('accessibilityPreview.highContrast ??');
+        expect(appSource).toContain('settingsStore.settings?.accessibility_high_contrast ??');
+        expect(appSource).toContain('authStore.highContrast');
+        expect(appSource).toContain('accessibilityPreview.dyslexiaFont ??');
+        expect(appSource).toContain('accessibilityPreview.reducedMotion ??');
+    });
+
+    it('gives the document root exactly one owner', () => {
+        // The Settings editor previously toggled the same classes from its
+        // unsaved props with no teardown, so an abandoned preview stuck to
+        // the whole app until a reload. The editor now publishes a preview
+        // value, only on a change, and clears it on unmount; App alone
+        // touches the DOM.
+        expect(accessibilityEditorSource).not.toContain('documentElement');
+        expect(accessibilityEditorSource).toContain('accessibilityPreview.clear()');
+    });
+
+    it('backs the reduced-motion class with stylesheet rules', () => {
+        // The class had no CSS at all: a control labelled as disabling
+        // animations changed one sparkline. The class now mirrors the
+        // prefers-reduced-motion media block, since the in-app setting must
+        // work for a reader whose OS preference it cannot see.
+        expect(appCss).toContain('.reduced-motion *');
+        expect(appCss).toContain('.reduced-motion .animate-ping');
+    });
+
+    it('reaches the scripts that gate their own motion', () => {
+        expect(footerSource).toContain("classList.contains('reduced-motion')");
+        expect(collageSource).toContain("classList.contains('reduced-motion')");
     });
 
     it('reads both from auth status, which a guest can load', () => {

--- a/apps/ui/src/App.svelte
+++ b/apps/ui/src/App.svelte
@@ -21,6 +21,7 @@
   import { checkHealth, fetchAnalysisStatus, fetchCacheStats, fetchEventClassificationStatus, setAuthErrorCallback } from './lib/api';
   import { themeStore } from './lib/stores/theme.svelte';
   import { layoutStore } from './lib/stores/layout.svelte';
+import { accessibilityPreview } from './lib/stores/accessibility_preview.svelte';
   import { settingsStore } from './lib/stores/settings.svelte';
   import { detectionsStore } from './lib/stores/detections.svelte';
   import { authStore } from './lib/stores/auth.svelte';
@@ -123,13 +124,19 @@
   // and survive a reload. AccessibilitySettings toggles the same classes from
   // its unsaved state, which is the live preview while you are editing.
   const highContrast = $derived(
-      settingsStore.settings?.accessibility_high_contrast ?? authStore.highContrast
+      accessibilityPreview.highContrast ??
+          settingsStore.settings?.accessibility_high_contrast ??
+          authStore.highContrast
   );
   const dyslexiaFont = $derived(
-      settingsStore.settings?.accessibility_dyslexia_font ?? authStore.dyslexiaFont
+      accessibilityPreview.dyslexiaFont ??
+          settingsStore.settings?.accessibility_dyslexia_font ??
+          authStore.dyslexiaFont
   );
   const reducedMotion = $derived(
-      settingsStore.settings?.accessibility_reduced_motion ?? authStore.reducedMotion
+      accessibilityPreview.reducedMotion ??
+          settingsStore.settings?.accessibility_reduced_motion ??
+          authStore.reducedMotion
   );
 
   $effect(() => {

--- a/apps/ui/src/app.css
+++ b/apps/ui/src/app.css
@@ -659,6 +659,26 @@ html.theme-bluetit.dark .ai-markdown-surface th { color: rgb(191 219 254); }
   }
 }
 
+/* The owner's Reduce Motion setting applies the same suppression by class.
+   The media query only honours the OS preference; the in-app control has to
+   work for a reader whose OS setting it cannot see. */
+.reduced-motion *,
+.reduced-motion *::before,
+.reduced-motion *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+.reduced-motion .status-pulse::after {
+  animation: none !important;
+}
+
+.reduced-motion .animate-ping {
+  animation: none !important;
+}
+
 /* Screen reader only - hides visually but keeps for assistive tech */
 .sr-only {
   position: absolute;

--- a/apps/ui/src/lib/components/Footer.svelte
+++ b/apps/ui/src/lib/components/Footer.svelte
@@ -62,7 +62,8 @@
     onMount(() => {
         const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
         const updateMotionPreference = () => {
-            prefersReducedMotion = motionQuery.matches;
+            prefersReducedMotion =
+                motionQuery.matches || document.documentElement.classList.contains('reduced-motion');
             if (prefersReducedMotion && transitionTimeout !== undefined) {
                 clearTimeout(transitionTimeout);
                 transitionTimeout = undefined;

--- a/apps/ui/src/lib/components/TopSpeciesCollage.svelte
+++ b/apps/ui/src/lib/components/TopSpeciesCollage.svelte
@@ -53,7 +53,7 @@
         if (typeof window === 'undefined') return;
         const query = window.matchMedia('(prefers-reduced-motion: reduce)');
         const syncPreference = () => {
-            reduceMotion = query.matches;
+            reduceMotion = query.matches || document.documentElement.classList.contains('reduced-motion');
         };
         syncPreference();
         query.addEventListener('change', syncPreference);

--- a/apps/ui/src/lib/components/settings/AccessibilitySettings.svelte
+++ b/apps/ui/src/lib/components/settings/AccessibilitySettings.svelte
@@ -3,6 +3,7 @@
     import SettingsCard from './_primitives/SettingsCard.svelte';
     import SettingsRow from './_primitives/SettingsRow.svelte';
     import SettingsToggle from './_primitives/SettingsToggle.svelte';
+    import { accessibilityPreview } from '../../stores/accessibility_preview.svelte';
 
     let {
         highContrast = $bindable(false),
@@ -21,14 +22,13 @@
     const currentLocale = $derived(typeof $locale === 'string' ? $locale : 'en');
     const showDyslexicFont = $derived(latinLanguages.includes(currentLocale));
 
+    // The document root has exactly one owner: App.svelte applies
+    // preview ?? saved. Publishing only on a change (never on mount) means
+    // opening this tab cannot strip a saved-on class while settings are
+    // still loading, and clearing on unmount means an abandoned preview
+    // falls back to the saved value instead of sticking until a reload.
     $effect(() => {
-        document.documentElement.classList.toggle('high-contrast', highContrast);
-    });
-    $effect(() => {
-        document.documentElement.classList.toggle('font-dyslexic', dyslexiaFont);
-    });
-    $effect(() => {
-        document.documentElement.classList.toggle('reduced-motion', reducedMotion);
+        return () => accessibilityPreview.clear();
     });
 </script>
 
@@ -46,7 +46,10 @@
             checked={highContrast}
             labelledBy="setting-high-contrast"
             srLabel={$_('settings.accessibility.high_contrast')}
-            onchange={(v) => (highContrast = v)}
+            onchange={(v) => {
+                highContrast = v;
+                accessibilityPreview.highContrast = v;
+            }}
         />
     </SettingsRow>
 
@@ -60,7 +63,10 @@
                 checked={dyslexiaFont}
                 labelledBy="setting-dyslexia-font"
                 srLabel={$_('settings.accessibility.dyslexia_font')}
-                onchange={(v) => (dyslexiaFont = v)}
+                onchange={(v) => {
+                dyslexiaFont = v;
+                accessibilityPreview.dyslexiaFont = v;
+            }}
             />
         </SettingsRow>
     {/if}
@@ -74,7 +80,10 @@
             checked={reducedMotion}
             labelledBy="setting-reduced-motion"
             srLabel={$_('settings.accessibility.reduced_motion')}
-            onchange={(v) => (reducedMotion = v)}
+            onchange={(v) => {
+                reducedMotion = v;
+                accessibilityPreview.reducedMotion = v;
+            }}
         />
     </SettingsRow>
 

--- a/apps/ui/src/lib/stores/accessibility_preview.svelte.ts
+++ b/apps/ui/src/lib/stores/accessibility_preview.svelte.ts
@@ -1,0 +1,22 @@
+/**
+ * The unsaved state of the Settings accessibility toggles.
+ *
+ * The editor publishes what the owner is trying out; App.svelte applies
+ * preview ?? saved to the document root. Null means "no preview", so an
+ * abandoned edit falls back to the saved value the moment the editor
+ * unmounts - previously the editor toggled the classes itself with no
+ * teardown, and an unsaved preview stuck to the whole app until a reload.
+ */
+class AccessibilityPreview {
+    highContrast = $state<boolean | null>(null);
+    dyslexiaFont = $state<boolean | null>(null);
+    reducedMotion = $state<boolean | null>(null);
+
+    clear(): void {
+        this.highContrast = null;
+        this.dyslexiaFont = null;
+        this.reducedMotion = null;
+    }
+}
+
+export const accessibilityPreview = new AccessibilityPreview();


### PR DESCRIPTION
## Outcome

The two Settings-page findings from this week's review.

- **Reduce Motion does what it says.** The `reduced-motion` class had no stylesheet rule; its only consumer was one sparkline — the same claims-an-effect-it-lacks defect zen mode was removed for. The class now mirrors the `prefers-reduced-motion` suppression (the in-app setting must work for readers whose OS preference it cannot see), and the footer and species collage honour the class alongside their media-query checks.
- **The live preview has one owner.** The accessibility editor toggled document-root classes from unsaved props with no teardown: abandon the preview and it stuck app-wide until reload; mount the tab and saved-on classes were stripped while settings loaded. The editor now publishes unsaved values to a small preview store — only on a user change — and clears it on unmount; App.svelte alone touches the DOM, applying `preview ?? saved ?? public`.

## Verification

`npm run check` 0/0; `npm test` 948 passed. The accessibility-reach layout contract now pins: the three-way fallback chain, the editor never touching `documentElement`, the stylesheet rules existing for the class, and the script-gated components reading it. The one `@ts-expect-error` follows the repo's existing convention that Node types stay out of the browser tsconfig (see code-quality-no-any.test.ts).