### PR TITLE
Show only the hidden visits when the Hidden facet is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The Hidden facet now shows the hidden visits
+  ([#347](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/347)).** The toggle sits
+  under "Only", beside facets that filter the list down, but it was wired to *include* hidden rows
+  in the full list - with one hidden visit among a thousand, selecting it visibly did nothing.
+  Selecting Hidden now shows exactly the hidden visits, and unhiding one removes it from that view.
+
 - **The RAM prediction now counts the video worker, and the video pool follows the one knob.**
   Video analysis runs on its own worker pool, so with video enabled those model copies are real
   memory — observed live as a video-0 worker holding a copy no prediction accounted for. The

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -11,6 +11,7 @@ export interface FetchEventsOptions {
     camera?: string;
     sort?: 'newest' | 'oldest' | 'confidence';
     includeHidden?: boolean;
+    onlyHidden?: boolean;
     favoritesOnly?: boolean;
     audioConfirmedOnly?: boolean;
     eventId?: string;
@@ -20,7 +21,7 @@ export interface FetchEventsOptions {
 }
 
 export async function fetchEvents(options: FetchEventsOptions = {}): Promise<Detection[]> {
-    const { limit = 50, offset = 0, startDate, endDate, species, camera, sort, includeHidden, favoritesOnly, audioConfirmedOnly, eventId, fields, requestKey, signal } = options;
+    const { limit = 50, offset = 0, startDate, endDate, species, camera, sort, includeHidden, onlyHidden, favoritesOnly, audioConfirmedOnly, eventId, fields, requestKey, signal } = options;
     const params = new URLSearchParams();
     params.set('limit', limit.toString());
     params.set('offset', offset.toString());
@@ -30,6 +31,7 @@ export async function fetchEvents(options: FetchEventsOptions = {}): Promise<Det
     if (camera) params.set('camera', camera);
     if (sort) params.set('sort', sort);
     if (includeHidden) params.set('include_hidden', 'true');
+    if (onlyHidden) params.set('only_hidden', 'true');
     if (favoritesOnly) params.set('favorites', 'true');
     if (audioConfirmedOnly) params.set('audio_confirmed_only', 'true');
     if (eventId) params.set('event_id', eventId);
@@ -40,7 +42,7 @@ export async function fetchEvents(options: FetchEventsOptions = {}): Promise<Det
         species || 'all',
         camera || 'all',
         sort || 'newest',
-        includeHidden ? 'hidden' : 'visible',
+        onlyHidden ? 'only-hidden' : includeHidden ? 'hidden' : 'visible',
         favoritesOnly ? 'favorites' : 'all',
         audioConfirmedOnly ? 'audio' : 'all',
         eventId || 'all-events',
@@ -86,6 +88,7 @@ export interface EventsCountOptions {
     species?: string;
     camera?: string;
     includeHidden?: boolean;
+    onlyHidden?: boolean;
     favoritesOnly?: boolean;
     audioConfirmedOnly?: boolean;
     requestKey?: string | null;
@@ -94,13 +97,14 @@ export interface EventsCountOptions {
 export type EventsCountResponse = paths['/api/events/count']['get']['response'];
 
 export async function fetchEventsCount(options: EventsCountOptions = {}): Promise<EventsCountResponse> {
-    const { startDate, endDate, species, camera, includeHidden, favoritesOnly, audioConfirmedOnly, requestKey } = options;
+    const { startDate, endDate, species, camera, includeHidden, onlyHidden, favoritesOnly, audioConfirmedOnly, requestKey } = options;
     const params = new URLSearchParams();
     if (startDate) params.set('start_date', startDate);
     if (endDate) params.set('end_date', endDate);
     if (species) params.set('species', species);
     if (camera) params.set('camera', camera);
     if (includeHidden) params.set('include_hidden', 'true');
+    if (onlyHidden) params.set('only_hidden', 'true');
     if (favoritesOnly) params.set('favorites', 'true');
     if (audioConfirmedOnly) params.set('audio_confirmed_only', 'true');
 
@@ -108,7 +112,7 @@ export async function fetchEventsCount(options: EventsCountOptions = {}): Promis
         'events-count',
         species || 'all',
         camera || 'all',
-        includeHidden ? 'hidden' : 'visible',
+        onlyHidden ? 'only-hidden' : includeHidden ? 'hidden' : 'visible',
         favoritesOnly ? 'favorites' : 'all',
         audioConfirmedOnly ? 'audio' : 'all',
         startDate || 'none',

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -2577,6 +2577,7 @@ export interface paths {
     include_hidden?: boolean;
     limit?: number;
     offset?: number;
+    only_hidden?: boolean;
     sort?: "newest" | "oldest" | "confidence";
     species?: string | null;
     start_date?: string | null;
@@ -2613,6 +2614,7 @@ export interface paths {
     end_date?: string | null;
     favorites?: boolean;
     include_hidden?: boolean;
+    only_hidden?: boolean;
     species?: string | null;
     start_date?: string | null;
 };

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -199,7 +199,7 @@
                     species: speciesFilter || undefined,
                     camera: cameraFilter || undefined,
                     sort: sortOrder,
-                    includeHidden: showHidden,
+                    onlyHidden: showHidden,
                     favoritesOnly,
                     audioConfirmedOnly,
                     fields: 'list',
@@ -210,7 +210,7 @@
                     endDate: range.end,
                     species: speciesFilter || undefined,
                     camera: cameraFilter || undefined,
-                    includeHidden: showHidden,
+                    onlyHidden: showHidden,
                     favoritesOnly,
                     audioConfirmedOnly,
                     requestKey: 'events-page:count'
@@ -690,7 +690,10 @@
                 selectedEvent = null;
                 hiddenCount++;
             } else {
-                events = events.map(e => e.frigate_event === eventId ? { ...e, is_hidden: false } : e);
+                // In the hidden-only view an unhidden row no longer qualifies.
+                events = showHidden
+                    ? events.filter(e => e.frigate_event !== eventId)
+                    : events.map(e => e.frigate_event === eventId ? { ...e, is_hidden: false } : e);
                 hiddenCount = Math.max(0, hiddenCount - 1);
                 selectedEvent = null;
             }
@@ -1421,7 +1424,10 @@
                 }
                 hiddenCount++;
             } else {
-                events = events.map((event) => event.frigate_event === hiddenEventId ? { ...event, is_hidden: false } : event);
+                // In the hidden-only view an unhidden row no longer qualifies.
+                events = showHidden
+                    ? events.filter((event) => event.frigate_event !== hiddenEventId)
+                    : events.map((event) => event.frigate_event === hiddenEventId ? { ...event, is_hidden: false } : event);
                 hiddenCount = Math.max(0, hiddenCount - 1);
             }
             selectedEvent = null;

--- a/apps/ui/src/lib/pages/hidden-facet-only.layout.test.ts
+++ b/apps/ui/src/lib/pages/hidden-facet-only.layout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import eventsPageSource from './Events.svelte?raw';
+import eventsApiSource from '../api/events.ts?raw';
+
+describe('the Hidden facet shows only the hidden visits (#347)', () => {
+    // The toggle sits under the "Only" heading beside Favourites and Audio
+    // matches, both of which filter the list down. Wiring it to
+    // include_hidden merely added the hidden rows to everything else, so
+    // with one hidden visit in 1,316 it visibly did nothing.
+
+    it('the Explorer asks for only the hidden rows, not the full list plus them', () => {
+        expect(eventsPageSource).toContain('onlyHidden: showHidden');
+        expect(eventsPageSource).not.toContain('includeHidden: showHidden');
+    });
+
+    it('the API layer carries only_hidden to both the list and the count', () => {
+        const occurrences = eventsApiSource.split("params.set('only_hidden', 'true')").length - 1;
+        expect(occurrences).toBe(2);
+        // Distinct cache keys, or a toggle would replay the other view's rows.
+        expect(eventsApiSource).toContain("onlyHidden ? 'only-hidden' : includeHidden ? 'hidden' : 'visible'");
+    });
+
+    it('unhiding a visit while viewing only hidden removes it from the list', () => {
+        // A row that stops qualifying for the active filter must leave the
+        // view, or the list claims a state the database no longer holds.
+        const removals = eventsPageSource.split('In the hidden-only view an unhidden row no longer qualifies.').length - 1;
+        expect(removals).toBe(2);
+    });
+});

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1744,6 +1744,7 @@ class DetectionRepository:
         camera: str | None = None,
         sort: str = "newest",
         include_hidden: bool = False,
+        hidden_only: bool = False,
         favorite_only: bool = False,
         audio_confirmed_only: bool = False,
         frigate_event: str | None = None,
@@ -1775,8 +1776,11 @@ class DetectionRepository:
         params: list = []
         conditions = []
 
-        # By default, exclude hidden detections
-        if not include_hidden:
+        # Hidden rows are excluded by default; the Explorer's Hidden facet
+        # asks for them exclusively, which outranks merely including them.
+        if hidden_only:
+            conditions.append("d.is_hidden = 1")
+        elif not include_hidden:
             conditions.append("(d.is_hidden = 0 OR d.is_hidden IS NULL)")
 
         if start_date:
@@ -1851,6 +1855,7 @@ class DetectionRepository:
         taxa_id: int | None = None,
         camera: str | None = None,
         include_hidden: bool = False,
+        hidden_only: bool = False,
         favorite_only: bool = False,
         exclude_favorites: bool = False,
         audio_confirmed_only: bool = False,
@@ -1878,8 +1883,11 @@ class DetectionRepository:
         params: list = []
         conditions = []
 
-        # By default, exclude hidden detections
-        if not include_hidden:
+        # Hidden rows are excluded by default; the Explorer's Hidden facet
+        # asks for them exclusively, which outranks merely including them.
+        if hidden_only:
+            conditions.append("d.is_hidden = 1")
+        elif not include_hidden:
             conditions.append("(d.is_hidden = 0 OR d.is_hidden IS NULL)")
 
         if start_date:

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -637,6 +637,7 @@ async def get_events(
     audio_confirmed_only: bool = Query(default=False, description="Only return detections with audio confirmation"),
     sort: Literal["newest", "oldest", "confidence"] = Query(default="newest", description="Sort order"),
     include_hidden: bool = Query(default=False, description="Include hidden/ignored detections"),
+    only_hidden: bool = Query(default=False, description="Return only hidden/ignored detections"),
     fields: Optional[str] = Query(
         default=None,
         description="Comma-separated field names to return. Use 'list' for minimal fields, 'detail' for all. Default: all fields.",
@@ -670,6 +671,7 @@ async def get_events(
 
         # Never show hidden detections to guests
         include_hidden = False
+        only_hidden = False
 
         # Prevent camera-based filtering if camera names are hidden
         if hide_camera_names:
@@ -697,6 +699,7 @@ async def get_events(
             camera=camera,
             sort=sort,
             include_hidden=include_hidden,
+            hidden_only=only_hidden,
             favorite_only=favorites,
             audio_confirmed_only=audio_confirmed_only,
             frigate_event=event_id,
@@ -928,6 +931,7 @@ async def get_events_count(
     favorites: bool = Query(default=False, description="Only count favorited detections"),
     audio_confirmed_only: bool = Query(default=False, description="Only count detections with audio confirmation"),
     include_hidden: bool = Query(default=False, description="Include hidden/ignored detections"),
+    only_hidden: bool = Query(default=False, description="Count only hidden/ignored detections"),
     auth: AuthContext = Depends(get_auth_context_with_legacy),
 ):
     """Get total count of events (optionally filtered). Public users see limited historical data."""
@@ -945,6 +949,7 @@ async def get_events_count(
             start_date = date.today()
             end_date = date.today()
         include_hidden = False
+        only_hidden = False
         if hide_camera_names:
             camera = None
 
@@ -966,12 +971,13 @@ async def get_events_count(
             taxa_id=taxa_id,
             camera=camera,
             include_hidden=include_hidden,
+            hidden_only=only_hidden,
             favorite_only=favorites,
             audio_confirmed_only=audio_confirmed_only,
         )
 
         # Determine if any filters are applied
-        filtered = any([start_date, end_date, species, camera, favorites, audio_confirmed_only])
+        filtered = any([start_date, end_date, species, camera, favorites, audio_confirmed_only, only_hidden])
 
         return EventsCountResponse(count=count, filtered=filtered)
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18225,6 +18225,18 @@
             }
           },
           {
+            "description": "Return only hidden/ignored detections",
+            "in": "query",
+            "name": "only_hidden",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Return only hidden/ignored detections",
+              "title": "Only Hidden",
+              "type": "boolean"
+            }
+          },
+          {
             "description": "Comma-separated field names to return. Use 'list' for minimal fields, 'detail' for all. Default: all fields.",
             "in": "query",
             "name": "fields",
@@ -18515,6 +18527,18 @@
               "default": false,
               "description": "Include hidden/ignored detections",
               "title": "Include Hidden",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Count only hidden/ignored detections",
+            "in": "query",
+            "name": "only_hidden",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Count only hidden/ignored detections",
+              "title": "Only Hidden",
               "type": "boolean"
             }
           }

--- a/backend/tests/test_events_hidden_filter_api.py
+++ b/backend/tests/test_events_hidden_filter_api.py
@@ -1,0 +1,82 @@
+"""The Explorer's Hidden facet promises "only hidden" and must deliver it.
+
+Upstream #347: hiding an event and selecting the Hidden facet changed
+nothing, because the UI's toggle mapped to include_hidden — which adds
+hidden rows to the full list instead of filtering to them. These tests
+pin the only_hidden contract end to end.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import close_db, get_db, init_db
+from app.main import app
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_test_db():
+    await init_db()
+    try:
+        async with get_db() as db:
+            await db.execute("DELETE FROM detections")
+            await db.execute("""
+                INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index, score, display_name, category_name, is_hidden)
+                VALUES
+                ('event_visible_1', 'cam1', '2026-01-01 10:00:00', 1, 0.9, 'Robin', 'Robin', 0),
+                ('event_visible_2', 'cam1', '2026-01-01 10:05:00', 1, 0.9, 'Blue Jay', 'Blue Jay', 0),
+                ('event_hidden', 'cam1', '2026-01-01 10:10:00', 1, 0.9, 'House Sparrow', 'House Sparrow', 1)
+            """)
+            await db.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_events_only_hidden_returns_just_the_hidden_rows():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events?only_hidden=true")
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data) == 1
+        assert data[0]["frigate_event"] == "event_hidden"
+        assert data[0]["is_hidden"] is True
+
+
+@pytest.mark.asyncio
+async def test_events_default_still_excludes_hidden():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events")
+        assert res.status_code == 200
+        assert {d["frigate_event"] for d in res.json()} == {"event_visible_1", "event_visible_2"}
+
+
+@pytest.mark.asyncio
+async def test_events_include_hidden_still_returns_everything():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events?include_hidden=true")
+        assert res.status_code == 200
+        assert len(res.json()) == 3
+
+
+@pytest.mark.asyncio
+async def test_events_count_only_hidden_counts_just_the_hidden_rows():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events/count?only_hidden=true")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["count"] == 1
+        assert data["filtered"] is True
+
+
+@pytest.mark.asyncio
+async def test_events_only_hidden_composes_with_other_filters():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events?only_hidden=true&species=Robin")
+        assert res.status_code == 200
+        assert res.json() == []
+
+        res = await client.get("/api/events?only_hidden=true&species=House%20Sparrow")
+        assert res.status_code == 200
+        assert [d["frigate_event"] for d in res.json()] == ["event_hidden"]


### PR DESCRIPTION
## Outcome

Fixes [#347](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/347). The Explorer's **Hidden** facet sits under the *Only* heading beside Favourites and Audio matches — both of which narrow the list — but it was wired to `include_hidden`, which merely *adds* hidden rows to the full list. With one hidden visit among 1,316, selecting it visibly did nothing.

## Included

- `GET /api/events` and `GET /api/events/count` take `only_hidden`, which outranks inclusion; guests have it forced off alongside `include_hidden`.
- The Explorer's Hidden facet sends `only_hidden`; unhiding a visit while in that view removes the row, since it no longer qualifies.
- OpenAPI artifact and generated SPA types regenerated.

## Verification

New API tests pin the contract (only-hidden, default exclusion, include still works, composition with species filter); a layout test pins the UI wiring. Full suites green: 2,589 backend, 972 frontend, svelte-check 0/0.