### PR TITLE
Judge a loading worker by signs of life, and degrade honestly when it dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A worker loading a large model is no longer mistaken for a dead one.** Observed in the field:
+  the supervisor killed a worker with "heartbeat timeout" while its stderr was mid-way through
+  TensorFlow's import chatter — heavy imports and cold GPU model compiles hold the GIL long enough
+  to starve the heartbeat, and on slow hardware the kill/reload loop meant subprocess mode never
+  classified anything. Three defences now: stderr output counts as proof of life; the first load
+  is judged against a warm-up deadline (3 minutes by default) instead of the 5-second steady-state
+  window; and if the worker circuit still trips, classification falls back to the main process and
+  the Detection status band says so in amber instead of silently dropping every visit. The
+  OpenVINO kernel cache also moved to the persistent models volume, so a slow first compile is
+  paid once, not on every container start.
+
 - **The species card now opens for a bird the feeder has never seen.** Opening a notable nearby
   sighting answered "Detection not found", because the stats request 404s for a species with no
   local visits and the card treated that as a failure. An empty record is the normal case for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   so an unusual bird reported in your area is one click from its description, taxonomy, and your
   own history with it — including when that history is empty.
 
+- **First-run setup can be skipped.** The wizard's header now offers *Skip setup* wherever the
+  rerun mode shows its close button. Skipping asks first and is honest about its one consequence:
+  leaving before the account step means the app runs without a password until one is set under
+  Settings → Security. It completes initial setup through the same path the account step uses
+  (auth disabled), so the gate state stays consistent, and the wizard remains re-runnable from
+  Settings at any time. Escape-to-close stays rerun-only.
+
 ### Fixed
 
 - **A worker loading a large model is no longer mistaken for a dead one.** Observed in the field:
@@ -70,8 +77,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   32 MB property of the protocol shared by both ends, and an encode that would exceed it is
   refused before it is written, so the framing can never be poisoned mid-line.
 
-### Fixed
-
 - **The log speaks at the right volume.** Three realignments so an error in the log means an
   actual error: a worker's relayed crash traceback is now a warning instead of an info line (and
   runtime start-up banners drop to debug); a clip Frigate simply never stored logs at info,
@@ -110,15 +115,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   polynomial on crafted labels. The eight deliberate keeps — owner-facing diagnostic messages,
   the informational /health payload, and the Fernet key derived from a generated high-entropy
   secret — are dismissed on GitHub with the reasoning recorded on each alert.
-
-### Added
-
-- **First-run setup can be skipped.** The wizard's header now offers *Skip setup* wherever the
-  rerun mode shows its close button. Skipping asks first and is honest about its one consequence:
-  leaving before the account step means the app runs without a password until one is set under
-  Settings → Security. It completes initial setup through the same path the account step uses
-  (auth disabled), so the gate state stays consistent, and the wizard remains re-runnable from
-  Settings at any time. Escape-to-close stays rerun-only.
 
 ## [2.18.1] - 2026-08-29
 

