### PR TITLE
Redraw the aurora as a drifting mesh, after Apple's Sports app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   notes moved into Technical details. The prediction is honest arithmetic — model RAM × process
   mode × worker concurrency: isolated workers multiply by the resolved live + background counts,
   in-process is one shared copy, and the caption states the formula. The aurora is a shared kit
-  effect and also plays behind the status band; the Models header lost its duplicate subtitle,
+  effect and also plays behind the status band, redrawn as an animated mesh in the manner of
+  Apple's Sports app — soft blobs of brand color drifting on two independent periods, so the
+  motion never lines up into a pattern; the Models header lost its duplicate subtitle,
   the GPU guide shrank to one link line, and the execution-mode explainer was cut to two
   sentences.
 

--- a/apps/ui/src/app.css
+++ b/apps/ui/src/app.css
@@ -704,46 +704,59 @@ html.theme-bluetit.dark .ai-markdown-surface th { color: rgb(191 219 254); }
 }
 
 /* Decorative aurora shared by highlighted cards (selected model card, the
-   Detection status band): corner tints plus a flag-like ripple of faint
-   diagonal bands swaying sideways. Transform-only, so it stays on the
-   compositor; stilled entirely under prefers-reduced-motion. Hosts set
-   `relative overflow-hidden` and keep their content on a stacking layer. */
+   Detection status band). Modeled on animated mesh gradients: soft blobs of
+   brand color at asymmetric positions on two layers that drift at different
+   periods, so the motion never lines up into a pattern. Transform-only, so it
+   stays on the compositor; stilled entirely under prefers-reduced-motion.
+   Hosts set `relative overflow-hidden` and keep content on a stacking layer. */
 .card-aurora {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background:
-    radial-gradient(120% 100% at 12% 0%, rgb(59 130 246 / 0.14), transparent 55%),
-    radial-gradient(110% 90% at 90% 100%, rgb(45 212 191 / 0.16), transparent 55%),
-    radial-gradient(70% 60% at 75% 15%, rgb(129 140 248 / 0.09), transparent 60%);
 }
 
+.card-aurora::before,
 .card-aurora::after {
   content: '';
   position: absolute;
-  inset: -40% -35%;
-  background: repeating-linear-gradient(
-    104deg,
-    transparent 0px,
-    transparent 28px,
-    rgb(59 130 246 / 0.05) 42px,
-    rgb(45 212 191 / 0.07) 56px,
-    transparent 70px,
-    transparent 96px
-  );
-  animation: card-aurora-ripple 9s ease-in-out infinite alternate;
+  inset: -25%;
 }
 
-@keyframes card-aurora-ripple {
+.card-aurora::before {
+  background:
+    radial-gradient(60% 55% at 22% 28%, rgb(59 130 246 / 0.1), transparent 65%),
+    radial-gradient(50% 60% at 78% 20%, rgb(129 140 248 / 0.07), transparent 60%),
+    radial-gradient(55% 65% at 30% 85%, rgb(45 212 191 / 0.09), transparent 60%);
+  animation: card-aurora-drift-a 21s ease-in-out infinite alternate;
+}
+
+.card-aurora::after {
+  background:
+    radial-gradient(45% 50% at 85% 75%, rgb(45 212 191 / 0.08), transparent 60%),
+    radial-gradient(40% 45% at 60% 40%, rgb(59 130 246 / 0.05), transparent 65%);
+  animation: card-aurora-drift-b 17s ease-in-out infinite alternate;
+}
+
+@keyframes card-aurora-drift-a {
   from {
-    transform: translateX(-4%) skewY(-1deg);
+    transform: translate(-3%, -2%) scale(1);
   }
   to {
-    transform: translateX(4%) skewY(1deg);
+    transform: translate(3%, 2%) scale(1.06);
+  }
+}
+
+@keyframes card-aurora-drift-b {
+  from {
+    transform: translate(2.5%, 2%) scale(1.04);
+  }
+  to {
+    transform: translate(-2.5%, -2%) scale(1);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .card-aurora::before,
   .card-aurora::after {
     animation: none;
   }


### PR DESCRIPTION
## Outcome

Review feedback on #332: the ripple was too uniform. Bands are gone entirely — the shared `card-aurora` is now an animated mesh in the manner of Apple's Sports app: five faint blobs of brand color at asymmetric positions on two layers drifting at different periods (21s / 17s, alternate ease-in-out), so the interference never lines up into a visible pattern. Opacities 0.05–0.10, transform-only (compositor-friendly), stilled under `prefers-reduced-motion`.

## Verification

svelte-check 0/0; 966 frontend tests green; verified visually on the status band and selected model card.