### PR TITLE
Let an owner open a detection's originating Frigate event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- **An owner can open a detection's originating Frigate event.** A detection came from a Frigate
+  event, and there was no way to get from one to the other: finding the clip or timeline meant
+  searching Frigate by camera and time
+  ([#309](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/309)). The link lives with
+  the technical identifiers behind the detection-ID disclosure, not as an action on the photograph.
+  It is built from the owner-only settings payload, so a guest never sees the Frigate address, and
+  a detection whose event Frigate no longer holds says so in words instead of offering a link that
+  lands on an error. One honest caveat: the link uses the configured Frigate URL, which on some
+  installs is a container address the browser cannot reach — reachable-from-the-browser
+  configurations work today, and a separate browser-facing URL setting can follow if needed.
+
 - **The Explorer's filter rail can be folded away.** It holds 14rem of screen permanently, and once
   a filter is set the chips above the results already say what is applied, so the rail is mostly
   restating itself. Hiding it gives that width back to the detections. The control is on the filter

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -866,6 +866,16 @@
     const frigateIssueBadgeVisible = $derived(hasFrigateMediaIssue(detection) && !missingEventMetadataGone);
     const upstreamMissing = $derived(!isManualObservation && detection.frigate_status === 'missing');
     const missingEventNoticeVisible = $derived(upstreamMissing || missingEventMetadataGone);
+    // The originating Frigate event, for the owner only: frigate_url travels
+    // on the owner-only settings payload and never reaches a guest, and a
+    // retired event gets words instead of a link that lands on an error (#309).
+    const frigateEventUrl = $derived.by(() => {
+        if (!hasOwnerDetectionActions || isManualObservation) return null;
+        if (missingEventMetadataGone) return null;
+        const base = settingsStore.settings?.frigate_url;
+        if (!base || !detection.frigate_event) return null;
+        return `${base.replace(/\/$/, '')}/explore?event_id=${encodeURIComponent(detection.frigate_event)}`;
+    });
     const videoFailureInsight = $derived.by(() => getVideoFailureInsight(detection, $_));
     const videoClassificationDiagnostics = $derived(detection.video_classification_diagnostics ?? null);
     const videoClassificationSources = $derived(
@@ -2587,6 +2597,23 @@
                     <p class="mt-1 break-all {terminalTheme.output}">
                         {detection.frigate_event}<span class="terminal-caret" aria-hidden="true">&#9608;</span>
                     </p>
+                    {#if frigateEventUrl}
+                        <p class="mt-1">
+                            <a
+                                href={frigateEventUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-slate-400 underline decoration-dotted underline-offset-2 transition-colors hover:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+                                data-frigate-event-link
+                            >
+                                {$_('detection.open_in_frigate', { default: 'Open in Frigate' })} &nearr;
+                            </a>
+                        </p>
+                    {:else if hasOwnerDetectionActions && !isManualObservation && missingEventMetadataGone}
+                        <p class="mt-1 text-slate-500" data-frigate-event-gone>
+                            {$_('detection.open_in_frigate_gone', { default: 'No longer in Frigate' })}
+                        </p>
+                    {/if}
                 </div>
                 <!-- The "Frigate event missing" indicator that used to live here as a
                      standalone pill has been folded into the consolidated snapshot/

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -26,6 +26,19 @@ describe('detection surface polish', () => {
         expect(detectionModalSource).toContain('class="absolute top-4 right-4 z-40 inline-flex h-11 w-11');
     });
 
+    it('offers the originating Frigate event to the owner, honestly', () => {
+        // The URL comes from the owner-only settings payload, so a guest can
+        // never see the address; a retired event gets words instead of a
+        // link that lands on an error; and it lives with the technical
+        // identifiers behind the disclosure, not on the photograph (#309).
+        expect(detectionModalSource).toContain('settingsStore.settings?.frigate_url');
+        expect(detectionModalSource).toContain('/explore?event_id=');
+        expect(detectionModalSource).toContain('if (!hasOwnerDetectionActions || isManualObservation) return null;');
+        expect(detectionModalSource).toContain('if (missingEventMetadataGone) return null;');
+        expect(detectionModalSource).toContain('data-frigate-event-link');
+        expect(detectionModalSource).toContain('data-frigate-event-gone');
+    });
+
     it('keeps implementation identity collapsed until it is requested', () => {
         expect(detectionModalSource).toContain('data-detection-technical-identity');
         expect(detectionModalSource).toContain('<details');

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -1611,6 +1611,8 @@
     "weather_snow": "Schnee",
     "weather_icy": "Eisig",
     "id": "Erkennungs-ID",
+    "open_in_frigate": "In Frigate öffnen",
+    "open_in_frigate_gone": "Nicht mehr in Frigate",
     "upstream_missing": {
       "title": "In Frigate fehlend",
       "card_label": "Upstream fehlt",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -1620,6 +1620,8 @@
     "weather_snow": "Snow",
     "weather_icy": "Icy",
     "id": "Detection ID",
+    "open_in_frigate": "Open in Frigate",
+    "open_in_frigate_gone": "No longer in Frigate",
     "upstream_missing": {
       "title": "Missing in Frigate",
       "card_label": "Missing upstream",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -1611,6 +1611,8 @@
     "weather_snow": "Nieve",
     "weather_icy": "Helado",
     "id": "ID de detección",
+    "open_in_frigate": "Abrir en Frigate",
+    "open_in_frigate_gone": "Ya no está en Frigate",
     "upstream_missing": {
       "title": "Falta en Frigate",
       "card_label": "Falta en origen",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -1611,6 +1611,8 @@
     "weather_snow": "Neige",
     "weather_icy": "Glacé",
     "id": "ID de détection",
+    "open_in_frigate": "Ouvrir dans Frigate",
+    "open_in_frigate_gone": "Absent de Frigate",
     "upstream_missing": {
       "title": "Manquant dans Frigate",
       "card_label": "Manquant en amont",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -1620,6 +1620,8 @@
     "weather_snow": "Neve",
     "weather_icy": "Ghiaccio",
     "id": "ID rilevamento",
+    "open_in_frigate": "Apri in Frigate",
+    "open_in_frigate_gone": "Non più in Frigate",
     "upstream_missing": {
       "title": "Mancante in Frigate",
       "card_label": "Mancante a monte",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -1611,6 +1611,8 @@
     "weather_snow": "雪",
     "weather_icy": "凍結",
     "id": "検出ID",
+    "open_in_frigate": "Frigate で開く",
+    "open_in_frigate_gone": "Frigate に存在しません",
     "upstream_missing": {
       "title": "Frigate に存在しません",
       "card_label": "上流で欠落",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -1620,6 +1620,8 @@
     "weather_snow": "Neve",
     "weather_icy": "Gelado",
     "id": "ID de detecção",
+    "open_in_frigate": "Abrir no Frigate",
+    "open_in_frigate_gone": "Já não está no Frigate",
     "upstream_missing": {
       "title": "Ausente no Frigate",
       "card_label": "Ausente upstream",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -1620,6 +1620,8 @@
     "weather_snow": "Снег",
     "weather_icy": "Лёд",
     "id": "ID обнаружения",
+    "open_in_frigate": "Открыть в Frigate",
+    "open_in_frigate_gone": "Больше нет в Frigate",
     "upstream_missing": {
       "title": "Отсутствует во Frigate",
       "card_label": "Отсутствует upstream",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -1611,6 +1611,8 @@
     "weather_snow": "雪",
     "weather_icy": "结冰",
     "id": "检测ID",
+    "open_in_frigate": "在 Frigate 中打开",
+    "open_in_frigate_gone": "已不在 Frigate 中",
     "upstream_missing": {
       "title": "Frigate 中缺失",
       "card_label": "上游缺失",


### PR DESCRIPTION
## Outcome

Closes #309. The detection-ID disclosure in the modal now carries an "Open in Frigate" link for owners — `{frigate_url}/explore?event_id={id}`, matching the documented Frigate 0.17+ floor.

## The issue's three requirements

- **A guest never sees the link or the address**: the URL derives from the owner-only `/api/settings` payload; it is absent from the public status payload, and the settings store structurally never fetches for guests. The derivation also requires owner access directly.
- **Honest when the event is gone**: the same `missingEventMetadataGone` signal the notices use replaces the link with "No longer in Frigate" in words.
- **With the technical identifiers**: inside the existing terminal-style disclosure, as a quiet mono line under the event id — never an action on the photograph.

Manual observations never show either state. Strings land in all nine locales.

## Known limit, stated in the changelog

`frigate_url` is the server→Frigate address (often a container hostname); on such installs the link won't resolve from a browser. The repo solved this for BirdNET with `birdnet_external_url` — a `frigate_external_url` sibling is the follow-up if users hit it.

## Verification

`npm run check` 0/0; `npm test` 946 passed, including a new layout contract pinning the owner gating, the missing-event honesty, and the disclosure placement.