### PR TITLE
Only offer a species filter the rows can answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A species the filter panel offers can no longer come back as an empty page
+  ([#301](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/301)).** The filter list
+  keyed some options on a taxon id that lived only in the taxonomy cache, and the cache is
+  rewritten whenever a lookup corrects an id — so "Eurasian Blue Tit · 2" could return "0 visits"
+  moments later without any detection changing. An option now carries a taxon id only when some
+  detection row actually stores it; cache-linked groups filter by name, which reaches the rows
+  through their own columns and survives cache drift. Alongside it, a failed taxonomy lookup can
+  no longer take an identity away: the cache upsert keeps an existing taxon id and name when the
+  incoming write has none. A new invariant suite drives adversarial label shapes through the real
+  API and asserts an offered option is never an empty answer.
+
+- **An empty Explorer page under active filters now says so.** It used to show "No events yet —
+  Backfill or wait for new detections", telling an owner their history was gone when a filter
+  simply matched nothing. With filters active it now says no visits match, that the history is
+  still there, and offers one button that clears every filter.
+
 ### Security
 
 - **The 49 CodeQL alerts are triaged: fixed, or dismissed with a written reason

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -2026,7 +2026,10 @@
     "timeline_keyboard_hint": "Timeline-Tastatur: [ vorheriger Tag, ] nächster Tag, 0 zurücksetzen",
     "row_open": "{species} öffnen",
     "row_select": "{species} auswählen",
-    "row_below_threshold": "Unter der Benennungsschwelle"
+    "row_below_threshold": "Unter der Benennungsschwelle",
+    "empty_filtered_title": "Keine Besuche passen zu diesen Filtern",
+    "empty_filtered_desc": "Dein Verlauf ist noch da. Erweitere den Zeitraum oder entferne einen Filter, um ihn zu sehen.",
+    "empty_filtered_clear": "Alle Filter entfernen"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -2035,7 +2035,10 @@
     "timeline_keyboard_hint": "Timeline keyboard: [ previous day, ] next day, 0 reset",
     "row_open": "Open {species}",
     "row_select": "Select {species}",
-    "row_below_threshold": "Below the naming threshold"
+    "row_below_threshold": "Below the naming threshold",
+    "empty_filtered_title": "No visits match these filters",
+    "empty_filtered_desc": "Your history is still here. Widen the date range or remove a filter to see it.",
+    "empty_filtered_clear": "Clear all filters"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -2026,7 +2026,10 @@
     "timeline_keyboard_hint": "Teclado de línea de tiempo: [ día anterior, ] día siguiente, 0 restablecer",
     "row_open": "Abrir {species}",
     "row_select": "Seleccionar {species}",
-    "row_below_threshold": "Por debajo del umbral de identificación"
+    "row_below_threshold": "Por debajo del umbral de identificación",
+    "empty_filtered_title": "Ninguna visita coincide con estos filtros",
+    "empty_filtered_desc": "Tu historial sigue aquí. Amplía el rango de fechas o quita un filtro para verlo.",
+    "empty_filtered_clear": "Quitar todos los filtros"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -2026,7 +2026,10 @@
     "timeline_keyboard_hint": "Clavier de la chronologie : [ jour précédent, ] jour suivant, 0 réinitialiser",
     "row_open": "Ouvrir {species}",
     "row_select": "Sélectionner {species}",
-    "row_below_threshold": "Sous le seuil de nommage"
+    "row_below_threshold": "Sous le seuil de nommage",
+    "empty_filtered_title": "Aucune visite ne correspond à ces filtres",
+    "empty_filtered_desc": "Votre historique est toujours là. Élargissez la période ou retirez un filtre pour le voir.",
+    "empty_filtered_clear": "Effacer tous les filtres"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -2035,7 +2035,10 @@
     "timeline_keyboard_hint": "Tastiera timeline: [ giorno precedente, ] giorno successivo, 0 reimposta",
     "row_open": "Apri {species}",
     "row_select": "Seleziona {species}",
-    "row_below_threshold": "Sotto la soglia di denominazione"
+    "row_below_threshold": "Sotto la soglia di denominazione",
+    "empty_filtered_title": "Nessuna visita corrisponde a questi filtri",
+    "empty_filtered_desc": "La tua cronologia è ancora qui. Allarga il periodo o rimuovi un filtro per vederla.",
+    "empty_filtered_clear": "Rimuovi tutti i filtri"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -2026,7 +2026,10 @@
     "timeline_keyboard_hint": "タイムライン操作: [ 前日、] 翌日、0 リセット",
     "row_open": "{species} を開く",
     "row_select": "{species} を選択",
-    "row_below_threshold": "命名のしきい値未満"
+    "row_below_threshold": "命名のしきい値未満",
+    "empty_filtered_title": "このフィルターに一致する訪問はありません",
+    "empty_filtered_desc": "履歴は残っています。期間を広げるかフィルターを外すと表示されます。",
+    "empty_filtered_clear": "すべてのフィルターを解除"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -2035,7 +2035,10 @@
     "timeline_keyboard_hint": "Teclado da linha do tempo: [ dia anterior, ] próximo dia, 0 redefinir",
     "row_open": "Abrir {species}",
     "row_select": "Selecionar {species}",
-    "row_below_threshold": "Abaixo do limiar de identificação"
+    "row_below_threshold": "Abaixo do limiar de identificação",
+    "empty_filtered_title": "Nenhuma visita corresponde a estes filtros",
+    "empty_filtered_desc": "Seu histórico continua aqui. Amplie o período ou remova um filtro para vê-lo.",
+    "empty_filtered_clear": "Limpar todos os filtros"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -2035,7 +2035,10 @@
     "timeline_keyboard_hint": "Клавиши таймлайна: [ предыдущий день, ] следующий день, 0 сброс",
     "row_open": "Открыть {species}",
     "row_select": "Выбрать {species}",
-    "row_below_threshold": "Ниже порога определения"
+    "row_below_threshold": "Ниже порога определения",
+    "empty_filtered_title": "Ни один визит не подходит под эти фильтры",
+    "empty_filtered_desc": "Ваша история на месте. Расширьте период или уберите фильтр, чтобы её увидеть.",
+    "empty_filtered_clear": "Сбросить все фильтры"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -2026,7 +2026,10 @@
     "timeline_keyboard_hint": "时间线快捷键：[ 前一天，] 后一天，0 重置",
     "row_open": "打开 {species}",
     "row_select": "选择 {species}",
-    "row_below_threshold": "低于命名阈值"
+    "row_below_threshold": "低于命名阈值",
+    "empty_filtered_title": "没有符合这些筛选条件的到访",
+    "empty_filtered_desc": "您的历史记录仍在。放宽日期范围或移除一个筛选即可看到。",
+    "empty_filtered_clear": "清除所有筛选"
   },
   "audio": {
     "chart": {

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -741,6 +741,18 @@
             .map(([key, count]) => ({ key, count, label: formatTimelineBucketLabel(key) }));
     });
 
+    let hasActiveExplorerFilters = $derived(
+        Boolean(
+            speciesFilter ||
+                cameraFilter ||
+                favoritesOnly ||
+                audioConfirmedOnly ||
+                showHidden ||
+                datePreset !== 'all' ||
+                selectedTimelineBucket !== 'all'
+        )
+    );
+
     let visibleEvents = $derived.by(() => {
         if (selectedTimelineBucket === 'all') return events;
         return events.filter((event) => detectionDayKey(event) === selectedTimelineBucket);
@@ -1292,8 +1304,35 @@
                     <path stroke-linecap="round" stroke-linejoin="round" d="M16 7h.01M3.5 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.3-2.3L2 20" />
                     <path stroke-linecap="round" stroke-linejoin="round" d="m20 7 2 .5-2 .5M10 18v3m4-3.25V21M7 18a6 6 0 0 0 3.8-10.6" />
                 </svg>
-                <h3 class="text-lg font-semibold text-slate-900 dark:text-white">{$_('events.empty_title')}</h3>
-                <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">{$_('events.empty_desc')}</p>
+                {#if hasActiveExplorerFilters}
+                    <!-- An empty page under active filters is a statement about the
+                         filters, never about the feeder (#301): saying "no events
+                         yet" here told an owner their history was gone. -->
+                    <h3 class="text-lg font-semibold text-slate-900 dark:text-white">{$_('events.empty_filtered_title', { default: 'No visits match these filters' })}</h3>
+                    <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">{$_('events.empty_filtered_desc', { default: 'Your history is still here. Widen the date range or remove a filter to see it.' })}</p>
+                    <button
+                        type="button"
+                        class="btn btn-secondary mt-4 min-h-11 px-4"
+                        onclick={() => {
+                            datePreset = 'all';
+                            speciesFilter = '';
+                            cameraFilter = '';
+                            favoritesOnly = false;
+                            audioConfirmedOnly = false;
+                            showHidden = false;
+                            customStartDate = '';
+                            customEndDate = '';
+                            selectedTimelineBucket = 'all';
+                            currentPage = 1;
+                            loadEvents();
+                        }}
+                    >
+                        {$_('events.empty_filtered_clear', { default: 'Clear all filters' })}
+                    </button>
+                {:else}
+                    <h3 class="text-lg font-semibold text-slate-900 dark:text-white">{$_('events.empty_title')}</h3>
+                    <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">{$_('events.empty_desc')}</p>
+                {/if}
             </div>
         {:else if explorerView === 'list'}
             <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white/80 dark:border-slate-800 dark:bg-slate-900/50" data-explorer-list>

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1968,11 +1968,16 @@ class DetectionRepository:
             f"""
             WITH species_rows AS (
                 -- Enrich taxa_id from taxonomy_cache when the detection is missing it
-                -- but has a known scientific_name we can join on.
+                -- but has a known scientific_name we can join on. The stored id is
+                -- kept separately: grouping may use the enriched id, but the value
+                -- offered to the filter may not - the cache is rewritten whenever a
+                -- lookup corrects an id, and a filter keyed on a cache-only id goes
+                -- from counted to empty without any detection changing (#301).
                 SELECT
                     d.display_name,
                     d.scientific_name,
                     d.common_name,
+                    d.taxa_id AS stored_taxa_id,
                     COALESCE(d.taxa_id, tc.taxa_id) AS taxa_id
                 FROM detections d
                 LEFT JOIN taxonomy_cache tc
@@ -1980,6 +1985,19 @@ class DetectionRepository:
                     AND LOWER(tc.scientific_name) = LOWER(d.scientific_name)
                 WHERE (d.is_hidden = 0 OR d.is_hidden IS NULL)
                   {start_filter}
+            ),
+            -- The id a filter can safely be keyed on: one some detection row
+            -- actually stores, per species group.
+            group_stored AS (
+                SELECT
+                    COALESCE(
+                        CAST(taxa_id AS TEXT),
+                        LOWER(scientific_name),
+                        LOWER(display_name)
+                    ) AS species_key,
+                    MAX(stored_taxa_id) AS stored_taxa_id
+                FROM species_rows
+                GROUP BY species_key
             ),
             -- The filter bar shows how many detections each option would return, so the
             -- count has to be taken over the same grouping the options are built from.
@@ -2030,10 +2048,11 @@ class DetectionRepository:
                 ranked.display_name,
                 ranked.scientific_name,
                 ranked.common_name,
-                ranked.taxa_id,
+                group_stored.stored_taxa_id AS taxa_id,
                 COALESCE(group_counts.detection_count, 0) AS detection_count
             FROM ranked
             LEFT JOIN group_counts ON group_counts.species_key = ranked.species_key
+            LEFT JOIN group_stored ON group_stored.species_key = ranked.species_key
             WHERE ranked.rn = 1
             ORDER BY ranked.display_name ASC
             """,

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -314,10 +314,17 @@ class TaxonomyService:
                (scientific_name, common_name, taxa_id, is_not_found, thumbnail_url, last_updated) 
                VALUES (?, ?, ?, ?, ?, ?)
                ON CONFLICT(scientific_name) DO UPDATE SET
-                   common_name = excluded.common_name,
-                   taxa_id = excluded.taxa_id,
-                   is_not_found = excluded.is_not_found,
-                   thumbnail_url = excluded.thumbnail_url,
+                   common_name = COALESCE(excluded.common_name, taxonomy_cache.common_name),
+                   -- A lookup may correct an id, but a failed one may never take an
+                   -- identity away: features key on the id a row carries, and nulling
+                   -- it turns an offered species into an empty filter (#301).
+                   taxa_id = COALESCE(excluded.taxa_id, taxonomy_cache.taxa_id),
+                   is_not_found = CASE
+                       WHEN taxonomy_cache.taxa_id IS NOT NULL AND excluded.taxa_id IS NULL
+                           THEN taxonomy_cache.is_not_found
+                       ELSE excluded.is_not_found
+                   END,
+                   thumbnail_url = COALESCE(excluded.thumbnail_url, taxonomy_cache.thumbnail_url),
                    last_updated = excluded.last_updated""",
             (
                 data["scientific_name"],

--- a/backend/tests/test_species_facet_filter_consistency.py
+++ b/backend/tests/test_species_facet_filter_consistency.py
@@ -1,0 +1,218 @@
+"""Every species the filter panel offers must return its rows when chosen.
+
+The Explorer builds its species list by collapsing the different spellings a
+bird was recorded under, then filtering has to take the chosen option back to
+every one of those rows. Where the two sides disagree, the panel offers a
+species and the filter finds none of it - the exact shape reported in #301
+("Eurasian Blue Tit ... 2" offered, "0 visits" returned). These cases drive
+adversarial label shapes through the real API and assert the invariant:
+an offered option is never an empty answer.
+"""
+
+import uuid
+import httpx
+import pytest
+import pytest_asyncio
+
+from app.config import settings
+from app.database import close_db, get_db, init_db
+from app.main import app
+from app.routers.events import _event_filters_cache
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def offline_taxonomy(monkeypatch):
+    from app.services.taxonomy import taxonomy_service as ts_module
+
+    async def unavailable(self, name):
+        raise ts_module.TaxonomyLookupUnavailable(name)
+
+    monkeypatch.setattr(ts_module.TaxonomyService, "_lookup_inaturalist", unavailable)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def db_setup():
+    await init_db()
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+    _event_filters_cache.clear()
+    # These invariants assert on the exact option values the facet emits, so
+    # every case starts from an empty slate rather than tolerating leftovers.
+    async with get_db() as db:
+        await db.execute("DELETE FROM detections")
+        await db.execute("DELETE FROM taxonomy_cache")
+        await db.commit()
+    yield
+    _event_filters_cache.clear()
+    await close_db()
+
+
+async def _insert(event_id, display, *, sci=None, common=None, taxa=None, hidden=False):
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO detections (
+                detection_time, detection_index, score, display_name, category_name,
+                frigate_event, camera_name, is_hidden, manual_tagged,
+                scientific_name, common_name, taxa_id
+            ) VALUES (datetime('now'), 1, 0.8, ?, ?, ?, 'cam', ?, 0, ?, ?, ?)""",
+            (display, display, event_id, 1 if hidden else 0, sci, common, taxa),
+        )
+        await db.commit()
+
+
+async def _cache(sci, common, taxa):
+    async with get_db() as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO taxonomy_cache (scientific_name, common_name, taxa_id) VALUES (?,?,?)",
+            (sci, common, taxa),
+        )
+        await db.commit()
+
+
+SHAPES = [
+    # (label, rows[(display, sci, common, taxa)], cache[(sci, common, taxa)])
+    ("plain-no-taxonomy", [("Mystery Wren", None, None, None)], []),
+    ("parenthetical-common-sci", [("Eurasian Blue Tit (Cyanistes caeruleus)", None, None, None)], []),
+    ("parenthetical-sci-common", [("Cyanistes caeruleus (Eurasian Blue Tit)", None, None, None)], []),
+    (
+        "sci-stored-cache-known",
+        [("Blue Tit Label", "Cyanistes caeruleus", None, None)],
+        [("Cyanistes caeruleus", "Eurasian Blue Tit", 13270)],
+    ),
+    (
+        "mixed-one-taxa-one-not",
+        [
+            ("Eurasian Blue Tit", "Cyanistes caeruleus", "Eurasian Blue Tit", 13270),
+            ("Cyanistes caeruleus (Eurasian Blue Tit)", None, None, None),
+        ],
+        [("Cyanistes caeruleus", "Eurasian Blue Tit", 13270)],
+    ),
+    (
+        "cache-only-via-sci",
+        [("Tit A", "Cyanistes caeruleus", None, None), ("Tit B", "Cyanistes caeruleus", None, None)],
+        [("Cyanistes caeruleus", "Eurasian Blue Tit", 13270)],
+    ),
+    ("accented", [("Grünfink", None, None, None)], []),
+    ("taxa-stored-cache-conflict", [("Conflict Bird", "Parus major", None, 999)], [("Parus major", "Great Tit", 111)]),
+    (
+        "parenthetical-with-cache-common-match",
+        [("Eurasian Blue Tit (Cyanistes caeruleus)", None, None, None)],
+        [("Cyanistes caeruleus", "Eurasian Blue Tit", 13270)],
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label,rows,cache", SHAPES, ids=[s[0] for s in SHAPES])
+async def test_every_offered_species_returns_its_rows(client, label, rows, cache):
+    for sci, common, taxa in cache:
+        await _cache(sci, common, taxa)
+    displays = set()
+    for i, (display, sci, common, taxa) in enumerate(rows):
+        await _insert(f"evt-{label}-{i}-{uuid.uuid4().hex[:6]}", display, sci=sci, common=common, taxa=taxa)
+        displays.add(display.lower())
+
+    resp = await client.get("/api/events/filters", params={"force_refresh": "true"})
+    assert resp.status_code == 200
+    options = resp.json()["species"]
+    # find the option(s) covering our seeded rows
+    mine = [
+        o
+        for o in options
+        if (o["display_name"] or "").lower() in displays
+        or (o.get("scientific_name") or "").lower() in {r[1].lower() for r in rows if r[1]}
+        or (o["value"] or "").lower() in displays
+        or any(d in (o["display_name"] or "").lower() for d in displays)
+    ]
+    assert mine, f"{label}: no facet option found among {[o['display_name'] for o in options]}"
+    for o in mine:
+        value = o["value"]
+        r = await client.get("/api/events", params={"species": value, "fields": "list", "limit": 50})
+        assert r.status_code == 200, r.text
+        events = r.json()
+        c = await client.get("/api/events/count", params={"species": value})
+        n = c.json()["count"]
+        assert len(events) > 0 and n > 0, (
+            f"{label}: option value={value!r} display={o['display_name']!r} "
+            f"facet_count={o['count']} -> list={len(events)} count={n}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_cache_linked_group_offers_a_name_not_an_unstored_id(client):
+    """A `taxa:` value must only be offered when some detection row stores that
+    id: an id that exists only in the taxonomy cache is rewritten whenever the
+    cache refreshes, and a filter built on it goes from "2 detections" to
+    "0 visits" without anything else changing (#301)."""
+    await _cache("Cyanistes caeruleus", "Eurasian Blue Tit", 13270)
+    await _insert(f"evt-{uuid.uuid4().hex[:8]}", "Blue Tit Label", sci="Cyanistes caeruleus")
+
+    resp = await client.get("/api/events/filters", params={"force_refresh": "true"})
+    option = next(
+        o for o in resp.json()["species"] if (o.get("scientific_name") or "").lower() == "cyanistes caeruleus"
+    )
+    assert not option["value"].startswith("taxa:"), option
+    r = await client.get("/api/events/count", params={"species": option["value"]})
+    assert r.json()["count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_offered_value_survives_taxonomy_cache_drift(client):
+    """Filtering by an offered option must still work after the cache learns a
+    corrected taxon id, because the cache is refreshed independently of the
+    filter list the user is looking at (#301)."""
+    await _cache("Cyanistes caeruleus", "Eurasian Blue Tit", 13270)
+    await _insert(f"evt-{uuid.uuid4().hex[:8]}", "Blue Tit Label", sci="Cyanistes caeruleus")
+
+    resp = await client.get("/api/events/filters", params={"force_refresh": "true"})
+    option = next(
+        o for o in resp.json()["species"] if (o.get("scientific_name") or "").lower() == "cyanistes caeruleus"
+    )
+
+    # iNaturalist corrects the id after the filter list was built.
+    async with get_db() as db:
+        await db.execute("UPDATE taxonomy_cache SET taxa_id = 144849 WHERE scientific_name = 'Cyanistes caeruleus'")
+        await db.commit()
+
+    r = await client.get("/api/events/count", params={"species": option["value"]})
+    assert r.json()["count"] >= 1, option
+    rows = await client.get("/api/events", params={"species": option["value"], "fields": "list", "limit": 10})
+    assert len(rows.json()) >= 1
+
+
+@pytest.mark.asyncio
+async def test_stored_ids_keep_the_taxa_fast_path(client):
+    await _insert(f"evt-{uuid.uuid4().hex[:8]}", "Great Tit", sci="Parus major", common="Great Tit", taxa=111)
+    resp = await client.get("/api/events/filters", params={"force_refresh": "true"})
+    option = next(o for o in resp.json()["species"] if o.get("taxa_id") == 111)
+    assert option["value"] == "taxa:111"
+    r = await client.get("/api/events/count", params={"species": "taxa:111"})
+    assert r.json()["count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_failed_lookup_never_downgrades_a_cached_identity():
+    """A not-found answer for a name must not null the taxon id a cache row
+    already carries: features key on that id, and losing it turns an offered
+    species into an empty filter (#301)."""
+    from app.services.taxonomy.taxonomy_service import taxonomy_service
+
+    await taxonomy_service._save_to_cache(
+        {"scientific_name": "Parus major", "common_name": "Great Tit", "taxa_id": 111, "is_not_found": False}
+    )
+    await taxonomy_service._save_to_cache(
+        {"scientific_name": "Parus major", "common_name": None, "taxa_id": None, "is_not_found": True}
+    )
+    async with get_db() as db:
+        async with db.execute(
+            "SELECT common_name, taxa_id, is_not_found FROM taxonomy_cache WHERE scientific_name = 'Parus major'"
+        ) as cur:
+            row = await cur.fetchone()
+    assert row == ("Great Tit", 111, 0), row


### PR DESCRIPTION
## Outcome

Fixes [#301](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/301). The species facet keyed some options on a taxon id that lived only in the taxonomy cache; the cache is rewritten whenever a lookup corrects an id, so an offered species ("Eurasian Blue Tit · 2") could return "0 visits" without any detection changing — species-specific, intermittent, size-independent, exactly as reported.

## Included

- The facet emits a `taxa:` value only when some detection row actually stores that id (the guarantee the endpoint's comment already claimed); cache-linked groups filter by name, which survives cache drift.
- The taxonomy-cache upsert can improve but never downgrade: a failed lookup no longer nulls a stored taxon id or overwrites a resolved identity with not-found.
- Honest filtered-empty state in the Explorer: "No visits match these filters" + one clear-all button, instead of "No events yet — backfill or wait".
- New invariant suite (13 tests): adversarial label shapes through the real API — an offered option is never an empty answer; network stubbed for determinism.

## Verification

Backend 2577 green including the new suite; svelte-check 0/0; 967 frontend tests; verified against a quark database snapshot (46/46 options consistent).