### PR TITLE
Let every species reach the block list, named or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A species can always be added to the block list, even when search cannot name it.** The
+  structured picker only offered what the species search could resolve to a canonical identity,
+  and some model labels carry no name it can find — the large iNat21 models label 10,000 species
+  by scientific name alone, so typing the common name shown on the detection card found nothing,
+  and clicking a result without resolved taxonomy silently did nothing at all
+  ([#311](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/311)). The picker now
+  always offers the typed text as a raw label, exactly as written — matching has always been
+  label-first, so a name copied off a detection card blocks — and an unresolvable result falls
+  back to a raw label instead of no-oping. The search itself also stops starving stored species:
+  classifier-label matches and detection-derived matches each keep their own budget, where before
+  fifty label variants could push every stored species out of the response.
+
 - **Reduce Motion now actually reduces motion.** The setting applied a `reduced-motion` class that
   no stylesheet carried a rule for, so a control described as disabling animations changed exactly
   one sparkline — the same defect the zen mode toggle was removed for. The class now applies the

--- a/apps/ui/src/lib/components/settings/DetectionSettings.svelte
+++ b/apps/ui/src/lib/components/settings/DetectionSettings.svelte
@@ -394,13 +394,32 @@
         return blockedSpecies.some((existingEntry) => sameBlockedSpeciesEntry(existingEntry, entry));
     }
 
-    function addBlockedSpecies(result: SearchResult) {
-        const entry = buildBlockedSpeciesEntry(result);
-        if (!entry) return;
-        blockedSpecies = mergeBlockedSpeciesEntries([...blockedSpecies, entry]);
+    function resetBlockedSpeciesSearch() {
         blockedSpeciesSearchQuery = '';
         blockedSpeciesSearchResults = [];
         blockedSpeciesSearchError = null;
+    }
+
+    function addBlockedLabelText(label: string) {
+        const value = label.trim();
+        if (!value) return;
+        if (!blockedLabels.some((existing) => existing.toLowerCase() === value.toLowerCase())) {
+            blockedLabels = [...blockedLabels, value];
+        }
+        resetBlockedSpeciesSearch();
+    }
+
+    function addBlockedSpecies(result: SearchResult) {
+        const entry = buildBlockedSpeciesEntry(result);
+        if (!entry) {
+            // A result with no canonical identity used to no-op silently: the
+            // row looked clickable and nothing happened. The raw label still
+            // blocks - matching is label-first - so store it as written (#311).
+            addBlockedLabelText(result.display_name || result.id);
+            return;
+        }
+        blockedSpecies = mergeBlockedSpeciesEntries([...blockedSpecies, entry]);
+        resetBlockedSpeciesSearch();
     }
 
     function removeBlockedSpecies(entryToRemove: BlockedSpeciesEntry) {
@@ -1014,6 +1033,23 @@
                         <p role="status" class="px-4 py-4 text-sm italic text-slate-500 dark:text-slate-400">
                             {blockedSpeciesSearching ? $_('common.loading') : $_('settings.detection.no_blocked_species_results', { default: 'No matching species found.' })}
                         </p>
+                    {/if}
+                    <!-- Search only offers what it can name, and some model
+                         labels carry no name it can find - the species on a
+                         detection card must always be blockable, so the typed
+                         text itself is offered as written (#311). -->
+                    {#if !blockedSpeciesSearching && blockedSpeciesSearchQuery.trim() && !blockedLabels.some((existing) => existing.toLowerCase() === blockedSpeciesSearchQuery.trim().toLowerCase())}
+                        <button
+                            type="button"
+                            onclick={() => addBlockedLabelText(blockedSpeciesSearchQuery)}
+                            data-blocked-label-escape-hatch
+                            class="min-h-11 w-full cursor-pointer rounded-xl border-t border-dashed border-slate-200 px-4 py-2.5 text-left text-sm font-medium text-slate-600 transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-700/60 dark:text-slate-300 dark:hover:bg-red-950/20 dark:hover:text-red-300"
+                        >
+                            {$_('settings.detection.block_exact_label', {
+                                values: { label: blockedSpeciesSearchQuery.trim() },
+                                default: 'Block "{label}" exactly as written'
+                            })}
+                        </button>
                     {/if}
                 </div>
             </div>

--- a/apps/ui/src/lib/components/settings/blocked-species.layout.test.ts
+++ b/apps/ui/src/lib/components/settings/blocked-species.layout.test.ts
@@ -9,4 +9,15 @@ describe('blocked species picker wiring', () => {
         expect(settingsPageSource).toContain('migrateLegacyBlockedLabels');
         expect(detectionSettingsSource).toContain('blockedSpecies = $bindable<');
     });
+
+    it('always offers the typed text as a raw label, since search cannot name everything', () => {
+        // Some model labels carry no name the search can resolve, and a result
+        // without canonical identity used to no-op silently when clicked. The
+        // species on a detection card must always be blockable (#311): the
+        // typed text is offered exactly as written, and an unresolvable result
+        // falls back to a raw label instead of doing nothing.
+        expect(detectionSettingsSource).toContain('data-blocked-label-escape-hatch');
+        expect(detectionSettingsSource).toContain('settings.detection.block_exact_label');
+        expect(detectionSettingsSource).toContain('addBlockedLabelText(result.display_name || result.id)');
+    });
 });

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -1390,6 +1390,7 @@
       "blocked_species_structured": "Blockierte Arten",
       "model_manager_threshold_hint": "Empfohlener Konfidenzschwellenwert für dieses Modell:",
       "no_blocked_species_results": "Keine passende Art gefunden.",
+      "block_exact_label": "\"{label}\" genau wie geschrieben blockieren",
       "crop_priority_frigate_first": "Frigate-Hinweise zuerst",
       "crop_priority_crop_first": "Zuschneidemodell zuerst",
       "crop_priority_crop_only": "Nur Zuschneidemodell",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -1248,6 +1248,7 @@
       "blocked_species_picker_desc": "Search for a species or other taxon to block it reliably across common-name, scientific-name, and taxonomy-aware matches. Cached detections and legacy raw labels still apply until you remove them.",
       "blocked_species_placeholder": "Search taxa to block",
       "no_blocked_species_results": "No matching species found.",
+      "block_exact_label": "Block \"{label}\" exactly as written",
       "blocked_species_structured": "Blocked species",
       "blocked_species_legacy": "Legacy raw labels",
       "no_blocked_labels": "No labels blocked yet.",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -1390,6 +1390,7 @@
       "blocked_species_structured": "Especies bloqueadas",
       "model_manager_threshold_hint": "Umbral de confianza recomendado para este modelo:",
       "no_blocked_species_results": "No se encontraron especies coincidentes.",
+      "block_exact_label": "Bloquear \"{label}\" tal como está escrito",
       "crop_priority_frigate_first": "Pistas de Frigate primero",
       "crop_priority_crop_first": "Modelo de recorte primero",
       "crop_priority_crop_only": "Solo modelo de recorte",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -1390,6 +1390,7 @@
       "blocked_species_structured": "Espèces bloquées",
       "model_manager_threshold_hint": "Seuil de confiance recommandé pour ce modèle :",
       "no_blocked_species_results": "Aucune espèce correspondante trouvée.",
+      "block_exact_label": "Bloquer « {label} » tel quel",
       "crop_priority_frigate_first": "Indices Frigate en premier",
       "crop_priority_crop_first": "Modèle de recadrage en premier",
       "crop_priority_crop_only": "Modèle de recadrage uniquement",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -1399,6 +1399,7 @@
       "blocked_species_structured": "Specie bloccate",
       "model_manager_threshold_hint": "Soglia di confidenza consigliata per questo modello:",
       "no_blocked_species_results": "Nessuna specie corrispondente trovata.",
+      "block_exact_label": "Blocca \"{label}\" esattamente come scritto",
       "crop_priority_frigate_first": "Suggerimenti Frigate prima",
       "crop_priority_crop_first": "Modello di ritaglio prima",
       "crop_priority_crop_only": "Solo modello di ritaglio",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -1390,6 +1390,7 @@
       "blocked_species_structured": "ブロック済みの種",
       "model_manager_threshold_hint": "このモデルの推奨信頼度しきい値:",
       "no_blocked_species_results": "一致する種が見つかりません。",
+      "block_exact_label": "「{label}」をそのままブロック",
       "crop_priority_frigate_first": "Frigateヒント優先",
       "crop_priority_crop_first": "切り取りモデル優先",
       "crop_priority_crop_only": "切り取りモデルのみ",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -1399,6 +1399,7 @@
       "blocked_species_structured": "Espécies bloqueadas",
       "model_manager_threshold_hint": "Limite de confiança recomendado para este modelo:",
       "no_blocked_species_results": "Nenhuma espécie correspondente encontrada.",
+      "block_exact_label": "Bloquear \"{label}\" tal como está escrito",
       "crop_priority_frigate_first": "Dicas do Frigate primeiro",
       "crop_priority_crop_first": "Modelo de recorte primeiro",
       "crop_priority_crop_only": "Apenas modelo de recorte",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -1399,6 +1399,7 @@
       "blocked_species_structured": "Заблокированные виды",
       "model_manager_threshold_hint": "Рекомендуемый порог уверенности для этой модели:",
       "no_blocked_species_results": "Подходящих видов не найдено.",
+      "block_exact_label": "Блокировать «{label}» как есть",
       "crop_priority_frigate_first": "Сначала подсказки Frigate",
       "crop_priority_crop_first": "Сначала модель обрезки",
       "crop_priority_crop_only": "Только модель обрезки",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -1390,6 +1390,7 @@
       "blocked_species_structured": "已屏蔽物种",
       "model_manager_threshold_hint": "此模型的推荐置信度阈值：",
       "no_blocked_species_results": "未找到匹配的物种。",
+      "block_exact_label": "按原样屏蔽“{label}”",
       "crop_priority_frigate_first": "Frigate提示优先",
       "crop_priority_crop_first": "裁剪模型优先",
       "crop_priority_crop_only": "仅裁剪模型",

--- a/backend/app/routers/species.py
+++ b/backend/app/routers/species.py
@@ -469,19 +469,22 @@ async def search_species(
 
     async with get_db() as db:
         if q:
-            matches = [label for label in labels if q_lower in label.lower()]
-            matches.extend(
+            # Each source keeps its own budget: truncating the union let a
+            # model whose label list matched the query fifty times push every
+            # detection-derived species out of the payload, and the block list
+            # can only offer what this search returns (#311).
+            stored_matches = [
                 label
                 for label in await SpeciesRepository(db).search_labels(q_lower, lang)
                 if not should_hide_species_label(label)
-            )
+            ][:limit]
+            label_budget = max(limit - len(stored_matches), limit // 2)
+            label_matches = [label for label in labels if q_lower in label.lower()][:label_budget]
 
             seen = set()
-            matches = [m for m in matches if not (m in seen or seen.add(m))]
+            matches = [m for m in label_matches + stored_matches if not (m in seen or seen.add(m))]
         else:
-            matches = labels
-
-        matches = matches[:limit]
+            matches = labels[:limit]
 
         deduped_results: dict[str, dict] = {}
         for label in matches:
@@ -502,7 +505,7 @@ async def search_species(
             existing = deduped_results.get(key)
             deduped_results[key] = _pick_preferred_species_search_result(existing, result) if existing else result
 
-        results = list(deduped_results.values())
+        results = list(deduped_results.values())[:limit]
 
     if hydrate_missing and results:
         await _hydrate_species_search_results(results, lang)

--- a/backend/tests/test_species_search_api.py
+++ b/backend/tests/test_species_search_api.py
@@ -304,3 +304,32 @@ async def test_species_search_merges_same_species_when_only_one_source_has_a_tax
     assert len(payload) == 1, f"expected one merged species, got {[p['display_name'] for p in payload]}"
     assert payload[0]["scientific_name"] == "Rattus"
     assert payload[0]["taxa_id"] == 44436
+
+
+@pytest.mark.asyncio
+async def test_species_search_db_matches_survive_a_flood_of_label_matches(client: httpx.AsyncClient):
+    """A species known only from stored detections stays findable (#311).
+
+    Classifier-label hits were truncated together with repository hits before
+    deduplication, so a model whose label list matched the query fifty times
+    pushed every detection-derived species out of the payload - and the block
+    list can only offer what this search returns.
+    """
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+    flood = [f"Floodfinch variant {i:02d}" for i in range(60)]
+    stored_species = f"Promerops cafer {uuid.uuid4().hex[:6]}"
+
+    with (
+        patch("app.routers.species.get_classifier", return_value=_MockClassifier(flood)),
+        patch(
+            "app.repositories.species_repository.SpeciesRepository.search_labels",
+            new=AsyncMock(return_value=[stored_species]),
+        ),
+    ):
+        response = await client.get("/api/species/search", params={"q": "f", "limit": 50})
+
+    assert response.status_code == 200
+    names = {row["display_name"] for row in response.json()}
+    assert stored_species in names
+    assert len(response.json()) <= 50


### PR DESCRIPTION
## Outcome

Closes #311. Three compounding gaps, each fixed at its own layer:

- **The escape hatch returns.** The picker always offers the typed text — *Block "…" exactly as written* — appending to the raw `blocked_labels` list the backend has kept first-class all along. Matching is label-first (raw label, collapsed label, Frigate sub-label, scientific and common names), so a name copied off a detection card genuinely blocks.
- **No more silent no-op.** A search result without canonical identity previously rendered as clickable and did nothing; it now falls back to the raw-label path.
- **Search stops starving stored species.** Classifier-label matches and detection-derived matches each keep their own budget before dedup, where previously fifty plumage-variant label hits from one model could push every stored species out of the payload.

## Excluded, deliberately

Wiring the search to the species catalogue (the only source mapping every emittable model label to both names) is the real discoverability fix but a larger change; the strict `is_hidden = 0` in the search index (hiding the bogus detection removes its species from search) is related and worth its own look. Both are follow-up material — the escape hatch unblocks users today.

## Verification

Backend: new test pins that a stored species survives a flood of label matches; 2,557 passed. Frontend: layout contract pins the escape hatch, its i18n key (all nine locales), and the no-op fallback; 946 passed, `svelte-check` 0/0. Repo-wide ruff clean.