### PR TITLE
Realign log severities so an error means an actual error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The log speaks at the right volume.** Three realignments so an error in the log means an
+  actual error: a worker's relayed crash traceback is now a warning instead of an info line (and
+  runtime start-up banners drop to debug); a clip Frigate simply never stored logs at info,
+  because the absence is an expected state the UI already reports honestly; and the nested
+  DB-acquire detector now names the connection's holder as well as the nested caller, and says
+  each unique pair once per process instead of on every request.
+
 - **A species the filter panel offers can no longer come back as an empty page
   ([#301](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/301)).** The filter list
   keyed some options on a taxon id that lived only in the taxonomy cache, and the cache is

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -306,6 +306,7 @@ def durable_work():
 # such callers, every connection is held by someone waiting for one only another
 # waiter can release.
 _acquire_depth: ContextVar[int] = ContextVar("db_acquire_depth", default=0)
+_acquire_label: ContextVar[Optional[str]] = ContextVar("db_acquire_label", default=None)
 
 
 def is_durable_work() -> bool:
@@ -355,6 +356,7 @@ class DatabasePool:
         # because aiosqlite connections are not hashable by value.
         self._checked_out: dict[int, tuple[float, str]] = {}
         self._nested_acquires = 0
+        self._nested_acquire_warned: set = set()
         self._last_nested_acquire_label: Optional[str] = None
 
     async def _create_connection(self) -> aiosqlite.Connection:
@@ -407,12 +409,20 @@ class DatabasePool:
         if depth:
             self._nested_acquires += 1
             self._last_nested_acquire_label = label
-            log.warning(
-                "Nested DB connection acquire",
-                held_by=label,
-                depth=depth + 1,
-                pool_size=self.pool_size,
-            )
+            # Name the holder, and say it once per unique pair: the detector is
+            # for finding the call site, and repeating it every request buries
+            # actual errors. The counter still counts every occurrence.
+            outer = _acquire_label.get()
+            pair = (outer, label)
+            if pair not in self._nested_acquire_warned:
+                self._nested_acquire_warned.add(pair)
+                log.warning(
+                    "Nested DB connection acquire",
+                    outer_held_by=outer,
+                    nested_by=label,
+                    depth=depth + 1,
+                    pool_size=self.pool_size,
+                )
         # An unbounded wait is only safe while holding nothing. A durable task
         # that already holds a connection must still take the deadline: hanging
         # here stops ingest for good and loses every later detection, where
@@ -866,12 +876,16 @@ async def get_db():
             yield db
         return
 
-    conn = await _db_pool.acquire(label=_caller_label())
+    caller = _caller_label()
+    conn = await _db_pool.acquire(label=caller)
     # Counted for the lifetime of the hold, so a second acquire from the same
-    # task is recognised as nesting rather than as an ordinary acquire.
+    # task is recognised as nesting rather than as an ordinary acquire - and
+    # labelled, so the nested-acquire warning can name who was holding.
     depth_token = _acquire_depth.set(_acquire_depth.get() + 1)
+    label_token = _acquire_label.set(caller)
     try:
         yield conn
     finally:
+        _acquire_label.reset(label_token)
         _acquire_depth.reset(depth_token)
         await _db_pool.release(conn)

--- a/backend/app/services/classifier_worker_client.py
+++ b/backend/app/services/classifier_worker_client.py
@@ -15,6 +15,36 @@ from .classifier_worker_protocol import (
 ProcessFactory = Callable[..., Awaitable[Any]]
 
 
+_STDERR_NOISE_MARKERS = (
+    # Runtime banners emitted at every worker start; they carry no signal
+    # beyond "the runtime initialised", so they log at debug.
+    "absl::InitializeLog()",
+    "TF-TRT Warning",
+    "tensorflow/core",
+)
+_STDERR_FAULT_MARKERS = (
+    "Traceback (most recent call last):",
+    "Error:",
+    "Error(",
+    "raise ",
+    "Exception",
+)
+
+
+def classify_worker_stderr_severity(text: str) -> str:
+    """Errors when there are actual errors: a relayed crash traceback is a
+    warning, a runtime banner is debug, everything else stays info."""
+    for marker in _STDERR_NOISE_MARKERS:
+        if marker in text:
+            return "debug"
+    for marker in _STDERR_FAULT_MARKERS:
+        if marker in text:
+            return "warning"
+    if "error" in text.lower():
+        return "warning"
+    return "info"
+
+
 class ClassifierWorkerClient:
     def __init__(
         self,
@@ -179,7 +209,8 @@ class ClassifierWorkerClient:
                 from structlog import get_logger
 
                 log = get_logger()
-                log.info(f"Worker {self.worker_name} stderr", text=text)
+                severity = classify_worker_stderr_severity(text)
+                getattr(log, severity)(f"Worker {self.worker_name} stderr", text=text)
         except Exception:
             pass
 

--- a/backend/app/services/frigate_client.py
+++ b/backend/app/services/frigate_client.py
@@ -163,7 +163,9 @@ class FrigateClient:
             if resp.status_code == 200:
                 return resp.content, None
             if resp.status_code == 404:
-                log.warning("Clip not found", event_id=event_id)
+                # Expected state: Frigate simply never stored a clip for this
+                # event. The caller reports the absence honestly to the UI.
+                log.info("Clip not found", event_id=event_id)
                 return None, "clip_not_found"
             if resp.status_code == 400:
                 try:
@@ -172,7 +174,7 @@ class FrigateClient:
                     payload = None
                 message = str((payload or {}).get("message") or "")
                 if "No recordings found for the specified time range" in message:
-                    log.warning("Clip recordings not retained", event_id=event_id)
+                    log.info("Clip recordings not retained", event_id=event_id)
                     return None, "clip_not_retained"
             log.warning("Failed to fetch clip", event_id=event_id, status=resp.status_code)
             return None, f"clip_http_{resp.status_code}"

--- a/backend/tests/test_log_severity_realignment.py
+++ b/backend/tests/test_log_severity_realignment.py
@@ -1,0 +1,48 @@
+"""Errors only when there are actual errors.
+
+The production log carried three kinds of noise at the wrong level: expected
+Frigate states (a clip it never stored) as warnings, real worker crash
+tracebacks relayed at info, and the nested-DB-acquire detector naming only the
+inner acquirer - repeating itself without saying who held the connection.
+"""
+
+import inspect
+
+from app.services.classifier_worker_client import classify_worker_stderr_severity
+
+
+def test_worker_stderr_severity_reflects_content():
+    # Real faults surface as warnings - a traceback at info hides a crash.
+    assert classify_worker_stderr_severity("Traceback (most recent call last):") == "warning"
+    assert classify_worker_stderr_severity("ValueError: Separator is not found") == "warning"
+    assert classify_worker_stderr_severity("  raise ValueError(e.args[0])") == "warning"
+    # Known runtime banners are debug: they say a worker started, nothing more.
+    assert (
+        classify_worker_stderr_severity(
+            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR"
+        )
+        == "debug"
+    )
+    # Anything else stays visible at info.
+    assert classify_worker_stderr_severity("loading model catalogue") == "info"
+
+
+def test_expected_frigate_absences_are_not_warnings():
+    from app.services import frigate_client
+
+    source = inspect.getsource(frigate_client.FrigateClient.get_clip_with_error)
+    assert 'log.info("Clip not found"' in source
+    assert 'log.info("Clip recordings not retained"' in source
+    assert 'log.warning("Clip not found"' not in source
+
+
+def test_nested_acquire_warning_names_the_holder_and_says_it_once():
+    import app.database as database
+
+    source = inspect.getsource(database.DatabasePool.acquire)
+    assert "outer_held_by=" in source
+    # Each unique (holder, nested) pair warns once per process; the counter
+    # still counts every occurrence for the stats endpoint.
+    assert "_nested_acquire_warned" in source
+    get_db_source = inspect.getsource(database.get_db)
+    assert "_acquire_label" in get_db_source


### PR DESCRIPTION
## Outcome

From the live-log review on the production host: three kinds of noise at the wrong level. Now: relayed worker stderr is classified (crash tracebacks **warn** — they were info; runtime banners drop to debug); a clip Frigate never stored is **info** (expected state, honestly surfaced in the UI already); the nested DB-acquire detector names the **holder** as well as the nested caller and warns once per unique pair per process (counter unchanged for stats).

## Verification

Backend 2580 tests green including the new severity tests; repo-wide ruff clean.