### PR TITLE
Give the Frigate link an address the browser can reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- **A browser-facing Frigate URL, so the "open in Frigate" link actually opens.** The detection's
+  Frigate link is built from the configured server URL, which on most Docker installs is a
+  container address like `http://frigate:5000` that a browser cannot reach. Connection settings
+  now take an optional public Frigate URL (also `FRIGATE__FRIGATE_EXTERNAL_URL`), and the link
+  prefers it, falling back to the server URL when it is not set — the same split BirdNET-Go
+  already has.
+
 - **An owner can open a detection's originating Frigate event.** A detection came from a Frigate
   event, and there was no way to get from one to the other: finding the clip or timeline meant
   searching Frigate by camera and time

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -1300,6 +1300,7 @@ export interface components {
     enrichment_single_provider?: string | null;
     enrichment_summary_source?: string | null;
     enrichment_taxonomy_source?: string | null;
+    frigate_external_url?: string | null;
     frigate_missing_behavior?: "mark_missing" | "keep" | "delete";
     frigate_url?: string | null;
     image_execution_mode?: string | null;
@@ -1481,6 +1482,7 @@ export interface components {
     enrichment_single_provider?: string | null;
     enrichment_summary_source?: string | null;
     enrichment_taxonomy_source?: string | null;
+    frigate_external_url?: string | null;
     frigate_missing_behavior?: "mark_missing" | "keep" | "delete";
     frigate_url?: string | null;
     image_execution_mode?: string | null;

--- a/apps/ui/src/lib/api/settings.ts
+++ b/apps/ui/src/lib/api/settings.ts
@@ -13,6 +13,7 @@ export type NotificationSpeciesFilterMode = 'none' | 'blacklist' | 'whitelist';
 
 export interface Settings {
     frigate_url: string;
+    frigate_external_url: string;
     mqtt_server: string;
     mqtt_port: number;
     mqtt_auth: boolean;

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -869,10 +869,12 @@
     // The originating Frigate event, for the owner only: frigate_url travels
     // on the owner-only settings payload and never reaches a guest, and a
     // retired event gets words instead of a link that lands on an error (#309).
+    // The public URL wins when set, because frigate_url is often a container
+    // address the browser cannot reach.
     const frigateEventUrl = $derived.by(() => {
         if (!hasOwnerDetectionActions || isManualObservation) return null;
         if (missingEventMetadataGone) return null;
-        const base = settingsStore.settings?.frigate_url;
+        const base = settingsStore.settings?.frigate_external_url || settingsStore.settings?.frigate_url;
         if (!base || !detection.frigate_event) return null;
         return `${base.replace(/\/$/, '')}/explore?event_id=${encodeURIComponent(detection.frigate_event)}`;
     });

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -31,7 +31,11 @@ describe('detection surface polish', () => {
         // never see the address; a retired event gets words instead of a
         // link that lands on an error; and it lives with the technical
         // identifiers behind the disclosure, not on the photograph (#309).
-        expect(detectionModalSource).toContain('settingsStore.settings?.frigate_url');
+        // The browser-facing URL wins when configured, because frigate_url is
+        // often a container address the browser cannot reach.
+        expect(detectionModalSource).toContain(
+            'settingsStore.settings?.frigate_external_url || settingsStore.settings?.frigate_url'
+        );
         expect(detectionModalSource).toContain('/explore?event_id=');
         expect(detectionModalSource).toContain('if (!hasOwnerDetectionActions || isManualObservation) return null;');
         expect(detectionModalSource).toContain('if (missingEventMetadataGone) return null;');

--- a/apps/ui/src/lib/components/settings/ConnectionSettings.svelte
+++ b/apps/ui/src/lib/components/settings/ConnectionSettings.svelte
@@ -18,6 +18,7 @@
 
     let {
         frigateUrl = $bindable(''),
+        frigateExternalUrl = $bindable(''),
         mqttServer = $bindable(''),
         mqttPort = $bindable(1883),
         mqttAuth = $bindable(false),
@@ -45,6 +46,7 @@
         toggleCamera
     }: {
         frigateUrl: string;
+        frigateExternalUrl: string;
         mqttServer: string;
         mqttPort: number;
         mqttAuth: boolean;
@@ -318,6 +320,22 @@
                 placeholder={$_('settings.frigate.url_placeholder')}
                 ariaLabel={$_('settings.frigate.url')}
                 oninput={(v) => (frigateUrl = v)}
+            />
+        </SettingsRow>
+
+        <SettingsRow
+            labelId="setting-frigate-external-url"
+            label={$_('settings.frigate.external_url')}
+            description={$_('settings.frigate.external_url_desc')}
+            layout="stacked"
+        >
+            <SettingsInput
+                id="frigate-external-url"
+                type="url"
+                value={frigateExternalUrl}
+                placeholder={$_('settings.frigate.external_url_placeholder')}
+                ariaLabel={$_('settings.frigate.external_url')}
+                oninput={(v) => (frigateExternalUrl = v)}
             />
         </SettingsRow>
 

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -938,7 +938,10 @@
       "full_visit_retention": "Garantierte durchgehende Aufbewahrung: {days} Tag(e)",
       "full_visit_attention_cameras": "Kameras mit Handlungsbedarf",
       "full_visit_supported": "Für alle {count} ausgewählten Kameras ist die durchgehende Abdeckung bereit.",
-      "full_visit_unavailable": "Fähigkeitsinformationen sind derzeit nicht verfügbar."
+      "full_visit_unavailable": "Fähigkeitsinformationen sind derzeit nicht verfügbar.",
+      "external_url": "Öffentliche Frigate-URL",
+      "external_url_desc": "Die Adresse, über die dein Browser Frigate öffnet, wenn sie von der Serveradresse oben abweicht. Wird für den Link 'In Frigate öffnen' einer Erkennung verwendet.",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "Aktive Kameras",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -947,7 +947,10 @@
       "full_visit_issue_retention_unknown": "retention unknown",
       "full_visit_issue_unknown": "configuration needs attention",
       "url_placeholder": "http://frigate:5000",
-      "mqtt_broker_placeholder": "mosquitto"
+      "mqtt_broker_placeholder": "mosquitto",
+      "external_url": "Public Frigate URL",
+      "external_url_desc": "The address your browser uses to open Frigate when it differs from the server address above. Used for the 'open in Frigate' link on a detection.",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "Active Cameras",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -938,7 +938,10 @@
       "full_visit_retention": "Retención continua garantizada: {days} día(s)",
       "full_visit_attention_cameras": "Cámaras que requieren atención",
       "full_visit_supported": "La cobertura continua está lista para las {count} cámaras seleccionadas.",
-      "full_visit_unavailable": "La información de capacidad no está disponible en este momento."
+      "full_visit_unavailable": "La información de capacidad no está disponible en este momento.",
+      "external_url": "URL pública de Frigate",
+      "external_url_desc": "La dirección que usa tu navegador para abrir Frigate cuando difiere de la dirección del servidor de arriba. Se usa para el enlace 'Abrir en Frigate' de una detección.",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "Cámaras Activas",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -938,7 +938,10 @@
       "full_visit_retention": "Rétention continue garantie : {days} jour(s)",
       "full_visit_attention_cameras": "Caméras nécessitant une intervention",
       "full_visit_supported": "La couverture continue est prête pour les {count} caméras sélectionnées.",
-      "full_visit_unavailable": "Les informations de capacité sont indisponibles pour le moment."
+      "full_visit_unavailable": "Les informations de capacité sont indisponibles pour le moment.",
+      "external_url": "URL publique de Frigate",
+      "external_url_desc": "L'adresse que votre navigateur utilise pour ouvrir Frigate lorsqu'elle diffère de l'adresse du serveur ci-dessus. Utilisée pour le lien « Ouvrir dans Frigate » d'une détection.",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "Caméras actives",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -947,7 +947,10 @@
       "full_visit_retention": "Conservazione continua garantita: {days} giorno(i)",
       "full_visit_attention_cameras": "Telecamere che richiedono attenzione",
       "full_visit_supported": "La copertura continua è pronta per tutte le {count} telecamere selezionate.",
-      "full_visit_unavailable": "Le informazioni sulla capacità non sono disponibili in questo momento."
+      "full_visit_unavailable": "Le informazioni sulla capacità non sono disponibili in questo momento.",
+      "external_url": "URL pubblico di Frigate",
+      "external_url_desc": "L'indirizzo che il browser usa per aprire Frigate quando differisce dall'indirizzo del server qui sopra. Usato per il link 'Apri in Frigate' di un rilevamento.",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "Telecamere Attive",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -938,7 +938,10 @@
       "full_visit_retention": "保証される連続保持期間: {days} 日",
       "full_visit_attention_cameras": "確認が必要なカメラ",
       "full_visit_supported": "選択した {count} 台すべてのカメラで連続録画を利用できます。",
-      "full_visit_unavailable": "現在、対応情報を利用できません。"
+      "full_visit_unavailable": "現在、対応情報を利用できません。",
+      "external_url": "Frigate公開URL",
+      "external_url_desc": "上のサーバーアドレスと異なる場合に、ブラウザがFrigateを開くために使うアドレスです。検出の「Frigateで開く」リンクに使われます。",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "アクティブなカメラ",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -947,7 +947,10 @@
       "full_visit_retention": "Retenção contínua garantida: {days} dia(s)",
       "full_visit_attention_cameras": "Câmeras que precisam de atenção",
       "full_visit_supported": "A cobertura contínua está pronta para todas as {count} câmeras selecionadas.",
-      "full_visit_unavailable": "As informações de capacidade não estão disponíveis no momento."
+      "full_visit_unavailable": "As informações de capacidade não estão disponíveis no momento.",
+      "external_url": "URL público do Frigate",
+      "external_url_desc": "O endereço que o navegador usa para abrir o Frigate quando difere do endereço do servidor acima. Usado para o link 'Abrir no Frigate' de uma detecção.",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "Câmeras Ativas",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -947,7 +947,10 @@
       "full_visit_retention": "Гарантированный срок непрерывного хранения: {days} дн.",
       "full_visit_attention_cameras": "Камеры, требующие внимания",
       "full_visit_supported": "Непрерывная запись готова для всех выбранных камер ({count}).",
-      "full_visit_unavailable": "Информация о возможности сейчас недоступна."
+      "full_visit_unavailable": "Информация о возможности сейчас недоступна.",
+      "external_url": "Публичный URL Frigate",
+      "external_url_desc": "Адрес, по которому браузер открывает Frigate, если он отличается от адреса сервера выше. Используется для ссылки «Открыть в Frigate» у обнаружения.",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "Активные камеры",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -938,7 +938,10 @@
       "full_visit_retention": "保证的连续保留期：{days} 天",
       "full_visit_attention_cameras": "需要检查的摄像头",
       "full_visit_supported": "所有 {count} 个所选摄像头均已具备连续录像覆盖。",
-      "full_visit_unavailable": "当前无法获取能力信息。"
+      "full_visit_unavailable": "当前无法获取能力信息。",
+      "external_url": "Frigate 公开 URL",
+      "external_url_desc": "当与上面的服务器地址不同时,浏览器用来打开 Frigate 的地址。用于检测的“在 Frigate 中打开”链接。",
+      "external_url_placeholder": "https://frigate.example.com"
     },
     "cameras": {
       "title": "活动摄像头",

--- a/apps/ui/src/lib/pages/Settings.svelte
+++ b/apps/ui/src/lib/pages/Settings.svelte
@@ -205,6 +205,7 @@
     }
 
     let frigateUrl = $state('');
+    let frigateExternalUrl = $state('');
     let mqttServer = $state('');
     let mqttPort = $state(1883);
     let mqttAuth = $state(false);
@@ -1725,6 +1726,7 @@ Mantenha a resposta concisa (menos de 200 palavras). Sem seções extras.
 
         const checks = [
             { key: 'frigateUrl', val: frigateUrl, store: s.frigate_url },
+            { key: 'frigateExternalUrl', val: frigateExternalUrl, store: s.frigate_external_url || '' },
             { key: 'mqttServer', val: mqttServer, store: s.mqtt_server },
             { key: 'mqttPort', val: mqttPort, store: s.mqtt_port },
             { key: 'mqttAuth', val: mqttAuth, store: s.mqtt_auth },
@@ -2667,6 +2669,7 @@ Mantenha a resposta concisa (menos de 200 palavras). Sem seções extras.
             const settings = await fetchSettings();
             settingsStore.update(settings);
             frigateUrl = settings.frigate_url;
+            frigateExternalUrl = settings.frigate_external_url || '';
             mqttServer = settings.mqtt_server;
             mqttPort = settings.mqtt_port;
             mqttAuth = settings.mqtt_auth;
@@ -3026,6 +3029,7 @@ Mantenha a resposta concisa (menos de 200 palavras). Sem seções extras.
         try {
             await updateSettings({
                 frigate_url: frigateUrl,
+                frigate_external_url: frigateExternalUrl,
                 mqtt_server: mqttServer,
                 mqtt_port: mqttPort,
                 mqtt_auth: mqttAuth,
@@ -3275,6 +3279,7 @@ Mantenha a resposta concisa (menos de 200 palavras). Sem seções extras.
             {#if activeTab === 'connection'}
                 <ConnectionSettings
                     bind:frigateUrl
+                    bind:frigateExternalUrl
                     bind:mqttServer
                     bind:mqttPort
                     bind:mqttAuth

--- a/backend/app/config_loader.py
+++ b/backend/app/config_loader.py
@@ -146,6 +146,7 @@ def load_settings_instance(settings_cls: type[Any], config_path: Path) -> Any:
     # Build frigate settings from environment variables
     frigate_data = {
         "frigate_url": os.environ.get("FRIGATE__FRIGATE_URL", "http://frigate:5000"),
+        "frigate_external_url": os.environ.get("FRIGATE__FRIGATE_EXTERNAL_URL", ""),
         "frigate_auth_token": os.environ.get("FRIGATE__FRIGATE_AUTH_TOKEN", None),
         "main_topic": os.environ.get("FRIGATE__MAIN_TOPIC", "frigate"),
         "clips_enabled": os.environ.get("FRIGATE__CLIPS_ENABLED", "true").lower() == "true",

--- a/backend/app/config_models.py
+++ b/backend/app/config_models.py
@@ -183,6 +183,10 @@ def _expand_trusted_hosts(hosts: list[str]) -> list[str]:
 
 class FrigateSettings(BaseModel):
     frigate_url: str = Field(..., description="URL of the Frigate instance")
+    frigate_external_url: str = Field(
+        default="",
+        description="Public/browser-facing base URL of the Frigate web UI (e.g. https://frigate.example.com). Used for the 'open in Frigate' links in the dashboard. Falls back to frigate_url if empty.",
+    )
     frigate_auth_token: Optional[str] = Field(None, description="Optional Bearer token for Frigate proxy auth")
     main_topic: str = "frigate"
     camera: list[str] = Field(default_factory=list, description="List of cameras to monitor")

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -691,6 +691,7 @@ async def test_llm(
 
 class SettingsUpdate(BaseModel):
     frigate_url: Optional[str] = Field(None, min_length=1, description="Frigate instance URL")
+    frigate_external_url: Optional[str] = Field("", description="External Frigate base URL (browser→Frigate)")
     mqtt_server: Optional[str] = Field(None, min_length=1, description="MQTT server hostname")
     mqtt_port: int = Field(1883, ge=1, le=65535, description="MQTT server port")
     mqtt_auth: bool = Field(False, description="Enable MQTT authentication")
@@ -1243,6 +1244,7 @@ async def get_settings(auth: AuthContext = Depends(require_owner)):
 
     return {
         "frigate_url": settings.frigate.frigate_url,
+        "frigate_external_url": settings.frigate.frigate_external_url,
         "mqtt_server": settings.frigate.mqtt_server,
         "mqtt_port": settings.frigate.mqtt_port,
         "mqtt_auth": settings.frigate.mqtt_auth,
@@ -1502,6 +1504,8 @@ async def update_settings(
 
     if "frigate_url" in fields_set and update.frigate_url is not None:
         settings.frigate.frigate_url = update.frigate_url
+    if "frigate_external_url" in fields_set and update.frigate_external_url is not None:
+        settings.frigate.frigate_external_url = update.frigate_external_url.strip().rstrip("/")
     if "mqtt_server" in fields_set and update.mqtt_server is not None:
         settings.frigate.mqtt_server = update.mqtt_server
     if "mqtt_port" in fields_set:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -9179,6 +9179,18 @@
             "default": "inaturalist",
             "title": "Enrichment Taxonomy Source"
           },
+          "frigate_external_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "",
+            "title": "Frigate External Url"
+          },
           "frigate_missing_behavior": {
             "default": "mark_missing",
             "enum": [
@@ -11069,6 +11081,19 @@
             "default": "inaturalist",
             "description": "Provider for taxonomy/common names",
             "title": "Enrichment Taxonomy Source"
+          },
+          "frigate_external_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "",
+            "description": "External Frigate base URL (browser\u2192Frigate)",
+            "title": "Frigate External Url"
           },
           "frigate_missing_behavior": {
             "default": "mark_missing",

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -165,6 +165,43 @@ async def test_settings_roundtrip_birdnet_internal_and_external_urls(client: htt
 
 
 @pytest.mark.asyncio
+async def test_settings_roundtrip_frigate_external_url(client: httpx.AsyncClient):
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+
+    get_before = await client.get("/api/settings")
+    assert get_before.status_code == 200, get_before.text
+    before_payload = get_before.json()
+
+    assert "frigate_external_url" in before_payload
+
+    update_payload = {
+        "frigate_url": before_payload["frigate_url"],
+        "mqtt_server": before_payload["mqtt_server"],
+        "classification_threshold": before_payload["classification_threshold"],
+        "frigate_external_url": " https://frigate.example.com/ ",
+    }
+    post_resp = await client.post("/api/settings", json=update_payload)
+    assert post_resp.status_code == 200, post_resp.text
+
+    get_after = await client.get("/api/settings")
+    assert get_after.status_code == 200, get_after.text
+    after_payload = get_after.json()
+    assert after_payload["frigate_external_url"] == "https://frigate.example.com"
+
+    omitting_payload = {
+        "frigate_url": before_payload["frigate_url"],
+        "mqtt_server": before_payload["mqtt_server"],
+        "classification_threshold": before_payload["classification_threshold"],
+    }
+    post_resp = await client.post("/api/settings", json=omitting_payload)
+    assert post_resp.status_code == 200, post_resp.text
+
+    get_final = await client.get("/api/settings")
+    assert get_final.json()["frigate_external_url"] == "https://frigate.example.com"
+
+
+@pytest.mark.asyncio
 async def test_settings_rejects_enabling_auth_without_password(client: httpx.AsyncClient):
     settings.auth.enabled = False
     settings.auth.password_hash = None

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -69,6 +69,7 @@ settings and do not follow the `SECTION__FIELD` precedence rules above.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `FRIGATE__FRIGATE_URL` | `http://frigate:5000` | Frigate base URL for snapshots/clips. |
+| `FRIGATE__FRIGATE_EXTERNAL_URL` | _(empty)_ | Browser-facing Frigate URL for the detection's "open in Frigate" link. Falls back to `FRIGATE__FRIGATE_URL`. |
 | `FRIGATE__FRIGATE_AUTH_TOKEN` | _(unset)_ | Bearer token if Frigate requires auth. |
 | `FRIGATE__MAIN_TOPIC` | `frigate` | Frigate MQTT base topic. |
 | `FRIGATE__MQTT_SERVER` | `mqtt` | MQTT broker host. |


### PR DESCRIPTION
## Outcome

The "open in Frigate" link from #309 dies on installs where the configured Frigate URL is a container address (`http://frigate:5000`). Connection settings now take an optional **public Frigate URL** (env: `FRIGATE__FRIGATE_EXTERNAL_URL`); the detection link prefers it and falls back to the server URL when unset — the same internal/external split BirdNET-Go already has.

## Included

- `frigate_external_url` on `FrigateSettings`, env mapping, settings GET/POST (trimmed, trailing slash stripped, omitted-field untouched), OpenAPI artifact + generated SPA types refreshed.
- Connection tab field with description; detection modal prefers the public URL.
- i18n across all nine locales; env reference row; changelog.

## Excluded

- No migration — config-only field.

## Verification

Backend 2555 passed (new round-trip + omission test); frontend svelte-check 0/0, 951 tests green; docs consistency check passes. Manually verified: the field saves through the UI and `GET /api/settings` returns the trimmed URL.