### PR TITLE
Spawn one worker of each kind by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,14 +59,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   Settings page being starved ([#312](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/312),
   found through [#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)). New
   installs default to `subprocess`: supervised worker processes the app can kill and restart when
-  they stall, spawned only when work actually arrives. Worker counts now follow the configured
-  concurrency (`CLASSIFIER_IMAGE_MAX_CONCURRENT`) so every admitted job has a process to run in,
-  except on a single accelerator (`cuda`, `intel_gpu`, `intel_npu`), where one worker is derived —
-  the device serialises inference, so extra workers cost a model copy each and add no speed. An
-  explicitly set mode or worker count is kept exactly as written, and every existing install keeps
-  the mode saved in its `config.json`. The honest trade: each worker holds its own copy of the
-  model, so the default costs more memory than one shared copy — it buys an interface that stays
-  responsive under load and inference that can be restarted rather than waited out.
+  they stall, spawned only when work actually arrives — and one worker of each kind, never more,
+  unless the owner asks. Each worker holds its own copy of the model, so the worker count is the
+  memory price, and scaling upward is a deliberate act rather than a default. Admission capacity
+  always equals the worker count, so every admitted job has a process to run in. An explicitly set
+  mode or worker count is kept exactly as written, and every existing install keeps the mode saved
+  in its `config.json`. The honest trade: the default still costs more memory than one shared
+  in-process copy — it buys an interface that stays responsive under load and inference that can
+  be restarted rather than waited out.
 
 - **The Explorer's view controls live on one row, in one style.** Hide filters, the Cards/List
   switch, and Multi-select acted on the same list from two places in two styles: Multi-select sat

--- a/apps/ui/src/lib/components/settings/DetectionSettings.svelte
+++ b/apps/ui/src/lib/components/settings/DetectionSettings.svelte
@@ -760,7 +760,7 @@
                 <SettingsRow
                     labelId="setting-execution-mode"
                     label={$_('settings.detection.execution_mode', { default: 'Execution Mode' })}
-                    description={$_('settings.detection.execution_mode_desc', { default: 'Subprocess, the default, identifies birds in worker processes the app can restart, so a stalled or crashed identification never takes the interface down. The workers match your concurrency setting, and each keeps its own copy of the model in memory. In-Process keeps a single copy inside the app itself: less memory, but heavy identification competes with the pages you are looking at.' })}
+                    description={$_('settings.detection.execution_mode_desc', { default: 'Subprocess, the default, identifies birds in worker processes the app can restart, so a stalled or crashed identification never takes the interface down. One worker runs by default; each additional worker you configure holds its own copy of the model in memory. In-Process keeps a single copy inside the app itself: less memory, but heavy identification competes with the pages you are looking at.' })}
                     layout="stacked"
                 >
                     <SettingsSelect

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -1274,7 +1274,7 @@
       "provider_fallback_reason": "Fallback:",
       "model_config_warning": "Model config warning:",
       "execution_mode": "Execution Mode",
-      "execution_mode_desc": "Subprocess, the default, identifies birds in worker processes the app can restart, so a stalled or crashed identification never takes the interface down. The workers match your concurrency setting, and each keeps its own copy of the model in memory. In-Process keeps a single copy inside the app itself: less memory, but heavy identification competes with the pages you are looking at.",
+      "execution_mode_desc": "Subprocess, the default, identifies birds in worker processes the app can restart, so a stalled or crashed identification never takes the interface down. One worker runs by default; each additional worker you configure holds its own copy of the model in memory. In-Process keeps a single copy inside the app itself: less memory, but heavy identification competes with the pages you are looking at.",
       "execution_mode_worker_plan": "Resolved for this install: {live} live and {background} background worker processes, each with its own copy of the model.",
       "execution_mode_worker_ram": "The active model is estimated at {each} MB per copy, about {total} MB across the workers.",
       "mode_subprocess": "Subprocess (Isolated)",

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -166,35 +166,21 @@ log = structlog.get_logger()
 SUPPORTED_INFERENCE_PROVIDERS = {"auto", "cpu", "cuda", "intel_gpu", "intel_cpu", "intel_npu"}
 CLASSIFIER_IMAGE_MAX_CONCURRENT = max(1, int(os.getenv("CLASSIFIER_IMAGE_MAX_CONCURRENT", "2")))
 
-# A single accelerator serialises inference, so extra workers on it are a model
-# copy apiece with no parallelism. `auto` is treated as CPU: the provider is
-# only resolved after hardware detection, and a CPU-sized pool is the honest
-# default for the installs that have not pinned one (#312).
-SINGLE_DEVICE_INFERENCE_PROVIDERS = frozenset({"cuda", "intel_gpu", "intel_npu"})
-
 
 def resolve_image_worker_counts(
     *,
     configured_live: int | None,
     configured_background: int | None,
-    image_max_concurrent: int,
-    inference_provider: str,
 ) -> tuple[int, int]:
-    """Worker counts for subprocess mode: explicit values kept, unset derived.
+    """Worker counts for subprocess mode: explicit values kept, unset means one.
 
-    The derived live count follows the configured concurrency so every
-    admitted job has a worker process to run in — a pool smaller than
-    admission burns leases in a queue the caller cannot see (#314). Each
-    worker holds its own copy of the model, so the count is also the memory
-    price, stated in Settings.
+    Each worker holds its own copy of the model, so the count is the memory
+    price: one live and one background copy by default, and scaling upward is
+    a deliberate act, never a default (#312). Admission capacity equals the
+    resolved count, so every admitted job has a worker process to run in and
+    a lease can only expire on work that is actually running (#314).
     """
-    provider = (inference_provider or "auto").strip().lower()
-    if configured_live:
-        live = max(1, int(configured_live))
-    elif provider in SINGLE_DEVICE_INFERENCE_PROVIDERS:
-        live = 1
-    else:
-        live = max(1, int(image_max_concurrent))
+    live = max(1, int(configured_live)) if configured_live else 1
     background = max(1, int(configured_background)) if configured_background else 1
     return live, background
 
@@ -2759,8 +2745,6 @@ class ClassifierService:
         resolved_live_workers, resolved_background_workers = resolve_image_worker_counts(
             configured_live=getattr(settings.classification, "live_worker_count", None),
             configured_background=getattr(settings.classification, "background_worker_count", None),
-            image_max_concurrent=image_workers,
-            inference_provider=str(getattr(settings.classification, "inference_provider", "auto") or "auto"),
         )
         live_admission_capacity = image_workers
         background_admission_capacity = 1

--- a/backend/tests/test_inference_out_of_process_default.py
+++ b/backend/tests/test_inference_out_of_process_default.py
@@ -9,8 +9,6 @@ process to run in — a pool smaller than admission burns leases in a queue,
 which is the abandonment pathology #314 closed.
 """
 
-import pytest
-
 import app.config as config_module
 from app.config import Settings
 from app.services.classifier_service import resolve_image_worker_counts
@@ -30,39 +28,21 @@ def test_a_fresh_install_runs_inference_out_of_process(monkeypatch, tmp_path):
     assert loaded.classification.live_worker_count is None
 
 
-def test_worker_counts_follow_configured_concurrency():
-    assert resolve_image_worker_counts(
-        configured_live=None,
-        configured_background=None,
-        image_max_concurrent=2,
-        inference_provider="cpu",
-    ) == (2, 1)
-    assert resolve_image_worker_counts(
-        configured_live=None,
-        configured_background=None,
-        image_max_concurrent=4,
-        inference_provider="auto",
-    ) == (4, 1)
-
-
-@pytest.mark.parametrize("provider", ["cuda", "intel_gpu", "intel_npu"])
-def test_a_single_accelerator_gets_one_derived_worker(provider):
-    """One accelerator serialises the work; extra workers add a model copy
-    apiece and no parallelism, so they are memory spent on nothing."""
-    assert resolve_image_worker_counts(
-        configured_live=None,
-        configured_background=None,
-        image_max_concurrent=4,
-        inference_provider=provider,
-    ) == (1, 1)
+def test_one_worker_of_each_kind_is_the_default():
+    """Each worker holds its own copy of the model, so the count is the
+    memory price: one live and one background copy by default, on any
+    provider, and scaling upward is a deliberate act, never a default."""
+    for provider in ("cpu", "auto", "cuda", "intel_gpu", "intel_npu"):
+        assert resolve_image_worker_counts(
+            configured_live=None,
+            configured_background=None,
+        ) == (1, 1), provider
 
 
 def test_an_explicit_worker_count_is_kept():
     assert resolve_image_worker_counts(
         configured_live=3,
         configured_background=2,
-        image_max_concurrent=2,
-        inference_provider="intel_npu",
     ) == (3, 2)
 
 
@@ -110,7 +90,7 @@ def test_admission_capacity_matches_the_worker_pool(monkeypatch):
     monkeypatch.setattr(settings.classification, "image_execution_mode", "subprocess")
     monkeypatch.setattr(settings.classification, "live_worker_count", None)
     monkeypatch.setattr(settings.classification, "background_worker_count", None)
-    monkeypatch.setattr(settings.classification, "inference_provider", "intel_npu")
+    monkeypatch.setattr(settings.classification, "inference_provider", "cpu")
 
     with (
         patch.object(ClassifierService, "_init_bird_model", return_value=None),

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -113,7 +113,7 @@ settings and do not follow the `SECTION__FIELD` precedence rules above.
 | `CLASSIFICATION__VIDEO_FAILURE_THRESHOLD` | `5` | Failures before the video circuit opens. |
 | `CLASSIFICATION__VIDEO_FAILURE_WINDOW_MINUTES` | `10` | Window for counting video failures. |
 | `CLASSIFICATION__VIDEO_FAILURE_COOLDOWN_MINUTES` | `15` | Cooldown while the video circuit is open. |
-| `CLASSIFICATION__LIVE_WORKER_COUNT` | _(follows concurrency)_ | Live-inference worker processes. Unset follows `CLASSIFIER_IMAGE_MAX_CONCURRENT`, except on a single accelerator (`cuda`, `intel_gpu`, `intel_npu`), which derives one worker — the device serialises inference, so extra workers cost a model copy each and add no speed. Each worker holds its own copy of the model. |
+| `CLASSIFICATION__LIVE_WORKER_COUNT` | _(one)_ | Live-inference worker processes; unset means one. Each worker holds its own copy of the model, so raising this buys parallelism at one model copy per worker — scale it deliberately. Admission capacity always equals the worker count. |
 | `CLASSIFICATION__BACKGROUND_WORKER_COUNT` | _(one)_ | Background-inference worker processes; unset means one. |
 | `CLASSIFICATION__LIVE_EVENT_COALESCING_ENABLED` | `true` | Coalesce rapid live events. |
 | `CLASSIFICATION__LIVE_EVENT_STALE_DROP_SECONDS` | `30.0` | Drop live events older than this. |


### PR DESCRIPTION
## Outcome

An unset worker count now resolves to **one**, on every provider — the memory-frugal default #312 originally proposed. Scaling upward is always deliberate, via `CLASSIFICATION__LIVE_WORKER_COUNT`; each added worker holds its own model copy, and admission capacity equals the pool by construction. Retires the accelerator special case (the resolver loses its provider parameter). Explicit counts and existing installs untouched.

## Verification

Backend suite green with the defaults pinned; frontend 951 passed, svelte-check 0/0; repo-wide ruff clean.