### PR TITLE
Give the worker pipe one stream limit, and refuse what cannot fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A single large image can no longer kill a classifier worker.** The worker pipe carries
+  newline-framed JSON, and its two ends disagreed about how large a line may be: the worker read
+  requests with a 4 MB limit — which a high-quality snapshot exceeds as base64 — and the
+  supervisor read responses with only 512 KB. One oversized frame raised LimitOverrunError and
+  took the worker down instead of failing one request (observed live). The limit is now a single
+  32 MB property of the protocol shared by both ends, and an encode that would exceed it is
+  refused before it is written, so the framing can never be poisoned mid-line.
+
+### Fixed
+
 - **A species the filter panel offers can no longer come back as an empty page
   ([#301](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/301)).** The filter list
   keyed some options on a taxon id that lived only in the taxonomy cache, and the cache is

--- a/backend/app/services/classifier_worker_client.py
+++ b/backend/app/services/classifier_worker_client.py
@@ -5,7 +5,11 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from .classifier_worker_protocol import decode_protocol_message, encode_protocol_message
+from .classifier_worker_protocol import (
+    WORKER_PROTOCOL_STREAM_LIMIT_BYTES,
+    decode_protocol_message,
+    encode_protocol_message,
+)
 
 
 ProcessFactory = Callable[..., Awaitable[Any]]
@@ -216,8 +220,8 @@ class ClassifierWorkerClient:
 
     async def _spawn_process(self, *, worker_name: str, worker_generation: int) -> Any:
         backend_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-        # Use a large limit (512KB) for the StreamReader to prevent LimitOverrunError
-        # if a worker dumps a massive JSON payload or large GPU error stack trace.
+        # The stream limit is the protocol's own: both ends read newline-framed
+        # JSON, and a single high-quality frame is megabytes of base64.
         return await asyncio.create_subprocess_exec(
             sys.executable,
             "-m",
@@ -228,5 +232,5 @@ class ClassifierWorkerClient:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=backend_root,
-            limit=512 * 1024,
+            limit=WORKER_PROTOCOL_STREAM_LIMIT_BYTES,
         )

--- a/backend/app/services/classifier_worker_process.py
+++ b/backend/app/services/classifier_worker_process.py
@@ -9,6 +9,7 @@ from typing import Any, Awaitable, Callable
 from PIL import Image
 
 from .classifier_worker_protocol import (
+    WORKER_PROTOCOL_STREAM_LIMIT_BYTES,
     build_error_event,
     build_heartbeat_event,
     build_progress_event,
@@ -18,8 +19,6 @@ from .classifier_worker_protocol import (
     decode_protocol_message,
     encode_protocol_message,
 )
-
-WORKER_PROTOCOL_STREAM_LIMIT_BYTES = 4 * 1024 * 1024
 
 
 class _StdoutWriter:

--- a/backend/app/services/classifier_worker_protocol.py
+++ b/backend/app/services/classifier_worker_protocol.py
@@ -24,8 +24,22 @@ _REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
+# One limit for both ends of the newline-framed pipe. A high-quality event
+# snapshot is ~3MB of JPEG and ~4MB as base64, and results can carry large
+# diagnostics, so the ceiling is generous - and enforced at encode time so an
+# oversized message fails one request instead of desynchronising the framing
+# and killing the worker (observed live as asyncio LimitOverrunError).
+WORKER_PROTOCOL_STREAM_LIMIT_BYTES = 32 * 1024 * 1024
+
+
 def encode_protocol_message(message: dict[str, Any]) -> bytes:
-    return (json.dumps(message, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+    encoded = (json.dumps(message, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+    if len(encoded) > WORKER_PROTOCOL_STREAM_LIMIT_BYTES:
+        raise ValueError(
+            f"protocol message of {len(encoded)} bytes exceeds the protocol stream limit "
+            f"({WORKER_PROTOCOL_STREAM_LIMIT_BYTES} bytes)"
+        )
+    return encoded
 
 
 def decode_protocol_message(raw: bytes | str) -> dict[str, Any]:

--- a/backend/tests/test_classifier_worker_protocol.py
+++ b/backend/tests/test_classifier_worker_protocol.py
@@ -171,3 +171,39 @@ def test_classifier_worker_protocol_round_trips_video_messages():
     assert decoded_progress["current_frame"] == 3
     assert decoded_progress["top_label"] == "Robin"
     assert decoded_progress["frame_offset_seconds"] == 1.25
+
+
+def test_stream_limit_is_a_shared_protocol_property():
+    """Both ends of the pipe read newline-framed JSON, so both must share one
+    generous limit. A high-quality snapshot is ~3MB of JPEG, ~4MB as base64 -
+    the worker's old 4MB stdin limit sat exactly on that boundary, and the
+    supervisor read responses with only 512KB, so a single large frame killed
+    the worker with LimitOverrunError instead of failing one request (#305
+    era hardening, observed live on 2026-08-29)."""
+    import inspect
+
+    from app.services import classifier_worker_client, classifier_worker_process
+    from app.services.classifier_worker_protocol import WORKER_PROTOCOL_STREAM_LIMIT_BYTES
+
+    assert WORKER_PROTOCOL_STREAM_LIMIT_BYTES >= 32 * 1024 * 1024
+
+    assert classifier_worker_process.WORKER_PROTOCOL_STREAM_LIMIT_BYTES is WORKER_PROTOCOL_STREAM_LIMIT_BYTES
+    spawn_source = inspect.getsource(classifier_worker_client.ClassifierWorkerClient._spawn_process)
+    assert "limit=WORKER_PROTOCOL_STREAM_LIMIT_BYTES" in spawn_source
+    assert "512 * 1024" not in spawn_source
+
+
+def test_oversized_request_fails_cleanly_instead_of_poisoning_the_pipe():
+    """A message that cannot fit the stream limit must be refused before it is
+    written: half-written giant lines desynchronise the newline framing and
+    take the worker down with them."""
+    import pytest
+
+    from app.services.classifier_worker_protocol import (
+        WORKER_PROTOCOL_STREAM_LIMIT_BYTES,
+        encode_protocol_message,
+    )
+
+    huge = {"type": "classify", "image_b64": "x" * (WORKER_PROTOCOL_STREAM_LIMIT_BYTES + 1)}
+    with pytest.raises(ValueError, match="exceeds the protocol stream limit"):
+        encode_protocol_message(huge)


### PR DESCRIPTION
## Outcome

Found live on the production host: `background-0` dying with `asyncio LimitOverrunError` mid video job. The worker protocol's newline-framed pipe had two different line limits — 4 MB reading requests in the worker (a high-quality snapshot exceeds that as base64), 512 KB reading responses in the supervisor — and an oversized line killed the worker instead of failing one request.

## Included

- `WORKER_PROTOCOL_STREAM_LIMIT_BYTES` (32 MB) lives in the protocol module and is used by both ends: the worker's stdin `StreamReader` and the supervisor's `create_subprocess_exec(limit=…)`.
- `encode_protocol_message` refuses a message that cannot fit **before** writing, so a half-written giant line can never desynchronise the framing.
- Protocol test pins the shared constant, both consumers, and the clean refusal.

## Verification

Backend 2579 tests green; repo-wide ruff clean. Root cause taken from live logs on the production host tonight.