### PR TITLE
Stream clips to disk instead of through the API process's heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   transits were what glibc's arenas retained at high-water. Frigate downloads now stream straight
   to the job's temp file, cached clips are copied disk-to-disk, validation runs against the file,
   and the high-quality snapshot path takes the file path. The whole-clip byte string is gone from
-  the pipeline, and a source-level test keeps it gone.
+  the auto-video pipeline, and a source-level test keeps it gone. The high-quality snapshot
+  service's own queued fetch path (off by default) still buffers clips and keeps its bytes
+  entrypoints for that reason.
 
 - **A single large image can no longer kill a classifier worker.** The worker pipe carries
   newline-framed JSON, and its two ends disagreed about how large a line may be: the worker read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - **The API process no longer retains gigabytes of freed memory.** With ~70 threads, unbounded
   glibc malloc arenas kept the high-water mark of large transient buffers (whole video clips pass
   through memory on their way to the worker) — observed live as ~3.2 GB resident against an
-  expected ~1 GB. `MALLOC_ARENA_MAX=2` bounds that retention for every process in the image;
-  streaming clips to disk instead of through the heap is tracked in
-  [#341](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/341).
+  expected ~1 GB. `MALLOC_ARENA_MAX=2` bounds that retention for every process in the image.
+
+- **Video clips no longer pass through the API process's memory
+  ([#341](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/341)).** Every video job
+  used to load the whole clip into the main process — Frigate fetches as one byte string, cached
+  clips via read-into-memory — then write it to a temp file the worker reads anyway, and hand the
+  bytes to the snapshot upgrader, which wrote its own temp copy. Freed after each job, those
+  transits were what glibc's arenas retained at high-water. Frigate downloads now stream straight
+  to the job's temp file, cached clips are copied disk-to-disk, validation runs against the file,
+  and the high-quality snapshot path takes the file path. The whole-clip byte string is gone from
+  the pipeline, and a source-level test keeps it gone.
 
 - **A single large image can no longer kill a classifier worker.** The worker pipe carries
   newline-framed JSON, and its two ends disagreed about how large a line may be: the worker read

--- a/backend/app/services/auto_video_classifier_service.py
+++ b/backend/app/services/auto_video_classifier_service.py
@@ -2171,9 +2171,10 @@ class AutoVideoClassifierService:
             downloaded, error = await frigate_client.download_clip_to_file(frigate_event, dest_path, timeout=10.0)
 
             if downloaded:
-                if await self._clip_file_valid(dest_path):
+                validation_error = await self._clip_file_error(dest_path)
+                if validation_error is None:
                     return True, None
-                last_error = "clip_decode_failed"
+                last_error = validation_error
             else:
                 last_error = error or "clip_unavailable"
 
@@ -2301,8 +2302,12 @@ class AutoVideoClassifierService:
         cap.release()
         return ok
 
-    async def _clip_file_valid(self, clip_path: str) -> bool:
-        """Ensure the clip file carries an MP4 header and decodes one frame.
+    async def _clip_file_error(self, clip_path: str) -> Optional[str]:
+        """Validate the clip file; None when good, else the error code.
+
+        A non-MP4 body (Frigate answering 200 with an error stub) reports
+        `clip_invalid`; a real MP4 that will not decode reports
+        `clip_decode_failed` - the interface words the two differently.
 
         Works on the file directly - clips used to be validated as bytes and
         written to a temp file for cv2 anyway, so keeping them in memory bought
@@ -2323,15 +2328,19 @@ class AutoVideoClassifierService:
             return bool(head) and (head.startswith(b"\x00\x00\x00\x18ftyp") or b"ftyp" in head)
 
         if not await asyncio.to_thread(_has_mp4_header):
-            return False
+            return "clip_invalid"
         try:
-            return await asyncio.wait_for(
+            decodes = await asyncio.wait_for(
                 asyncio.to_thread(self._clip_decodes_sync, clip_path),
                 timeout=30.0,
             )
         except asyncio.TimeoutError:
             log.warning("Clip decode check timed out — treating clip as invalid")
-            return False
+            return "clip_decode_failed"
+        return None if decodes else "clip_decode_failed"
+
+    async def _clip_file_valid(self, clip_path: str) -> bool:
+        return await self._clip_file_error(clip_path) is None
 
     def _schedule_precheck_retry(
         self,

--- a/backend/app/services/auto_video_classifier_service.py
+++ b/backend/app/services/auto_video_classifier_service.py
@@ -6,6 +6,7 @@ import math
 import os
 from pathlib import Path
 import random
+import shutil
 import tempfile
 import structlog
 import time
@@ -1613,12 +1614,24 @@ class AutoVideoClassifierService:
                     )
                     return
 
-            # 2. Prefer a cached recording/full-visit clip when available.
-            clip_bytes, clip_error, clip_variant, clip_start_timestamp = await self._load_preferred_clip(
-                frigate_event,
-                skip_delay=skip_delay,
-            )
-            if not clip_bytes:
+            # 2. Prefer a cached recording/full-visit clip when available. The
+            # temp file is reserved first and the loader fills it directly, so
+            # the clip never passes through this process's heap (#341).
+            _fd, tmp_path = tempfile.mkstemp(suffix=".mp4")
+            os.close(_fd)
+            try:
+                clip_loaded, clip_error, clip_variant, clip_start_timestamp = await self._load_preferred_clip(
+                    frigate_event,
+                    tmp_path,
+                    skip_delay=skip_delay,
+                )
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(os.remove, tmp_path)
+                raise
+            if not clip_loaded:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(os.remove, tmp_path)
                 if snapshot_fallback_requested():
                     log.info(
                         "Falling back to snapshot classification because video is unavailable",
@@ -1661,19 +1674,6 @@ class AutoVideoClassifierService:
                     reason=clip_error or "clip_unavailable",
                 )
                 return
-
-            # 3. Save to temp file for processing (write offloaded so large clips don't
-            # block the loop).  mkstemp reserves the path synchronously so tmp_path is
-            # always set before the first cancellation-risk await, avoiding a NameError
-            # in the CancelledError cleanup path if the task is cancelled mid-write.
-            _fd, tmp_path = tempfile.mkstemp(suffix=".mp4")
-            os.close(_fd)
-            try:
-                await asyncio.to_thread(Path(tmp_path).write_bytes, clip_bytes)
-            except BaseException:
-                with contextlib.suppress(OSError):
-                    await asyncio.to_thread(os.remove, tmp_path)
-                raise
 
             try:
                 # 4. Run classification
@@ -1770,7 +1770,7 @@ class AutoVideoClassifierService:
                         "timeout_seconds": timeout,
                         "source": source,
                         "camera": camera,
-                        "clip_bytes": len(clip_bytes),
+                        "clip_bytes": await asyncio.to_thread(os.path.getsize, tmp_path),
                         "max_frames": settings.classification.video_classification_frames,
                     }
                     timeout_context.update(await asyncio.to_thread(self._clip_probe_context_sync, tmp_path))
@@ -1944,16 +1944,16 @@ class AutoVideoClassifierService:
 
                     # Generate HQ snapshot after top frames are persisted so the
                     # crop model works on the best-scored frames from this run.
-                    # Wrapped with a hard timeout: replace_from_clip_bytes runs
+                    # Wrapped with a hard timeout: replace_from_clip_path runs
                     # asyncio.to_thread CPU work (ONNX bird-crop model) and a
                     # synchronous classifier.classify() call with no inner timeout.
                     # A hang here holds the maintenance coordinator slot forever.
                     if settings.media_cache.high_quality_event_snapshots:
                         try:
                             await asyncio.wait_for(
-                                high_quality_snapshot_service.replace_from_clip_bytes(
+                                high_quality_snapshot_service.replace_from_clip_path(
                                     frigate_event,
-                                    clip_bytes,
+                                    Path(tmp_path),
                                     event_data=event_data,
                                     clip_variant=clip_variant,
                                 ),
@@ -2155,9 +2155,9 @@ class AutoVideoClassifierService:
             cap.release()
 
     async def _wait_for_clip(
-        self, frigate_event: str, skip_delay: bool = False
-    ) -> tuple[Optional[bytes], Optional[str]]:
-        """Poll Frigate for clip availability with retries."""
+        self, frigate_event: str, dest_path: str, skip_delay: bool = False
+    ) -> tuple[bool, Optional[str]]:
+        """Poll Frigate for clip availability with retries, streaming into dest_path."""
         # Initial delay to allow Frigate to finalize the clip
         if not skip_delay:
             await asyncio.sleep(settings.classification.video_classification_delay)
@@ -2168,16 +2168,12 @@ class AutoVideoClassifierService:
         last_error: Optional[str] = None
         for attempt in range(max_retries + 1):
             log.debug("Polling for clip", event_id=frigate_event, attempt=attempt)
-            clip_bytes, error = await frigate_client.get_clip_with_error(frigate_event, timeout=10.0)
+            downloaded, error = await frigate_client.download_clip_to_file(frigate_event, dest_path, timeout=10.0)
 
-            if clip_bytes and len(clip_bytes) > 0:
-                # Basic sanity check: MP4 header
-                if clip_bytes.startswith(b"\x00\x00\x00\x18ftyp") or b"ftyp" in clip_bytes[:32]:
-                    if await self._clip_decodes(clip_bytes):
-                        return clip_bytes, None
-                    last_error = "clip_decode_failed"
-                else:
-                    last_error = "clip_invalid"
+            if downloaded:
+                if await self._clip_file_valid(dest_path):
+                    return True, None
+                last_error = "clip_decode_failed"
             else:
                 last_error = error or "clip_unavailable"
 
@@ -2190,15 +2186,29 @@ class AutoVideoClassifierService:
                 log.debug(f"Clip not ready, waiting {wait_time}s", event_id=frigate_event)
                 await asyncio.sleep(wait_time)
 
-        return None, last_error
+        return False, last_error
 
     async def _load_preferred_clip(
         self,
         frigate_event: str,
+        dest_path: str,
         *,
         skip_delay: bool = False,
-    ) -> tuple[Optional[bytes], Optional[str], Literal["event", "recording"], float | None]:
-        """Prefer a cached recording/full-visit clip when available, otherwise poll the event clip."""
+    ) -> tuple[bool, Optional[str], Literal["event", "recording"], float | None]:
+        """Fill dest_path with the preferred clip: a cached recording/full-visit
+        clip when available, otherwise the polled event clip.
+
+        Cached clips are copied disk-to-disk and Frigate downloads are streamed,
+        so no whole clip ever transits this process's heap (#341).
+        """
+
+        async def _copy_and_validate(source_path: str) -> bool:
+            try:
+                await asyncio.to_thread(shutil.copyfile, source_path, dest_path)
+            except OSError:
+                return False
+            return await self._clip_file_valid(dest_path)
+
         recording_start_ts: float | int | None = None
         try:
             (
@@ -2212,14 +2222,9 @@ class AutoVideoClassifierService:
             )
             if recording_cached_path:
                 log.info("Using cached recording clip for auto video classification", event_id=frigate_event)
-                clip_bytes = await asyncio.to_thread(Path(recording_cached_path).read_bytes)
-                if (
-                    clip_bytes
-                    and (clip_bytes.startswith(b"\x00\x00\x00\x18ftyp") or b"ftyp" in clip_bytes[:32])
-                    and await self._clip_decodes(clip_bytes)
-                ):
+                if await _copy_and_validate(str(recording_cached_path)):
                     return (
-                        clip_bytes,
+                        True,
                         None,
                         "recording",
                         float(recording_start_ts) if recording_start_ts is not None else None,
@@ -2239,18 +2244,13 @@ class AutoVideoClassifierService:
         partial_recording_path = media_cache.get_recording_clip_path(frigate_event)
         if partial_recording_path:
             try:
-                clip_bytes = await asyncio.to_thread(Path(partial_recording_path).read_bytes)
-                if (
-                    clip_bytes
-                    and (clip_bytes.startswith(b"\x00\x00\x00\x18ftyp") or b"ftyp" in clip_bytes[:32])
-                    and await self._clip_decodes(clip_bytes)
-                ):
+                if await _copy_and_validate(str(partial_recording_path)):
                     log.info(
                         "Using retained partial recording clip for auto video classification",
                         event_id=frigate_event,
                     )
                     return (
-                        clip_bytes,
+                        True,
                         None,
                         "recording",
                         float(recording_start_ts) if recording_start_ts is not None else None,
@@ -2270,14 +2270,9 @@ class AutoVideoClassifierService:
         cached_clip_path = media_cache.get_clip_path(frigate_event)
         if cached_clip_path:
             try:
-                clip_bytes = await asyncio.to_thread(Path(cached_clip_path).read_bytes)
-                if (
-                    clip_bytes
-                    and (clip_bytes.startswith(b"\x00\x00\x00\x18ftyp") or b"ftyp" in clip_bytes[:32])
-                    and await self._clip_decodes(clip_bytes)
-                ):
+                if await _copy_and_validate(str(cached_clip_path)):
                     log.info("Using cached event clip for auto video classification", event_id=frigate_event)
-                    return clip_bytes, None, "event", None
+                    return True, None, "event", None
                 log.warning(
                     "Cached event clip was invalid; falling back to Frigate fetch",
                     event_id=frigate_event,
@@ -2290,43 +2285,48 @@ class AutoVideoClassifierService:
                     error=str(exc),
                 )
 
-        clip_bytes, clip_error = await self._wait_for_clip(frigate_event, skip_delay=skip_delay)
-        return clip_bytes, clip_error, "event", None
+        loaded, clip_error = await self._wait_for_clip(frigate_event, dest_path, skip_delay=skip_delay)
+        return loaded, clip_error, "event", None
 
     @staticmethod
-    def _clip_decodes_sync(clip_bytes: bytes) -> bool:
+    def _clip_decodes_sync(clip_path: str) -> bool:
         """Synchronous inner check — runs in a thread so it cannot block the event loop."""
         import cv2
 
-        tmp_path = None
-        try:
-            with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
-                tmp.write(clip_bytes)
-                tmp_path = tmp.name
-
-            cap = cv2.VideoCapture(tmp_path)
-            if not cap.isOpened():
-                cap.release()
-                return False
-            ok, _frame = cap.read()
+        cap = cv2.VideoCapture(clip_path)
+        if not cap.isOpened():
             cap.release()
-            return ok
-        finally:
-            if tmp_path and os.path.exists(tmp_path):
-                with contextlib.suppress(OSError):
-                    os.remove(tmp_path)
+            return False
+        ok, _frame = cap.read()
+        cap.release()
+        return ok
 
-    async def _clip_decodes(self, clip_bytes: bytes) -> bool:
-        """Ensure clip bytes decode into at least one frame.
+    async def _clip_file_valid(self, clip_path: str) -> bool:
+        """Ensure the clip file carries an MP4 header and decodes one frame.
+
+        Works on the file directly - clips used to be validated as bytes and
+        written to a temp file for cv2 anyway, so keeping them in memory bought
+        nothing but glibc arena high-water in the API process (#341).
 
         cv2.VideoCapture and cap.read() are synchronous and can block
         indefinitely on corrupt or truncated MP4s.  Running them in a
         thread prevents the asyncio event loop from stalling (which would
         also silently disable all other timeouts in the job).
         """
+
+        def _has_mp4_header() -> bool:
+            try:
+                with open(clip_path, "rb") as handle:
+                    head = handle.read(32)
+            except OSError:
+                return False
+            return bool(head) and (head.startswith(b"\x00\x00\x00\x18ftyp") or b"ftyp" in head)
+
+        if not await asyncio.to_thread(_has_mp4_header):
+            return False
         try:
             return await asyncio.wait_for(
-                asyncio.to_thread(self._clip_decodes_sync, clip_bytes),
+                asyncio.to_thread(self._clip_decodes_sync, clip_path),
                 timeout=30.0,
             )
         except asyncio.TimeoutError:

--- a/backend/app/services/frigate_client.py
+++ b/backend/app/services/frigate_client.py
@@ -6,6 +6,7 @@ with connection pooling, authentication, and consistent error handling.
 
 import math
 
+import aiofiles
 import httpx
 import structlog
 from typing import Optional
@@ -184,6 +185,49 @@ class FrigateClient:
         except Exception as e:
             log.error("Unexpected error fetching clip", event_id=event_id, error=str(e))
             return None, "clip_unknown_error"
+
+    async def download_clip_to_file(
+        self, event_id: str, dest_path: str, timeout: float = 20.0
+    ) -> tuple[bool, Optional[str]]:
+        """Stream the event clip straight to a file.
+
+        Mirrors get_clip_with_error's status mapping, but the clip never passes
+        through this process's heap - whole clips transiting memory were the
+        dominant transient behind glibc arena retention in the API process
+        (#341).
+        """
+        url = f"{self.base_url}/api/events/{event_id}/clip.mp4"
+        client = self._get_client()
+        try:
+            async with client.stream("GET", url, headers=self._get_headers(), timeout=timeout) as resp:
+                if resp.status_code == 200:
+                    async with aiofiles.open(dest_path, "wb") as f:
+                        async for chunk in resp.aiter_bytes(256 * 1024):
+                            await f.write(chunk)
+                    return True, None
+                if resp.status_code == 404:
+                    # Expected state: Frigate never stored a clip for this event.
+                    log.info("Clip not found", event_id=event_id)
+                    return False, "clip_not_found"
+                if resp.status_code == 400:
+                    try:
+                        payload = (await resp.aread()).decode("utf-8", errors="replace")
+                    except Exception:
+                        payload = ""
+                    if "No recordings found for the specified time range" in payload:
+                        log.info("Clip recordings not retained", event_id=event_id)
+                        return False, "clip_not_retained"
+                log.warning("Failed to fetch clip", event_id=event_id, status=resp.status_code)
+                return False, f"clip_http_{resp.status_code}"
+        except httpx.TimeoutException:
+            log.warning("Clip fetch timed out", event_id=event_id)
+            return False, "clip_timeout"
+        except httpx.RequestError as e:
+            log.error("Error fetching clip", event_id=event_id, error=str(e))
+            return False, "clip_request_error"
+        except Exception as e:
+            log.error("Unexpected error fetching clip", event_id=event_id, error=str(e))
+            return False, "clip_unknown_error"
 
     async def get_clip(self, event_id: str) -> Optional[bytes]:
         """Fetch video clip for an event."""

--- a/backend/app/services/high_quality_snapshot_service.py
+++ b/backend/app/services/high_quality_snapshot_service.py
@@ -321,6 +321,27 @@ class HighQualitySnapshotService:
         clip_variant: str = "event",
     ) -> str:
         """Best-effort replacement using clip bytes already fetched by another workflow."""
+        tmp_path = await asyncio.to_thread(_write_temp_clip, clip_bytes)
+        try:
+            return await self.replace_from_clip_path(
+                event_id,
+                tmp_path,
+                event_data,
+                clip_variant=clip_variant,
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
+
+    async def replace_from_clip_path(
+        self,
+        event_id: str,
+        clip_path: Path,
+        event_data: Optional[dict[str, Any]] = None,
+        *,
+        clip_variant: str = "event",
+    ) -> str:
+        """Best-effort replacement from a clip already on disk; the caller owns the file (#341)."""
         if not self.enabled():
             return self._record_outcome(event_id, "disabled")
 
@@ -340,9 +361,9 @@ class HighQualitySnapshotService:
             selected_candidate = None
             classification_candidates: list[dict[str, Any]] = []
             try:
-                candidate_bundle = await self.generate_snapshot_candidates_from_clip_bytes(
+                candidate_bundle = await self.generate_snapshot_candidates_from_clip_path(
                     event_id,
-                    clip_bytes,
+                    Path(clip_path),
                     event_data=crop_event_data,
                     clip_variant=clip_variant,
                 )
@@ -365,8 +386,8 @@ class HighQualitySnapshotService:
             else:
                 try:
                     image_bytes = await asyncio.to_thread(
-                        self._extract_snapshot_from_clip,
-                        clip_bytes,
+                        self._extract_snapshot_from_clip_path,
+                        Path(clip_path),
                         snapshot_event_data,
                         clip_variant,
                     )
@@ -396,7 +417,7 @@ class HighQualitySnapshotService:
                 self._completed_ids.add(event_id)
 
             log.info(
-                "High-quality snapshot replaced from clip bytes",
+                "High-quality snapshot replaced from clip",
                 event_id=event_id,
                 size=len(image_bytes),
                 source=snapshot_source,
@@ -444,31 +465,47 @@ class HighQualitySnapshotService:
         event_data: Optional[dict[str, Any]] = None,
         clip_variant: str = "event",
     ) -> dict[str, Any]:
+        tmp_path = await asyncio.to_thread(_write_temp_clip, clip_bytes)
+        try:
+            return await self.generate_snapshot_candidates_from_clip_path(
+                event_id,
+                tmp_path,
+                event_data=event_data,
+                clip_variant=clip_variant,
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
+
+    async def generate_snapshot_candidates_from_clip_path(
+        self,
+        event_id: str,
+        clip_path: Path,
+        *,
+        event_data: Optional[dict[str, Any]] = None,
+        clip_variant: str = "event",
+    ) -> dict[str, Any]:
+        """Candidate generation against a clip already on disk; the caller owns the file (#341)."""
         preferred_indices = await self._load_preferred_frame_indices(event_id, clip_variant=clip_variant)
 
         raw_candidates: list[dict[str, Any]] = []
         extraction_error: Exception | None = None
-        tmp_path = await asyncio.to_thread(_write_temp_clip, clip_bytes)
         try:
-            try:
-                raw_candidates = await asyncio.to_thread(
-                    self._extract_snapshot_candidate_payloads_from_clip_path,
-                    tmp_path,
-                    event_id=event_id,
-                    event_data=event_data,
-                    clip_variant=clip_variant,
-                    override_frame_indices=preferred_indices,
-                )
-            except Exception as exc:
-                extraction_error = exc
-                log.warning(
-                    "High-quality clip candidate extraction failed; trying final Frigate snapshot",
-                    event_id=event_id,
-                    error=str(exc),
-                )
-        finally:
-            with contextlib.suppress(Exception):
-                await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
+            raw_candidates = await asyncio.to_thread(
+                self._extract_snapshot_candidate_payloads_from_clip_path,
+                Path(clip_path),
+                event_id=event_id,
+                event_data=event_data,
+                clip_variant=clip_variant,
+                override_frame_indices=preferred_indices,
+            )
+        except Exception as exc:
+            extraction_error = exc
+            log.warning(
+                "High-quality clip candidate extraction failed; trying final Frigate snapshot",
+                event_id=event_id,
+                error=str(exc),
+            )
 
         raw_candidates.extend(await self._load_final_frigate_snapshot_candidates(event_id, event_data))
         if not raw_candidates and extraction_error is not None:

--- a/backend/app/services/high_quality_snapshot_service.py
+++ b/backend/app/services/high_quality_snapshot_service.py
@@ -312,27 +312,6 @@ class HighQualitySnapshotService:
 
         return None
 
-    async def replace_from_clip_bytes(
-        self,
-        event_id: str,
-        clip_bytes: bytes,
-        event_data: Optional[dict[str, Any]] = None,
-        *,
-        clip_variant: str = "event",
-    ) -> str:
-        """Best-effort replacement using clip bytes already fetched by another workflow."""
-        tmp_path = await asyncio.to_thread(_write_temp_clip, clip_bytes)
-        try:
-            return await self.replace_from_clip_path(
-                event_id,
-                tmp_path,
-                event_data,
-                clip_variant=clip_variant,
-            )
-        finally:
-            with contextlib.suppress(Exception):
-                await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
-
     async def replace_from_clip_path(
         self,
         event_id: str,

--- a/backend/tests/test_auto_video_classifier_queueing.py
+++ b/backend/tests/test_auto_video_classifier_queueing.py
@@ -427,17 +427,17 @@ async def test_trigger_classification_ignores_open_maintenance_circuit(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_wait_for_clip_stops_retrying_on_terminal_clip_not_retained(monkeypatch: pytest.MonkeyPatch):
+async def test_wait_for_clip_stops_retrying_on_terminal_clip_not_retained(monkeypatch: pytest.MonkeyPatch, tmp_path):
     service = AutoVideoClassifierService()
-    fetch = AsyncMock(return_value=(None, "clip_not_retained"))
-    monkeypatch.setattr(auto_video_classifier_module.frigate_client, "get_clip_with_error", fetch)
+    fetch = AsyncMock(return_value=(False, "clip_not_retained"))
+    monkeypatch.setattr(auto_video_classifier_module.frigate_client, "download_clip_to_file", fetch)
     monkeypatch.setattr(settings.classification, "video_classification_delay", 0)
     monkeypatch.setattr(settings.classification, "video_classification_max_retries", 4)
     monkeypatch.setattr(settings.classification, "video_classification_retry_interval", 0)
 
-    clip_bytes, error = await service._wait_for_clip("evt-no-recordings", skip_delay=True)
+    loaded, error = await service._wait_for_clip("evt-no-recordings", str(tmp_path / "clip.mp4"), skip_delay=True)
 
-    assert clip_bytes is None
+    assert loaded is False
     assert error == "clip_not_retained"
     assert fetch.await_count == 1
 
@@ -1047,40 +1047,33 @@ async def test_process_event_still_fails_when_precheck_returns_event_not_found_a
 
 
 @pytest.mark.asyncio
-async def test_load_preferred_clip_uses_cached_event_clip_before_polling_frigate(monkeypatch):
+async def test_load_preferred_clip_uses_cached_event_clip_before_polling_frigate(monkeypatch, tmp_path):
     """_load_preferred_clip must serve the cached event clip (media_cache) instead of
     calling _wait_for_clip when a valid event clip is locally cached.
 
     This prevents the scenario where the precheck bypass fires (has_clip=True) but
     _wait_for_clip still goes to Frigate, fails, and triggers _auto_delete_if_missing
     — which would delete the cached media we just confirmed was present."""
-    import asyncio as _asyncio
-
     service = AutoVideoClassifierService()
 
     valid_clip = b"\x00\x00\x00\x18ftypisomcachedclip"
-    fake_path = MagicMock()
-    fake_path.read_bytes = MagicMock(return_value=valid_clip)
+    cached = tmp_path / "cached.mp4"
+    cached.write_bytes(valid_clip)
+    dest = tmp_path / "dest.mp4"
 
     monkeypatch.setattr(
         auto_video_classifier_module.media_cache,
         "get_clip_path",
-        lambda event_id: fake_path,
+        lambda event_id: str(cached),
     )
     monkeypatch.setattr(
-        service,
-        "_clip_decodes",
-        AsyncMock(return_value=True),
+        auto_video_classifier_module.media_cache,
+        "get_recording_clip_path",
+        lambda event_id: None,
     )
+    monkeypatch.setattr(service, "_clip_file_valid", AsyncMock(return_value=True))
 
-    monkeypatch.setattr(
-        auto_video_classifier_module,
-        "Path",
-        lambda p: fake_path,
-    )
-    monkeypatch.setattr(_asyncio, "to_thread", AsyncMock(return_value=valid_clip))
-
-    wait_for_clip_mock = AsyncMock(return_value=(None, "clip_not_found"))
+    wait_for_clip_mock = AsyncMock(return_value=(False, "clip_not_found"))
     monkeypatch.setattr(service, "_wait_for_clip", wait_for_clip_mock)
 
     # No recording clip cached.
@@ -1090,24 +1083,26 @@ async def test_load_preferred_clip_uses_cached_event_clip_before_polling_frigate
         AsyncMock(return_value=(None, None, None, None)),
     )
 
-    clip_bytes, clip_error, clip_variant, clip_start_timestamp = await service._load_preferred_clip(
-        "evt-cached-event-clip", skip_delay=True
+    loaded, clip_error, clip_variant, clip_start_timestamp = await service._load_preferred_clip(
+        "evt-cached-event-clip", str(dest), skip_delay=True
     )
 
-    assert clip_bytes == valid_clip
+    assert loaded is True
     assert clip_error is None
     assert clip_variant == "event"
     assert clip_start_timestamp is None
+    # The cached clip was copied disk-to-disk into the destination.
+    assert dest.read_bytes() == valid_clip
     wait_for_clip_mock.assert_not_awaited()  # must NOT have gone to Frigate
 
 
 @pytest.mark.asyncio
-async def test_load_preferred_clip_classifies_retained_partial_recording(monkeypatch):
-    import asyncio as _asyncio
-
+async def test_load_preferred_clip_classifies_retained_partial_recording(monkeypatch, tmp_path):
     service = AutoVideoClassifierService()
     valid_clip = b"\x00\x00\x00\x18ftypisompartialrecording"
-    fake_path = MagicMock()
+    partial = tmp_path / "partial.mp4"
+    partial.write_bytes(valid_clip)
+    dest = tmp_path / "dest.mp4"
 
     monkeypatch.setattr(
         auto_video_classifier_module,
@@ -1117,22 +1112,22 @@ async def test_load_preferred_clip_classifies_retained_partial_recording(monkeyp
     monkeypatch.setattr(
         auto_video_classifier_module.media_cache,
         "get_recording_clip_path",
-        lambda event_id: fake_path,
+        lambda event_id: str(partial),
     )
     monkeypatch.setattr(auto_video_classifier_module.media_cache, "get_clip_path", lambda event_id: None)
-    monkeypatch.setattr(auto_video_classifier_module, "Path", lambda path: fake_path)
-    monkeypatch.setattr(_asyncio, "to_thread", AsyncMock(return_value=valid_clip))
-    monkeypatch.setattr(service, "_clip_decodes", AsyncMock(return_value=True))
-    wait_for_clip_mock = AsyncMock(return_value=(None, "clip_not_found"))
+    monkeypatch.setattr(service, "_clip_file_valid", AsyncMock(return_value=True))
+    wait_for_clip_mock = AsyncMock(return_value=(False, "clip_not_found"))
     monkeypatch.setattr(service, "_wait_for_clip", wait_for_clip_mock)
 
-    clip_bytes, clip_error, clip_variant, clip_start_timestamp = await service._load_preferred_clip(
+    loaded, clip_error, clip_variant, clip_start_timestamp = await service._load_preferred_clip(
         "evt-partial-recording",
+        str(dest),
         skip_delay=True,
     )
 
-    assert clip_bytes == valid_clip
+    assert loaded is True
     assert clip_error is None
     assert clip_variant == "recording"
     assert clip_start_timestamp == 100.0
+    assert dest.read_bytes() == valid_clip
     wait_for_clip_mock.assert_not_awaited()

--- a/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
+++ b/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import os
 import tempfile
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -91,7 +91,7 @@ async def test_process_event_triggers_snapshot_upgrade_when_clip_valid():
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     settings.media_cache.high_quality_event_snapshots = True
 
     with (
@@ -103,13 +103,13 @@ async def test_process_event_triggers_snapshot_upgrade_when_clip_valid():
         patch.object(auto_video_classifier_module.broadcaster, "broadcast", new=AsyncMock()),
         patch.object(auto_video_classifier_module, "high_quality_snapshot_service") as mock_hq,
     ):
-        mock_hq.replace_from_clip_bytes = AsyncMock(return_value="replaced")
+        mock_hq.replace_from_clip_path = AsyncMock(return_value="replaced")
 
         await service._process_event("evt-auto-video-upgrade", "cam1", skip_delay=True)
 
-    mock_hq.replace_from_clip_bytes.assert_awaited_once_with(
+    mock_hq.replace_from_clip_path.assert_awaited_once_with(
         "evt-auto-video-upgrade",
-        b"clip-bytes",
+        ANY,
         event_data={"has_clip": True},
         clip_variant="event",
     )
@@ -138,7 +138,7 @@ async def test_process_event_records_temporal_abstention_without_breaker_failure
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     service._record_failure = MagicMock()  # type: ignore[method-assign]
     error_diagnostics_history.clear()
 
@@ -206,7 +206,7 @@ async def test_manual_video_abstention_falls_back_to_best_retained_snapshot():
     service._classifier.classify_video_async = AsyncMock(side_effect=classify_without_consensus)
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     service._classify_from_snapshot = AsyncMock(return_value=None)  # type: ignore[method-assign]
     service._record_success = MagicMock()  # type: ignore[method-assign]
     service._record_failure = MagicMock()  # type: ignore[method-assign]
@@ -255,7 +255,7 @@ async def test_manual_video_result_below_promotion_threshold_uses_snapshot_inste
     )
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     service._classify_from_snapshot = AsyncMock(return_value=None)  # type: ignore[method-assign]
     service._record_success = MagicMock()  # type: ignore[method-assign]
     service._record_failure = MagicMock()  # type: ignore[method-assign]
@@ -300,7 +300,7 @@ async def test_process_event_still_classifies_when_snapshot_upgrade_fails():
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     settings.media_cache.high_quality_event_snapshots = True
 
     with (
@@ -312,13 +312,13 @@ async def test_process_event_still_classifies_when_snapshot_upgrade_fails():
         patch.object(auto_video_classifier_module.broadcaster, "broadcast", new=AsyncMock()),
         patch.object(auto_video_classifier_module, "high_quality_snapshot_service") as mock_hq,
     ):
-        mock_hq.replace_from_clip_bytes = AsyncMock(return_value="frame_extract_failed")
+        mock_hq.replace_from_clip_path = AsyncMock(return_value="frame_extract_failed")
 
         await service._process_event("evt-auto-video-upgrade-failure", "cam1", skip_delay=True)
 
-    mock_hq.replace_from_clip_bytes.assert_awaited_once_with(
+    mock_hq.replace_from_clip_path.assert_awaited_once_with(
         "evt-auto-video-upgrade-failure",
-        b"clip-bytes",
+        ANY,
         event_data={"has_clip": True},
         clip_variant="event",
     )
@@ -335,7 +335,7 @@ async def test_process_event_falls_back_to_snapshot_when_clip_not_retained_for_b
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(None, "clip_not_retained"))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(False, "clip_not_retained"))  # type: ignore[method-assign]
 
     with (
         patch.object(
@@ -401,7 +401,7 @@ async def test_manual_reclassification_falls_back_for_any_unavailable_video_erro
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
     service._load_preferred_clip = AsyncMock(  # type: ignore[method-assign]
-        return_value=(None, "clip_fetch_failed", "event", None)
+        return_value=(False, "clip_fetch_failed", "event", None)
     )
     service._classify_from_snapshot = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
@@ -449,7 +449,7 @@ async def test_process_event_snapshot_fallback_retries_background_overload_then_
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(None, "clip_not_retained"))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(False, "clip_not_retained"))  # type: ignore[method-assign]
     service._record_success = MagicMock()  # type: ignore[method-assign]
     service._record_failure = MagicMock()  # type: ignore[method-assign]
 
@@ -502,7 +502,7 @@ async def test_process_event_snapshot_fallback_marks_background_overload_distinc
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(None, "clip_not_retained"))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(False, "clip_not_retained"))  # type: ignore[method-assign]
     service._record_success = MagicMock()  # type: ignore[method-assign]
     service._record_failure = MagicMock()  # type: ignore[method-assign]
 
@@ -550,7 +550,7 @@ async def test_process_event_snapshot_fallback_uses_extended_background_queue_ti
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(None, "clip_not_retained"))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(False, "clip_not_retained"))  # type: ignore[method-assign]
 
     with (
         patch.object(
@@ -583,7 +583,7 @@ async def test_process_event_passes_event_id_into_video_classification_context()
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
 
     with (
         patch.object(
@@ -629,7 +629,7 @@ async def test_process_event_prefers_cached_recording_clip_when_available():
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"event-clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
 
     # Write a real temp file so asyncio.to_thread(Path(...).read_bytes) succeeds.
     fd, recording_path = tempfile.mkstemp(suffix=".mp4")
@@ -649,7 +649,7 @@ async def test_process_event_prefers_cached_recording_clip_when_available():
                 "_get_valid_cached_recording_clip_path",
                 new=AsyncMock(return_value=(recording_path, "cam1", 1, 2)),
             ),
-            patch.object(AutoVideoClassifierService, "_clip_decodes", new=AsyncMock(return_value=True)),
+            patch.object(AutoVideoClassifierService, "_clip_file_valid", new=AsyncMock(return_value=True)),
         ):
             await service._process_event("evt-recording-preferred", "cam1", skip_delay=True)
     finally:
@@ -675,7 +675,7 @@ async def test_process_event_falls_back_to_event_clip_when_cached_recording_is_i
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"\x00\x00\x00\x18ftypevent-clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
 
     fd, recording_path = tempfile.mkstemp(suffix=".mp4")
     try:
@@ -694,7 +694,7 @@ async def test_process_event_falls_back_to_event_clip_when_cached_recording_is_i
                 "_get_valid_cached_recording_clip_path",
                 new=AsyncMock(return_value=(recording_path, "cam1", 1, 2)),
             ),
-            patch.object(AutoVideoClassifierService, "_clip_decodes", new=AsyncMock(return_value=False)),
+            patch.object(AutoVideoClassifierService, "_clip_file_valid", new=AsyncMock(return_value=False)),
         ):
             await service._process_event("evt-recording-invalid", "cam1", skip_delay=True)
     finally:
@@ -717,7 +717,7 @@ async def test_process_event_marks_failed_when_clip_not_retained_for_auto_mode()
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(None, "clip_not_retained"))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(False, "clip_not_retained"))  # type: ignore[method-assign]
 
     with (
         patch.object(
@@ -743,7 +743,7 @@ async def test_process_event_records_backend_diagnostic_for_worker_failure():
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     error_diagnostics_history.clear()
 
     try:
@@ -776,7 +776,7 @@ async def test_process_event_worker_failure_falls_back_to_snapshot_for_manual_re
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     service._classify_from_snapshot = AsyncMock(return_value=None)  # type: ignore[method-assign]
     service._broadcast_snapshot_fallback = AsyncMock()  # type: ignore[method-assign]
     service._record_success = MagicMock()  # type: ignore[method-assign]
@@ -853,7 +853,7 @@ async def test_process_event_diagnostic_includes_inference_provider_context():
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     error_diagnostics_history.clear()
 
     try:
@@ -917,7 +917,7 @@ async def test_process_event_timeout_diagnostic_includes_job_source_and_clip_con
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     error_diagnostics_history.clear()
 
     try:
@@ -944,7 +944,9 @@ async def test_process_event_timeout_diagnostic_includes_job_source_and_clip_con
         )
         assert event["context"]["source"] == "maintenance"
         assert event["context"]["camera"] == "cam1"
-        assert event["context"]["clip_bytes"] == len(b"clip-bytes")
+        # The stubbed loader writes nothing into the temp file, so the
+        # diagnostic reports the file's true size.
+        assert event["context"]["clip_bytes"] == 0
         assert event["context"]["timeout_seconds"] == settings.classification.video_classification_timeout_seconds
         assert event["context"]["max_frames"] == settings.classification.video_classification_frames
         assert event["context"]["inference_backend"] == "openvino"
@@ -961,7 +963,7 @@ async def test_process_event_maintenance_timeout_falls_back_to_snapshot_without_
     service._update_status = AsyncMock()  # type: ignore[method-assign]
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
     service._classify_from_snapshot = AsyncMock(return_value=None)  # type: ignore[method-assign]
     service._record_success = MagicMock()  # type: ignore[method-assign]
     service._record_failure = MagicMock()  # type: ignore[method-assign]
@@ -1014,7 +1016,7 @@ async def test_process_event_persists_top_frames_after_successful_video_classifi
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
     service._persist_video_top_frames = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
 
     async def mock_classify(video_path, **kwargs):
         cb = kwargs.get("progress_callback")
@@ -1058,7 +1060,7 @@ async def test_process_event_top_frames_ranked_by_score_descending():
     service._save_results = AsyncMock()  # type: ignore[method-assign]
     service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
     service._persist_video_top_frames = AsyncMock()  # type: ignore[method-assign]
-    service._wait_for_clip = AsyncMock(return_value=(b"clip-bytes", None))  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
 
     async def mock_classify(video_path, **kwargs):
         cb = kwargs.get("progress_callback")

--- a/backend/tests/test_clip_streaming.py
+++ b/backend/tests/test_clip_streaming.py
@@ -1,0 +1,94 @@
+"""Clips reach the video pipeline as files, never as heap-resident bytes (#341).
+
+The API process was observed at ~3.2GB anon with a wall of glibc arena-sized
+regions: whole clips passed through its heap on the way to a temp file the
+worker reads anyway. Downloads now stream to disk, cached clips are copied
+disk-to-disk, and validation runs against the file.
+"""
+
+import inspect
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from app.services.frigate_client import FrigateClient
+
+
+def _streaming_client(status_code: int, chunks: list[bytes] | None = None, body: bytes = b""):
+    class _Resp:
+        def __init__(self):
+            self.status_code = status_code
+
+        async def aiter_bytes(self, _size):
+            for chunk in chunks or []:
+                yield chunk
+
+        async def aread(self):
+            return body
+
+    client = MagicMock()
+
+    @asynccontextmanager
+    async def _stream(method, url, headers=None, timeout=None):
+        yield _Resp()
+
+    client.stream = _stream
+    return client
+
+
+@pytest.mark.asyncio
+async def test_download_streams_the_clip_to_the_file(tmp_path, monkeypatch):
+    fc = FrigateClient()
+    monkeypatch.setattr(fc, "_get_client", lambda: _streaming_client(200, chunks=[b"abc", b"def"]))
+    dest = tmp_path / "clip.mp4"
+    ok, error = await fc.download_clip_to_file("evt-1", str(dest))
+    assert ok is True and error is None
+    assert dest.read_bytes() == b"abcdef"
+
+
+@pytest.mark.asyncio
+async def test_download_maps_missing_and_not_retained_like_the_bytes_fetch(tmp_path, monkeypatch):
+    fc = FrigateClient()
+    monkeypatch.setattr(fc, "_get_client", lambda: _streaming_client(404))
+    ok, error = await fc.download_clip_to_file("evt-404", str(tmp_path / "a.mp4"))
+    assert (ok, error) == (False, "clip_not_found")
+
+    monkeypatch.setattr(
+        fc,
+        "_get_client",
+        lambda: _streaming_client(400, body=b'{"message": "No recordings found for the specified time range"}'),
+    )
+    ok, error = await fc.download_clip_to_file("evt-400", str(tmp_path / "b.mp4"))
+    assert (ok, error) == (False, "clip_not_retained")
+
+
+@pytest.mark.asyncio
+async def test_download_reports_timeouts_without_raising(tmp_path, monkeypatch):
+    fc = FrigateClient()
+
+    class _TimeoutClient:
+        def stream(self, *args, **kwargs):
+            raise httpx.TimeoutException("slow")
+
+    monkeypatch.setattr(fc, "_get_client", lambda: _TimeoutClient())
+    ok, error = await fc.download_clip_to_file("evt-slow", str(tmp_path / "c.mp4"))
+    assert (ok, error) == (False, "clip_timeout")
+
+
+def test_no_whole_clip_bytes_transit_the_video_job():
+    """The job path holds a temp-file path, never the clip's bytes."""
+    from app.services import auto_video_classifier_service as avs
+
+    loader_source = inspect.getsource(avs.AutoVideoClassifierService._load_preferred_clip)
+    assert "read_bytes" not in loader_source
+    assert "copyfile" in loader_source
+
+    wait_source = inspect.getsource(avs.AutoVideoClassifierService._wait_for_clip)
+    assert "download_clip_to_file" in wait_source
+    assert "get_clip_with_error" not in wait_source
+
+    process_source = inspect.getsource(avs.AutoVideoClassifierService._process_event)
+    assert "replace_from_clip_path" in process_source
+    assert "write_bytes, clip_bytes" not in process_source

--- a/backend/tests/test_high_quality_snapshot_service.py
+++ b/backend/tests/test_high_quality_snapshot_service.py
@@ -33,6 +33,13 @@ def _jpeg_bytes(color: str, size: tuple[int, int] = (32, 32), *, quality: int = 
     return buffer.getvalue()
 
 
+def _clip_file(tmp_path):
+    """The clip reaches the service as a file the caller owns (#341)."""
+    path = tmp_path / "clip.mp4"
+    path.write_bytes(b"clip-bytes")
+    return path
+
+
 def _make_cache_service(tmp_path, monkeypatch):
     cache_base = tmp_path / "media_cache"
     snapshots = cache_base / "snapshots"
@@ -52,7 +59,7 @@ def _make_cache_service(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_replace_from_clip_bytes_persists_and_selects_ranked_snapshot_candidates(tmp_path, monkeypatch):
+async def test_replace_from_clip_path_persists_and_selects_ranked_snapshot_candidates(tmp_path, monkeypatch):
     cache_service = _make_cache_service(tmp_path, monkeypatch)
     await cache_service.cache_snapshot("evt_candidates", b"frigate-bytes")
     monkeypatch.setattr(settings.media_cache, "high_quality_event_snapshots", True, raising=False)
@@ -124,7 +131,9 @@ async def test_replace_from_clip_bytes_persists_and_selects_ranked_snapshot_cand
         raising=False,
     )
 
-    result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_candidates", b"clip-bytes")
+    result = await hq_module.high_quality_snapshot_service.replace_from_clip_path(
+        "evt_candidates", _clip_file(tmp_path)
+    )
 
     assert result == "bird_crop_replaced"
     assert persisted["event_id"] == "evt_candidates"
@@ -2123,7 +2132,7 @@ async def test_high_quality_snapshot_service_status_tracks_outcomes(tmp_path, mo
 
 
 @pytest.mark.asyncio
-async def test_replace_from_clip_bytes_replaces_cached_snapshot_when_enabled(tmp_path, monkeypatch):
+async def test_replace_from_clip_path_replaces_cached_snapshot_when_enabled(tmp_path, monkeypatch):
     cache_service = _make_cache_service(tmp_path, monkeypatch)
     await cache_service.cache_snapshot("evt_clip_bytes", b"frigate-bytes")
     settings.media_cache.high_quality_event_snapshots = True
@@ -2134,14 +2143,16 @@ async def test_replace_from_clip_bytes_replaces_cached_snapshot_when_enabled(tmp
         lambda clip_path, *_args: b"derived-bytes",
     )
 
-    result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_clip_bytes", b"clip-bytes")
+    result = await hq_module.high_quality_snapshot_service.replace_from_clip_path(
+        "evt_clip_bytes", _clip_file(tmp_path)
+    )
 
     assert result == "replaced"
     assert await cache_service.get_snapshot("evt_clip_bytes") == b"derived-bytes"
 
 
 @pytest.mark.asyncio
-async def test_replace_from_clip_bytes_is_disabled_when_feature_flag_off(tmp_path, monkeypatch):
+async def test_replace_from_clip_path_is_disabled_when_feature_flag_off(tmp_path, monkeypatch):
     cache_service = _make_cache_service(tmp_path, monkeypatch)
     await cache_service.cache_snapshot("evt_clip_disabled", b"frigate-bytes")
     settings.media_cache.high_quality_event_snapshots = False
@@ -2152,14 +2163,16 @@ async def test_replace_from_clip_bytes_is_disabled_when_feature_flag_off(tmp_pat
         lambda clip_path, *_args: b"derived-bytes",
     )
 
-    result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_clip_disabled", b"clip-bytes")
+    result = await hq_module.high_quality_snapshot_service.replace_from_clip_path(
+        "evt_clip_disabled", _clip_file(tmp_path)
+    )
 
     assert result == "disabled"
     assert await cache_service.get_snapshot("evt_clip_disabled") == b"frigate-bytes"
 
 
 @pytest.mark.asyncio
-async def test_replace_from_clip_bytes_preserves_original_on_extraction_failure(tmp_path, monkeypatch):
+async def test_replace_from_clip_path_preserves_original_on_extraction_failure(tmp_path, monkeypatch):
     cache_service = _make_cache_service(tmp_path, monkeypatch)
     await cache_service.cache_snapshot("evt_clip_failure", b"frigate-bytes")
     settings.media_cache.high_quality_event_snapshots = True
@@ -2173,16 +2186,16 @@ async def test_replace_from_clip_bytes_preserves_original_on_extraction_failure(
         _boom,
     )
 
-    result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_clip_failure", b"clip-bytes")
+    result = await hq_module.high_quality_snapshot_service.replace_from_clip_path(
+        "evt_clip_failure", _clip_file(tmp_path)
+    )
 
     assert result == "frame_extract_failed"
     assert await cache_service.get_snapshot("evt_clip_failure") == b"frigate-bytes"
 
 
 @pytest.mark.asyncio
-async def test_replace_from_clip_bytes_satisfies_queued_event_without_duplicate_worker_processing(
-    tmp_path, monkeypatch
-):
+async def test_replace_from_clip_path_satisfies_queued_event_without_duplicate_worker_processing(tmp_path, monkeypatch):
     cache_service = _make_cache_service(tmp_path, monkeypatch)
     await cache_service.cache_snapshot("evt_clip_queued", b"frigate-bytes")
     settings.media_cache.high_quality_event_snapshots = True
@@ -2209,7 +2222,9 @@ async def test_replace_from_clip_bytes_satisfies_queued_event_without_duplicate_
     queued = hq_module.high_quality_snapshot_service.schedule_replacement("evt_clip_queued")
     assert queued is True
 
-    result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_clip_queued", b"clip-bytes")
+    result = await hq_module.high_quality_snapshot_service.replace_from_clip_path(
+        "evt_clip_queued", _clip_file(tmp_path)
+    )
     assert result == "replaced"
 
     worker_task = asyncio.create_task(hq_module.high_quality_snapshot_service._worker_loop(0))
@@ -2223,7 +2238,7 @@ async def test_replace_from_clip_bytes_satisfies_queued_event_without_duplicate_
 
 
 @pytest.mark.asyncio
-async def test_replace_from_clip_bytes_satisfies_deferred_event_without_later_worker_processing(tmp_path, monkeypatch):
+async def test_replace_from_clip_path_satisfies_deferred_event_without_later_worker_processing(tmp_path, monkeypatch):
     cache_service = _make_cache_service(tmp_path, monkeypatch)
     await cache_service.cache_snapshot("evt_clip_deferred_1", b"frigate-bytes")
     await cache_service.cache_snapshot("evt_clip_deferred_2", b"frigate-bytes")
@@ -2253,7 +2268,9 @@ async def test_replace_from_clip_bytes_satisfies_deferred_event_without_later_wo
     assert hq_module.high_quality_snapshot_service.schedule_replacement("evt_clip_deferred_1") is True
     assert hq_module.high_quality_snapshot_service.schedule_replacement("evt_clip_deferred_2") is True
 
-    result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_clip_deferred_2", b"clip-bytes")
+    result = await hq_module.high_quality_snapshot_service.replace_from_clip_path(
+        "evt_clip_deferred_2", _clip_file(tmp_path)
+    )
     assert result == "replaced"
 
     worker_task = asyncio.create_task(hq_module.high_quality_snapshot_service._worker_loop(0))

--- a/backend/tests/test_high_quality_snapshot_service.py
+++ b/backend/tests/test_high_quality_snapshot_service.py
@@ -57,9 +57,10 @@ async def test_replace_from_clip_bytes_persists_and_selects_ranked_snapshot_cand
     await cache_service.cache_snapshot("evt_candidates", b"frigate-bytes")
     monkeypatch.setattr(settings.media_cache, "high_quality_event_snapshots", True, raising=False)
 
-    async def fake_generate(event_id, clip_bytes, event_data=None, clip_variant="event"):
+    async def fake_generate(event_id, clip_path, event_data=None, clip_variant="event"):
         assert event_id == "evt_candidates"
-        assert clip_bytes == b"clip-bytes"
+        # The clip reaches candidate generation as a file, never as bytes (#341).
+        assert Path(clip_path).read_bytes() == b"clip-bytes"
         assert clip_variant == "event"
         return {
             "selected_candidate": {
@@ -112,7 +113,7 @@ async def test_replace_from_clip_bytes_persists_and_selects_ranked_snapshot_cand
 
     monkeypatch.setattr(
         hq_module.high_quality_snapshot_service,
-        "generate_snapshot_candidates_from_clip_bytes",
+        "generate_snapshot_candidates_from_clip_path",
         fake_generate,
         raising=False,
     )
@@ -1879,7 +1880,7 @@ async def test_process_event_falls_back_to_cached_recording_clip_when_event_clip
     )
     monkeypatch.setattr(
         hq_module.high_quality_snapshot_service,
-        "generate_snapshot_candidates_from_clip_bytes",
+        "generate_snapshot_candidates_from_clip_path",
         AsyncMock(return_value={}),
     )
     extraction_call = {}
@@ -2129,8 +2130,8 @@ async def test_replace_from_clip_bytes_replaces_cached_snapshot_when_enabled(tmp
 
     monkeypatch.setattr(
         hq_module.high_quality_snapshot_service,
-        "_extract_snapshot_from_clip",
-        lambda clip_bytes, *_args: b"derived-bytes",
+        "_extract_snapshot_from_clip_path",
+        lambda clip_path, *_args: b"derived-bytes",
     )
 
     result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_clip_bytes", b"clip-bytes")
@@ -2147,8 +2148,8 @@ async def test_replace_from_clip_bytes_is_disabled_when_feature_flag_off(tmp_pat
 
     monkeypatch.setattr(
         hq_module.high_quality_snapshot_service,
-        "_extract_snapshot_from_clip",
-        lambda clip_bytes, *_args: b"derived-bytes",
+        "_extract_snapshot_from_clip_path",
+        lambda clip_path, *_args: b"derived-bytes",
     )
 
     result = await hq_module.high_quality_snapshot_service.replace_from_clip_bytes("evt_clip_disabled", b"clip-bytes")
@@ -2189,8 +2190,8 @@ async def test_replace_from_clip_bytes_satisfies_queued_event_without_duplicate_
     monkeypatch.setattr(hq_module.high_quality_snapshot_service, "_ensure_workers_started", lambda: None)
     monkeypatch.setattr(
         hq_module.high_quality_snapshot_service,
-        "_extract_snapshot_from_clip",
-        lambda clip_bytes, *_args: b"derived-bytes",
+        "_extract_snapshot_from_clip_path",
+        lambda clip_path, *_args: b"derived-bytes",
     )
 
     worker_processed = asyncio.Event()
@@ -2233,8 +2234,8 @@ async def test_replace_from_clip_bytes_satisfies_deferred_event_without_later_wo
     monkeypatch.setattr(hq_module.high_quality_snapshot_service, "_ensure_workers_started", lambda: None)
     monkeypatch.setattr(
         hq_module.high_quality_snapshot_service,
-        "_extract_snapshot_from_clip",
-        lambda clip_bytes, *_args: b"derived-bytes",
+        "_extract_snapshot_from_clip_path",
+        lambda clip_path, *_args: b"derived-bytes",
     )
 
     worker_processed: list[str] = []


### PR DESCRIPTION
## Outcome

Closes #341. Whole video clips no longer transit the API process's memory: Frigate downloads stream straight into the job's temp file (256 KB chunks), cached clips are copied disk-to-disk, validation (MP4 header + cv2 decode) runs against the file, and the high-quality snapshot path takes the file path. This removes the dominant transient behind the ~3.2 GB glibc arena high-water found in the live review (bounded meanwhile by `MALLOC_ARENA_MAX=2`).

## Included

- `FrigateClient.download_clip_to_file` — streaming download with the same status mapping as the bytes fetch (404 → `clip_not_found` at info, `clip_not_retained`, timeout/request errors), unit-tested with a stubbed streaming client.
- `_load_preferred_clip`/`_wait_for_clip` now fill a destination path and report success as a boolean; validation is `_clip_file_valid` (header + cv2 straight on the file — clips were already written to a temp file for cv2, so bytes bought nothing).
- `replace_from_clip_path` / `generate_snapshot_candidates_from_clip_path` as the real implementations; the bytes entrypoints remain as thin wrappers for their other callers (event_processor, HQ's own fetch flow).
- Source-level test pins the invariant: no whole-clip byte strings in the video job path.

## Verification

Backend 2583 tests green (affected suites updated to the path contract: streaming poll, disk-to-disk cache copies, honest 0-byte diagnostic when a stubbed loader writes nothing); repo-wide ruff clean.