--- a/apps/ui/src/lib/api/classifier.ts
+++ b/apps/ui/src/lib/api/classifier.ts
@@ -17,6 +17,12 @@ export interface ClassifierStatus {
     openvino_gpu_probe_error?: string | null;
     resolved_live_workers?: number;
     resolved_background_workers?: number;
+    worker_in_process_fallback?: {
+        active: boolean;
+        reason: string | null;
+        active_seconds: number | null;
+        classifications: number;
+    };
     active_model_estimated_ram_mb?: number | null;
     openvino_model_compile_ok?: boolean | null;
     openvino_model_compile_device?: string | null;

--- a/apps/ui/src/lib/components/settings/DetectionStatusBand.svelte
+++ b/apps/ui/src/lib/components/settings/DetectionStatusBand.svelte
@@ -34,6 +34,7 @@
     const liveWorkers = $derived(classifierStatus?.resolved_live_workers ?? 1);
     const backgroundWorkers = $derived(classifierStatus?.resolved_background_workers ?? 1);
     const ramPerCopy = $derived(classifierStatus?.active_model_estimated_ram_mb ?? null);
+    const workerFallbackActive = $derived(classifierStatus?.worker_in_process_fallback?.active ?? false);
 
     function jumpTo(anchorId: string) {
         document.getElementById(anchorId)?.scrollIntoView({ block: 'start', behavior: 'smooth' });
@@ -85,6 +86,11 @@
         {#if imageExecutionMode === 'in_process'}
             <span class="text-sm font-bold text-slate-900 dark:text-white">{$_('settings.detection.band_in_process')}</span>
             <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">{$_('settings.detection.band_shared_runtime')}</span>
+        {:else if workerFallbackActive}
+            <!-- Work that needs a person, stated in words: the isolated workers
+                 keep dying and classification is running in-process meanwhile. -->
+            <span class="text-sm font-bold text-amber-700 dark:text-amber-300">{$_('settings.detection.band_worker_fallback')}</span>
+            <span class="text-xs font-semibold text-amber-700/80 dark:text-amber-300/80">{$_('settings.detection.band_worker_fallback_detail')}</span>
         {:else}
             <span class="text-sm font-bold text-slate-900 dark:text-white">
                 {#if autoVideoEnabled}

--- a/apps/ui/src/lib/components/settings/worker-fallback-band.layout.test.ts
+++ b/apps/ui/src/lib/components/settings/worker-fallback-band.layout.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import bandSource from './DetectionStatusBand.svelte?raw';
+import classifierApiSource from '../../api/classifier.ts?raw';
+
+describe('the status band states the in-process fallback in words', () => {
+    // When the isolated workers keep dying, classification silently moving
+    // in-process would hide exactly the state a person must act on. Amber is
+    // reserved for work that needs a person; this is that work.
+
+    it('the API type carries the fallback state', () => {
+        expect(classifierApiSource).toContain('worker_in_process_fallback?:');
+    });
+
+    it('the workers cell turns amber and says what is happening', () => {
+        expect(bandSource).toContain('worker_in_process_fallback?.active');
+        expect(bandSource).toContain('workerFallbackActive');
+        expect(bandSource).toContain("settings.detection.band_worker_fallback'");
+        expect(bandSource).toContain("settings.detection.band_worker_fallback_detail'");
+        const fallbackBlock = bandSource.slice(bandSource.indexOf('workerFallbackActive}'));
+        expect(fallbackBlock).toContain('text-amber-700');
+    });
+});

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -1491,7 +1491,9 @@
       "worker_counts_auto": "1 (Standard)",
       "video_concurrency_follows_workers": "Clips werden so viele gleichzeitig analysiert, wie es Hintergrund-Worker gibt — die Modelle klassifizieren ein Bild pro Worker, ein separater Parallelitätsregler könnte also nur Aufträge stauen oder Worker brachliegen lassen.",
       "band_worker_split_video": "{live} live · {background} im Hintergrund · {video} Video",
-      "model_manager_memory_formula_subprocess_video": "{per} pro Kopie × {live} live + {background} im Hintergrund + {video} Video (isolierter Modus)"
+      "model_manager_memory_formula_subprocess_video": "{per} pro Kopie × {live} live + {background} im Hintergrund + {video} Video (isolierter Modus)",
+      "band_worker_fallback": "Worker fallen aus — Klassifizierung im Hauptprozess",
+      "band_worker_fallback_detail": "Isolierte Worker sterben beim Laden des Modells; Erkennungen laufen im Hauptprozess weiter."
     },
     "llm": {
       "title": "KI-Einblicke",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -1500,7 +1500,9 @@
       "worker_counts_auto": "1 (default)",
       "video_concurrency_follows_workers": "Clips are analysed as many at a time as there are background workers — the models classify one image per worker, so a separate concurrency setting could only queue jobs or starve workers.",
       "band_worker_split_video": "{live} live · {background} background · {video} video",
-      "model_manager_memory_formula_subprocess_video": "{per} per copy × {live} live + {background} background + {video} video workers (isolated mode)"
+      "model_manager_memory_formula_subprocess_video": "{per} per copy × {live} live + {background} background + {video} video workers (isolated mode)",
+      "band_worker_fallback": "Workers failing — classifying in-process",
+      "band_worker_fallback_detail": "Isolated workers keep dying during model load; detections continue in the main process."
     },
     "llm": {
       "title": "AI Insights",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -1491,7 +1491,9 @@
       "worker_counts_auto": "1 (por defecto)",
       "video_concurrency_follows_workers": "Los clips se analizan tantos a la vez como procesos en segundo plano hay: los modelos clasifican una imagen por proceso, así que un ajuste de concurrencia aparte solo podría encolar trabajos o dejar procesos sin uso.",
       "band_worker_split_video": "{live} en vivo · {background} en segundo plano · {video} de vídeo",
-      "model_manager_memory_formula_subprocess_video": "{per} por copia × {live} en vivo + {background} en segundo plano + {video} de vídeo (modo aislado)"
+      "model_manager_memory_formula_subprocess_video": "{per} por copia × {live} en vivo + {background} en segundo plano + {video} de vídeo (modo aislado)",
+      "band_worker_fallback": "Los workers fallan — clasificando en el proceso principal",
+      "band_worker_fallback_detail": "Los workers aislados mueren al cargar el modelo; las detecciones continúan en el proceso principal."
     },
     "llm": {
       "title": "Análisis de IA",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -1491,7 +1491,9 @@
       "worker_counts_auto": "1 (par défaut)",
       "video_concurrency_follows_workers": "Les clips sont analysés autant à la fois qu'il y a de processus en arrière-plan : les modèles classifient une image par processus, un réglage de concurrence séparé ne pourrait donc que mettre en file ou laisser des processus inutilisés.",
       "band_worker_split_video": "{live} en direct · {background} en arrière-plan · {video} vidéo",
-      "model_manager_memory_formula_subprocess_video": "{per} par copie × {live} en direct + {background} en arrière-plan + {video} vidéo (mode isolé)"
+      "model_manager_memory_formula_subprocess_video": "{per} par copie × {live} en direct + {background} en arrière-plan + {video} vidéo (mode isolé)",
+      "band_worker_fallback": "Workers en échec — classification dans le processus principal",
+      "band_worker_fallback_detail": "Les workers isolés meurent au chargement du modèle. Les détections continuent dans le processus principal."
     },
     "llm": {
       "title": "Analyses IA",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -1500,7 +1500,9 @@
       "worker_counts_auto": "1 (predefinito)",
       "video_concurrency_follows_workers": "I clip vengono analizzati tanti alla volta quanti sono i processi in background: i modelli classificano una immagine per processo, quindi una regolazione separata potrebbe solo accodare lavori o lasciare processi inutilizzati.",
       "band_worker_split_video": "{live} dal vivo · {background} in background · {video} video",
-      "model_manager_memory_formula_subprocess_video": "{per} per copia × {live} dal vivo + {background} in background + {video} video (modalità isolata)"
+      "model_manager_memory_formula_subprocess_video": "{per} per copia × {live} dal vivo + {background} in background + {video} video (modalità isolata)",
+      "band_worker_fallback": "Worker in errore — classificazione nel processo principale",
+      "band_worker_fallback_detail": "I worker isolati muoiono durante il caricamento del modello; i rilevamenti continuano nel processo principale."
     },
     "llm": {
       "title": "Analisi IA",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -1491,7 +1491,9 @@
       "worker_counts_auto": "1(既定)",
       "video_concurrency_follows_workers": "クリップはバックグラウンドワーカーの数だけ同時に解析されます。モデルはワーカーごとに1枚ずつ分類するため、別個の同時実行設定はジョブを待たせるかワーカーを遊ばせるだけになります。",
       "band_worker_split_video": "ライブ{live}・バックグラウンド{background}・動画{video}",
-      "model_manager_memory_formula_subprocess_video": "コピーあたり{per} × ライブ{live}+バックグラウンド{background}+動画{video}(分離モード)"
+      "model_manager_memory_formula_subprocess_video": "コピーあたり{per} × ライブ{live}+バックグラウンド{background}+動画{video}(分離モード)",
+      "band_worker_fallback": "ワーカーが失敗 — メインプロセスで分類中",
+      "band_worker_fallback_detail": "分離ワーカーがモデル読み込み中に停止し続けています。検出はメインプロセスで継続しています。"
     },
     "llm": {
       "title": "AI インサイト",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -1500,7 +1500,9 @@
       "worker_counts_auto": "1 (padrão)",
       "video_concurrency_follows_workers": "Os clipes são analisados tantos por vez quantos forem os processos em segundo plano — os modelos classificam uma imagem por processo, então um ajuste separado de concorrência só poderia enfileirar trabalhos ou deixar processos ociosos.",
       "band_worker_split_video": "{live} ao vivo · {background} em segundo plano · {video} de vídeo",
-      "model_manager_memory_formula_subprocess_video": "{per} por cópia × {live} ao vivo + {background} em segundo plano + {video} de vídeo (modo isolado)"
+      "model_manager_memory_formula_subprocess_video": "{per} por cópia × {live} ao vivo + {background} em segundo plano + {video} de vídeo (modo isolado)",
+      "band_worker_fallback": "Workers falhando — classificando no processo principal",
+      "band_worker_fallback_detail": "Os workers isolados morrem ao carregar o modelo; as detecções continuam no processo principal."
     },
     "llm": {
       "title": "Análises de IA",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -1500,7 +1500,9 @@
       "worker_counts_auto": "1 (по умолчанию)",
       "video_concurrency_follows_workers": "Клипы анализируются одновременно в количестве фоновых процессов: модели классифицируют по одному изображению на процесс, поэтому отдельная настройка параллельности могла бы лишь копить очередь или простаивать процессы.",
       "band_worker_split_video": "{live} онлайн · {background} в фоне · {video} видео",
-      "model_manager_memory_formula_subprocess_video": "{per} на копию × {live} онлайн + {background} в фоне + {video} видео (изолированный режим)"
+      "model_manager_memory_formula_subprocess_video": "{per} на копию × {live} онлайн + {background} в фоне + {video} видео (изолированный режим)",
+      "band_worker_fallback": "Сбой воркеров — классификация в основном процессе",
+      "band_worker_fallback_detail": "Изолированные воркеры продолжают падать при загрузке модели; распознавание продолжается в основном процессе."
     },
     "llm": {
       "title": "ИИ-аналитика",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -1491,7 +1491,9 @@
       "worker_counts_auto": "1(默认)",
       "video_concurrency_follows_workers": "同时分析的剪辑数量等于后台工作进程数——模型每个进程一次只分类一张图像,单独的并发设置只会让任务排队或让进程闲置。",
       "band_worker_split_video": "{live} 个实时 · {background} 个后台 · {video} 个视频",
-      "model_manager_memory_formula_subprocess_video": "每份 {per} × {live} 个实时 + {background} 个后台 + {video} 个视频(隔离模式)"
+      "model_manager_memory_formula_subprocess_video": "每份 {per} × {live} 个实时 + {background} 个后台 + {video} 个视频(隔离模式)",
+      "band_worker_fallback": "工作进程故障 — 正在主进程中分类",
+      "band_worker_fallback_detail": "隔离的工作进程在加载模型时不断崩溃；检测在主进程中继续进行。"
     },
     "llm": {
       "title": "AI 洞察",

--- a/backend/app/services/bird_crop_service.py
+++ b/backend/app/services/bird_crop_service.py
@@ -14,6 +14,7 @@ import structlog
 from PIL import Image
 
 from app.config import settings
+from app.services.openvino_cache import resolve_openvino_cache_dir
 
 log = structlog.get_logger()
 
@@ -67,7 +68,7 @@ class _OpenVINODetectorSession:
         self.device = str(device or "CPU")
         self._lock = threading.Lock()
         self._core = core_cls()
-        cache_dir = os.getenv("OPENVINO_CACHE_DIR", "/tmp/openvino_cache")
+        cache_dir = resolve_openvino_cache_dir()
         os.makedirs(cache_dir, exist_ok=True)
         try:
             self._core.set_property({"CACHE_DIR": cache_dir})

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -2971,7 +2971,7 @@ class ClassifierService:
         startup_self_test_enabled = _openvino_gpu_startup_self_test_enabled() and not self._worker_process_mode
         return {
             "startup_self_test_enabled": startup_self_test_enabled,
-            "cache_dir": os.getenv("OPENVINO_CACHE_DIR", "/tmp/openvino_cache"),
+            "cache_dir": resolve_openvino_cache_dir(),
             "requested_compile_properties": {
                 "PERFORMANCE_HINT": "LATENCY",
                 "NUM_STREAMS": "1",

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -4,6 +4,7 @@ import os
 import cv2
 import asyncio
 import contextlib
+import functools
 import inspect
 import base64
 import ctypes
@@ -23,6 +24,7 @@ from PIL import Image
 from typing import Optional, Any, Awaitable, Callable, Literal
 
 from app.services.inference_health import InferenceHealth, Outcome, RuntimeKey
+from app.services.openvino_cache import resolve_openvino_cache_dir
 from app.services.startup_status import startup_status
 from app.utils.canonical_species import should_hide_species_label
 from app.utils.runtime_flavor import get_image_flavor, image_flavor_warning, packaged_inference_providers
@@ -2466,7 +2468,7 @@ class OpenVINOModelInstance:
 
             # Enable caching so GPU model compilation isn't repeated from scratch
             # on every worker process startup, avoiding readiness timeouts.
-            cache_dir = os.getenv("OPENVINO_CACHE_DIR", "/tmp/openvino_cache")
+            cache_dir = resolve_openvino_cache_dir()
             os.makedirs(cache_dir, exist_ok=True)
             self.core.set_property({"CACHE_DIR": cache_dir})
 
@@ -2808,6 +2810,13 @@ class ClassifierService:
                     float(getattr(settings.classification, "worker_ready_timeout_seconds", 20.0) or 20.0),
                     min(60.0, max(30.0, video_timeout_seconds / 2.0)),
                 ),
+                # A cold model load (native imports, GPU kernel compiles) can
+                # legitimately hold a worker silent far past the steady-state
+                # heartbeat window; killing it mid-load loops forever on slow
+                # hardware and classifies nothing (observed on #300).
+                warmup_liveness_timeout_seconds=float(
+                    getattr(settings.classification, "worker_first_load_grace_seconds", 180.0) or 180.0
+                ),
             )
             self._video_supervisor = isolated_supervisor
             if self._image_execution_mode == "subprocess":
@@ -2828,6 +2837,13 @@ class ClassifierService:
         self._runtime_gpu_retries = 0
         self._runtime_gpu_restore_attempts = 0
         self._runtime_gpu_restore_successes = 0
+        self._worker_fallback_lock = asyncio.Lock()
+        self._worker_fallback_state: dict[str, Any] = {
+            "active": False,
+            "reason": None,
+            "since_monotonic": None,
+            "classifications": 0,
+        }
         self._runtime_gpu_restore_failures = 0
         self._gpu_invalid_retry_remaining = CLASSIFIER_GPU_INVALID_RETRY_LIMIT
         self._gpu_restore_not_before_monotonic: float = 0.0
@@ -4651,6 +4667,9 @@ class ClassifierService:
 
         status = {
             "image_execution_mode": self._image_execution_mode,
+            # Honest degradation: when the worker circuit opens, classification
+            # continues in-process and this says so instead of hiding it.
+            "worker_in_process_fallback": self.get_worker_fallback_status(),
             # The worker count is derived from concurrency and provider now, so
             # Settings must be able to show what it resolved to and what each
             # worker costs — the price is stated, not implied (#312).
@@ -5530,7 +5549,7 @@ class ClassifierService:
             raise RuntimeError("classifier supervisor is not configured")
         normalized_input_context = _normalize_classification_input_context(input_context)
         try:
-            return await self._classifier_supervisor.classify(
+            results = await self._classifier_supervisor.classify(
                 priority=priority,
                 work_id=str(work_id or f"{priority}-{time.monotonic_ns()}"),
                 lease_token=int(lease_token or 1),
@@ -5541,10 +5560,18 @@ class ClassifierService:
                 if normalized_input_context is not None
                 else None,
             )
+            if self._worker_fallback_state["active"]:
+                self._worker_fallback_state["active"] = False
+                log.info("classifier_worker_fallback_recovered", reason=self._worker_fallback_state["reason"])
+            return results
         except ClassifierWorkerCircuitOpenError:
-            if priority == "live":
-                raise LiveImageClassificationOverloadedError("classify_snapshot_circuit_open") from None
-            raise BackgroundImageClassificationUnavailableError("background_image_circuit_open") from None
+            return await self._classify_in_process_as_last_resort(
+                priority=priority,
+                image=image,
+                camera_name=camera_name,
+                model_id=model_id,
+                input_context=normalized_input_context,
+            )
         except (ClassifierWorkerHeartbeatTimeoutError, ClassifierWorkerDeadlineExceededError):
             if priority == "live":
                 raise ClassificationLeaseExpiredError(
@@ -5561,6 +5588,61 @@ class ClassifierService:
             if priority == "live":
                 raise LiveImageClassificationOverloadedError("classify_snapshot_worker_unavailable") from None
             raise BackgroundImageClassificationUnavailableError("background_image_worker_unavailable") from None
+
+    async def _classify_in_process_as_last_resort(
+        self,
+        *,
+        priority: Literal["live", "background"],
+        image: Image.Image,
+        camera_name: Optional[str],
+        model_id: Optional[str],
+        input_context: Any | None,
+    ) -> list[dict]:
+        """Classify in this process when the worker circuit is open.
+
+        An open circuit means the isolated workers keep dying — on slow
+        hardware, typically killed mid-model-load. Dropping every detection
+        until someone notices is the worst outcome for a recorder of
+        history, so the main process loads its own copy and keeps
+        classifying, and the status endpoint says so plainly.
+        """
+        async with self._worker_fallback_lock:
+            if not self.model_loaded:
+                try:
+                    await asyncio.to_thread(self._init_bird_model)
+                except Exception as exc:
+                    log.error("worker_fallback_model_load_failed", error=str(exc))
+        if not self.model_loaded:
+            if priority == "live":
+                raise LiveImageClassificationOverloadedError("classify_snapshot_circuit_open") from None
+            raise BackgroundImageClassificationUnavailableError("background_image_circuit_open") from None
+
+        if not self._worker_fallback_state["active"]:
+            self._worker_fallback_state["active"] = True
+            self._worker_fallback_state["reason"] = "circuit_open"
+            self._worker_fallback_state["since_monotonic"] = time.monotonic()
+            log.warning(
+                "classifier_worker_fallback_engaged",
+                reason="circuit_open",
+                detail="isolated workers keep failing; classifying in-process until they recover",
+            )
+        self._worker_fallback_state["classifications"] += 1
+
+        executor = self._live_image_executor if priority == "live" else self._background_image_executor
+        return await asyncio.get_running_loop().run_in_executor(
+            executor,
+            functools.partial(self.classify, image, camera_name, model_id, input_context),
+        )
+
+    def get_worker_fallback_status(self) -> dict[str, Any]:
+        state = self._worker_fallback_state
+        since = state.get("since_monotonic")
+        return {
+            "active": bool(state["active"]),
+            "reason": state["reason"],
+            "active_seconds": (time.monotonic() - float(since)) if state["active"] and since else None,
+            "classifications": int(state["classifications"]),
+        }
 
     async def _run_coordinated_inference(
         self,

--- a/backend/app/services/classifier_supervisor.py
+++ b/backend/app/services/classifier_supervisor.py
@@ -69,6 +69,7 @@ class ClassifierSupervisor:
         video_hard_deadline_seconds: float | None = None,
         worker_ready_timeout_seconds: float = 20.0,
         video_worker_ready_timeout_seconds: float | None = None,
+        warmup_liveness_timeout_seconds: float | None = None,
         worker_factory=None,
         watchdog_interval_seconds: float = 0.05,
         restart_window_seconds: float = 60.0,
@@ -108,6 +109,16 @@ class ClassifierSupervisor:
                 else base_ready_timeout_seconds,
             ),
         }
+        # A cold model load legitimately starves heartbeats for minutes
+        # (native imports and GPU kernel compiles hold the GIL), so until a
+        # worker has completed its first request it is judged against this
+        # longer window instead of the steady-state heartbeat timeout.
+        self._warmup_liveness_timeout_seconds = (
+            max(self._heartbeat_timeout_seconds, float(warmup_liveness_timeout_seconds))
+            if warmup_liveness_timeout_seconds is not None
+            else None
+        )
+        self._completed_once: set[tuple[str, int]] = set()
         self._watchdog_interval_seconds = max(0.01, float(watchdog_interval_seconds))
         self._restart_window_seconds = max(0.01, float(restart_window_seconds))
         self._restart_threshold = max(1, int(restart_threshold))
@@ -633,6 +644,7 @@ class ClassifierSupervisor:
 
             self._assignments.pop(worker_name, None)
             if message["type"] == "result":
+                self._completed_once.add((worker_name, generation))
                 if not assignment.future.done():
                     assignment.future.set_result(list(message["results"]))
             else:
@@ -673,12 +685,23 @@ class ClassifierSupervisor:
                     last_activity = status.get("last_activity_monotonic")
                     if not isinstance(last_activity, (int, float)):
                         last_activity = status.get("last_heartbeat_monotonic")
-                    liveness_reference = (
-                        max(float(last_activity), assignment.started_at)
-                        if isinstance(last_activity, (int, float))
-                        else assignment.started_at
+                    liveness_candidates = [assignment.started_at]
+                    if isinstance(last_activity, (int, float)):
+                        liveness_candidates.append(float(last_activity))
+                    # A worker printing to stderr is demonstrably alive: heavy
+                    # imports chatter there while starving the heartbeat task.
+                    last_stderr = status.get("last_stderr_monotonic")
+                    if isinstance(last_stderr, (int, float)):
+                        liveness_candidates.append(float(last_stderr))
+                    liveness_reference = max(liveness_candidates)
+                    warming_up = (
+                        self._warmup_liveness_timeout_seconds is not None
+                        and (slot.worker_name, slot.worker_generation) not in self._completed_once
                     )
-                    if now - liveness_reference > self._heartbeat_timeout_seconds:
+                    liveness_budget = (
+                        self._warmup_liveness_timeout_seconds if warming_up else self._heartbeat_timeout_seconds
+                    )
+                    if now - liveness_reference > liveness_budget:
                         await self._replace_worker(
                             priority,
                             index,
@@ -687,7 +710,10 @@ class ClassifierSupervisor:
                             kill=True,
                         )
                         continue
-                    if now - assignment.started_at > self._hard_deadline_seconds[priority]:
+                    deadline_budget = self._hard_deadline_seconds[priority]
+                    if warming_up:
+                        deadline_budget = max(deadline_budget, self._warmup_liveness_timeout_seconds)
+                    if now - assignment.started_at > deadline_budget:
                         await self._replace_worker(
                             priority,
                             index,
@@ -714,6 +740,7 @@ class ClassifierSupervisor:
         assignment = self._assignments.pop(slot.worker_name, None)
         if assignment is not None and not assignment.future.done():
             assignment.future.set_exception(assignment_error)
+        self._completed_once.discard((slot.worker_name, slot.worker_generation))
         self._metrics[priority]["restarts"] += 1
         self._metrics[priority]["last_exit_reason"] = reason
         self._metrics[priority]["last_stderr_excerpt"] = str(worker_status.get("recent_stderr_excerpt") or "")

--- a/backend/app/services/classifier_worker_client.py
+++ b/backend/app/services/classifier_worker_client.py
@@ -17,10 +17,13 @@ ProcessFactory = Callable[..., Awaitable[Any]]
 
 _STDERR_NOISE_MARKERS = (
     # Runtime banners emitted at every worker start; they carry no signal
-    # beyond "the runtime initialised", so they log at debug.
+    # beyond "the runtime initialised", so they log at debug. TensorFlow's
+    # own lines are matched by their severity letter: only informational
+    # and warning chatter is noise — E/F lines are faults, below.
     "absl::InitializeLog()",
     "TF-TRT Warning",
-    "tensorflow/core",
+    "I tensorflow/",
+    "W tensorflow/",
 )
 _STDERR_FAULT_MARKERS = (
     "Traceback (most recent call last):",
@@ -28,18 +31,23 @@ _STDERR_FAULT_MARKERS = (
     "Error(",
     "raise ",
     "Exception",
+    "E tensorflow/",
+    "F tensorflow/",
+    "OP_REQUIRES failed",
 )
 
 
 def classify_worker_stderr_severity(text: str) -> str:
     """Errors when there are actual errors: a relayed crash traceback is a
-    warning, a runtime banner is debug, everything else stays info."""
-    for marker in _STDERR_NOISE_MARKERS:
-        if marker in text:
-            return "debug"
+    warning, a runtime banner is debug, everything else stays info. Faults
+    are checked first so a buffer that mixes banner chatter with a crash
+    still surfaces as a warning."""
     for marker in _STDERR_FAULT_MARKERS:
         if marker in text:
             return "warning"
+    for marker in _STDERR_NOISE_MARKERS:
+        if marker in text:
+            return "debug"
     if "error" in text.lower():
         return "warning"
     return "info"

--- a/backend/app/services/openvino_cache.py
+++ b/backend/app/services/openvino_cache.py
@@ -1,0 +1,22 @@
+"""One rule for where OpenVINO keeps its compiled-kernel cache.
+
+A cold GPU compile of a large model takes minutes; the cache is what makes
+that a one-time cost. Under /tmp it dies with the container, so every image
+pull recompiles from scratch — on slow hardware that is the difference
+between a worker that warms up once and one that gets killed mid-load on
+every start. Prefer the persistent models volume when it exists.
+"""
+
+import os
+
+_PERSISTENT_CACHE_DIR = "/data/models/.openvino_cache"
+_EPHEMERAL_CACHE_DIR = "/tmp/openvino_cache"
+
+
+def resolve_openvino_cache_dir() -> str:
+    configured = os.getenv("OPENVINO_CACHE_DIR")
+    if configured:
+        return configured
+    if os.path.isdir("/data/models"):
+        return _PERSISTENT_CACHE_DIR
+    return _EPHEMERAL_CACHE_DIR

--- a/backend/tests/test_classifier_service.py
+++ b/backend/tests/test_classifier_service.py
@@ -1121,7 +1121,9 @@ async def test_classifier_service_can_propagate_supervisor_video_failure_reason(
 
 
 @pytest.mark.asyncio
-async def test_classifier_service_maps_supervisor_circuit_open_to_live_overload(mock_tflite, mock_os_path_exists):
+async def test_classifier_service_circuit_open_falls_back_to_in_process(mock_tflite, mock_os_path_exists):
+    """An open circuit means the workers keep dying; dropping every detection
+    until someone notices is worse than classifying in-process and saying so."""
     original_mode = settings.classification.image_execution_mode
     settings.classification.image_execution_mode = "subprocess"
 
@@ -1129,12 +1131,16 @@ async def test_classifier_service_maps_supervisor_circuit_open_to_live_overload(
         async def classify(self, **_kwargs):
             raise ClassifierWorkerCircuitOpenError("live circuit open")
 
+    sentinel = [{"display_name": "Robin", "score": 0.9, "index": 1}]
     try:
         with patch.object(ClassifierService, "_init_bird_model", new=_stub_init_bird_model):
             service = ClassifierService(supervisor=_FakeSupervisor())
+            service.classify = lambda image, camera_name=None, model_id=None, input_context=None: sentinel
             img = Image.new("RGB", (16, 16), color="green")
-            with pytest.raises(LiveImageClassificationOverloadedError, match="classify_snapshot_circuit_open"):
-                await service.classify_async_live(img, camera_name="front")
+            results = await service.classify_async_live(img, camera_name="front")
+            assert results == sentinel
+            assert service.get_worker_fallback_status()["active"] is True
+            assert service.get_worker_fallback_status()["reason"] == "circuit_open"
             await service.shutdown()
     finally:
         settings.classification.image_execution_mode = original_mode

--- a/backend/tests/test_log_severity_realignment.py
+++ b/backend/tests/test_log_severity_realignment.py
@@ -27,6 +27,34 @@ def test_worker_stderr_severity_reflects_content():
     assert classify_worker_stderr_severity("loading model catalogue") == "info"
 
 
+def test_worker_stderr_severity_keeps_tensorflow_faults_visible():
+    # TensorFlow's own error lines carry the file path all its chatter does;
+    # only the informational severity letters are noise. An E/F line is a
+    # real fault and must never be demoted to debug.
+    assert (
+        classify_worker_stderr_severity(
+            "E tensorflow/core/framework/op_kernel.cc:1616] OP_REQUIRES failed at gather_op.cc:161 : "
+            "INVALID_ARGUMENT: indices[0,0,0] = 5 is not in [0, 4)"
+        )
+        == "warning"
+    )
+    assert classify_worker_stderr_severity("F tensorflow/core/util/some_check.cc:99] check failed") == "warning"
+    assert (
+        classify_worker_stderr_severity(
+            "I0000 00:00:1788107191.829092 199 cpu_feature_guard.cc:227] I tensorflow/core banner"
+        )
+        == "debug"
+    )
+    # A buffer mixing banner chatter with a crash surfaces as a warning.
+    assert (
+        classify_worker_stderr_severity(
+            "I tensorflow/core/platform/cpu_feature_guard.cc:210] oneDNN is on\n"
+            "Traceback (most recent call last):\n  raise RuntimeError('boom')"
+        )
+        == "warning"
+    )
+
+
 def test_expected_frigate_absences_are_not_warnings():
     from app.services import frigate_client
 

--- a/backend/tests/test_worker_liveness_and_fallback.py
+++ b/backend/tests/test_worker_liveness_and_fallback.py
@@ -1,0 +1,267 @@
+"""A worker loading a large model must not be mistaken for a dead one.
+
+Observed in the field (#300 follow-up): the video worker was killed with
+heartbeat_timeout while its stderr was mid-way through TensorFlow's import
+chatter. Heavy runtime imports and cold model compiles hold the GIL in long
+native stretches, starving the heartbeat task even though the worker is
+making progress — and the kill/reload loop means subprocess mode never
+classifies anything on slow hardware. These tests pin the three defences:
+stderr output counts as life, the first load gets a warm-up deadline, and a
+tripped circuit falls back to in-process classification instead of silently
+dropping every detection.
+"""
+
+import asyncio
+import time
+
+import pytest
+from PIL import Image
+
+from app.services.classifier_supervisor import (
+    ClassifierSupervisor,
+    ClassifierWorkerCircuitOpenError,
+    ClassifierWorkerHeartbeatTimeoutError,
+)
+
+
+class _FakeWorker:
+    def __init__(self, worker_name: str, worker_generation: int) -> None:
+        self.worker_name = worker_name
+        self.worker_generation = worker_generation
+        self.sent_messages: list[dict] = []
+        self.events: asyncio.Queue[dict] = asyncio.Queue()
+        self.last_heartbeat_monotonic = time.monotonic()
+        self.last_activity_monotonic: float | None = None
+        self.last_stderr_monotonic: float | None = None
+        self.current_request_id: str | None = None
+        self.busy = False
+        self.exit_code: int | None = None
+        self.killed = False
+
+    async def start(self) -> None:
+        return None
+
+    async def wait_until_ready(self, timeout_seconds: float = 1.0) -> None:
+        return None
+
+    async def send(self, message: dict) -> None:
+        self.sent_messages.append(message)
+        self.current_request_id = message.get("request_id")
+        self.busy = True
+
+    async def next_event(self) -> dict:
+        return await self.events.get()
+
+    async def terminate(self) -> None:
+        return None
+
+    async def kill(self) -> None:
+        self.killed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+    def get_status(self) -> dict:
+        status = {
+            "worker_name": self.worker_name,
+            "worker_generation": self.worker_generation,
+            "ready": True,
+            "busy": self.busy,
+            "current_request_id": self.current_request_id,
+            "last_heartbeat_monotonic": self.last_heartbeat_monotonic,
+            "heartbeat_timeout_seconds": 0.05,
+            "exit_code": self.exit_code,
+            "recent_stderr_excerpt": "",
+            "stderr_truncated_bytes": 0,
+        }
+        if self.last_activity_monotonic is not None:
+            status["last_activity_monotonic"] = self.last_activity_monotonic
+        if self.last_stderr_monotonic is not None:
+            status["last_stderr_monotonic"] = self.last_stderr_monotonic
+        return status
+
+
+def _make_supervisor(_factory, **overrides):
+    kwargs = dict(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.05,
+        hard_deadline_seconds=1.0,
+        worker_factory=_factory,
+        watchdog_interval_seconds=0.01,
+    )
+    kwargs.update(overrides)
+    return ClassifierSupervisor(**kwargs)
+
+
+def _classify_task(supervisor, work_id):
+    return asyncio.create_task(
+        supervisor.classify(
+            priority="live",
+            work_id=work_id,
+            lease_token=2,
+            image_b64="payload",
+            camera_name="front",
+            model_id="default",
+        )
+    )
+
+
+async def _resolve(worker, work_id):
+    await worker.events.put(
+        {
+            "type": "result",
+            "worker_generation": worker.worker_generation,
+            "request_id": worker.current_request_id,
+            "work_id": work_id,
+            "lease_token": 2,
+            "results": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_writing_stderr_is_alive_even_when_heartbeats_starve():
+    created: list[_FakeWorker] = []
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        worker = _FakeWorker(worker_name, worker_generation)
+        created.append(worker)
+        return worker
+
+    supervisor = _make_supervisor(_factory)
+    await supervisor.start()
+
+    task = _classify_task(supervisor, "live-loading")
+    await asyncio.sleep(0.01)
+    # Heartbeats starved for a full second, but stderr keeps chattering the
+    # way a TensorFlow import does — long past the assignment's own age.
+    for _ in range(4):
+        created[0].last_heartbeat_monotonic = time.monotonic() - 1.0
+        created[0].last_stderr_monotonic = time.monotonic()
+        await asyncio.sleep(0.03)
+
+    assert task.done() is False
+    assert created[0].killed is False
+
+    await _resolve(created[0], "live-loading")
+    assert await task == []
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_first_load_gets_a_warmup_deadline_then_normal_liveness_applies():
+    created: list[_FakeWorker] = []
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        worker = _FakeWorker(worker_name, worker_generation)
+        created.append(worker)
+        return worker
+
+    supervisor = _make_supervisor(_factory, warmup_liveness_timeout_seconds=10.0)
+    await supervisor.start()
+
+    # First request: everything silent well past the heartbeat timeout, but
+    # the worker has never completed a request — this is a cold model load.
+    task = _classify_task(supervisor, "live-first")
+    await asyncio.sleep(0.01)
+    created[0].last_heartbeat_monotonic = time.monotonic() - 1.0
+    await asyncio.sleep(0.05)
+
+    assert task.done() is False
+    assert created[0].killed is False
+
+    await _resolve(created[0], "live-first")
+    assert await task == []
+
+    # Second request: warmed up now, so the steady-state timeout applies.
+    task = _classify_task(supervisor, "live-second")
+    await asyncio.sleep(0.01)
+    created[0].last_heartbeat_monotonic = time.monotonic() - 1.0
+    with pytest.raises(ClassifierWorkerHeartbeatTimeoutError):
+        await task
+    assert created[0].killed is True
+
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_warmup_extends_the_hard_deadline_until_the_first_result():
+    created: list[_FakeWorker] = []
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        worker = _FakeWorker(worker_name, worker_generation)
+        created.append(worker)
+        return worker
+
+    supervisor = _make_supervisor(
+        _factory,
+        hard_deadline_seconds=0.05,
+        warmup_liveness_timeout_seconds=10.0,
+    )
+    await supervisor.start()
+
+    task = _classify_task(supervisor, "live-slow-load")
+    await asyncio.sleep(0.01)
+    # Keep heartbeats fresh; only the assignment age crosses the hard deadline.
+    created[0].last_heartbeat_monotonic = time.monotonic()
+    await asyncio.sleep(0.08)
+    created[0].last_heartbeat_monotonic = time.monotonic()
+
+    assert task.done() is False
+    assert created[0].killed is False
+
+    await _resolve(created[0], "live-slow-load")
+    assert await task == []
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_circuit_open_falls_back_to_in_process_and_says_so():
+    from app.services.classifier_service import ClassifierService
+
+    service = ClassifierService()
+
+    class _TrippedSupervisor:
+        async def classify(self, **_kwargs):
+            raise ClassifierWorkerCircuitOpenError("live classifier circuit is open")
+
+    loads: list[str] = []
+
+    class _LoadedModel:
+        loaded = True
+
+    def _fake_init() -> None:
+        loads.append("load")
+        service._models["bird"] = _LoadedModel()
+
+    sentinel = [{"display_name": "Robin", "score": 0.9}]
+    service._classifier_supervisor = _TrippedSupervisor()
+    service._init_bird_model = _fake_init
+    service.classify = lambda image, camera_name=None, model_id=None, input_context=None: sentinel
+
+    image = Image.new("RGB", (8, 8))
+    results = await service._run_supervised_inference("live", image, "front", None)
+    assert results == sentinel
+
+    fallback = service.get_worker_fallback_status()
+    assert fallback["active"] is True
+    assert fallback["reason"] == "circuit_open"
+
+    # A second call reuses the loaded model instead of loading again.
+    await service._run_supervised_inference("live", image, "front", None)
+    assert loads == ["load"]
+
+
+def test_openvino_cache_prefers_the_persistent_models_volume(monkeypatch):
+    from app.services import openvino_cache
+
+    monkeypatch.delenv("OPENVINO_CACHE_DIR", raising=False)
+    monkeypatch.setattr(openvino_cache.os.path, "isdir", lambda p: p == "/data/models")
+    assert openvino_cache.resolve_openvino_cache_dir() == "/data/models/.openvino_cache"
+
+    monkeypatch.setattr(openvino_cache.os.path, "isdir", lambda p: False)
+    assert openvino_cache.resolve_openvino_cache_dir() == "/tmp/openvino_cache"
+
+    monkeypatch.setenv("OPENVINO_CACHE_DIR", "/custom/cache")
+    assert openvino_cache.resolve_openvino_cache_dir() == "/custom/cache"


### PR DESCRIPTION
## Outcome

Hardens subprocess inference against the failure reported in [#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)'s follow-up: on slower hardware the worker was killed with `heartbeat_timeout` mid-model-load (its stderr caught mid-way through TensorFlow's import chatter), and the kill/reload loop meant **subprocess mode never classified anything** — reported as detections simply stopping until the owner reverted to in-process.

## Included

- **Stderr counts as proof of life.** The watchdog's liveness reference now includes `last_stderr_monotonic` — a worker chattering through an import is not hung.
- **Warm-up deadline.** Until a worker completes its first request it is judged against `worker_first_load_grace_seconds` (default 180s) instead of the 5s steady-state heartbeat window; the hard deadline stretches the same way. Existing steady-state behaviour is unchanged after the first result.
- **Honest fallback.** If the circuit still opens, classification runs in the main process instead of dropping every detection: the status endpoint reports `worker_in_process_fallback`, the Detection band shows it in amber (i18n'd, nine locales), and the state clears on the next supervised success.
- **Persistent OpenVINO kernel cache** (`/data/models/.openvino_cache` when the volume exists) so the expensive first GPU compile is paid once per model, not per container start.

## Verification

Six new tests: stderr-keeps-alive, warm-up-then-steady-state, warm-up-extends-hard-deadline, circuit-open fallback (returns results, records status, loads the model once), and cache-dir resolution; the old circuit-open-raises test updated to pin the new contract. Full suites green: 2,597 backend, 979 frontend, svelte-check 0/0, repo-wide ruff clean.