### PR TITLE
Clear the compile cache when a model is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Deleting a model also clears the compile cache.** The OpenVINO kernel cache now lives on the
+  persistent volume, and its blobs are keyed by opaque model hashes — so a deleted model's
+  compiled kernels (hundreds of megabytes for a large model) would otherwise sit there forever
+  with no way to map them back. Deleting a model empties the cache; the surviving models pay one
+  recompile, which the warm-up window covers, and cache themselves fresh. Model changes were
+  never at risk: the hash keying means a blob can only ever be reused by the exact model that
+  produced it.
+
 - **A worker loading a large model is no longer mistaken for a dead one.** Observed in the field:
   the supervisor killed a worker with "heartbeat timeout" while its stderr was mid-way through
   TensorFlow's import chatter — heavy imports and cold GPU model compiles hold the GIL long enough

--- a/backend/app/services/model_manager.py
+++ b/backend/app/services/model_manager.py
@@ -11,6 +11,7 @@ import aiofiles
 import httpx
 import structlog
 from datetime import datetime, UTC
+from app.services.openvino_cache import clear_openvino_cache, resolve_openvino_cache_dir
 from typing import Any, List, Optional, Dict
 from app.models.ai_models import CropGeneratorConfig, ModelMetadata, InstalledModel, DownloadProgress
 from app.config import settings
@@ -1690,7 +1691,16 @@ class ModelManager:
         freed = _directory_size_bytes(target)
         shutil.rmtree(target)
         _remove_empty_family_dir(os.path.dirname(target), models_root)
-        log.info("Deleted installed model", model_id=candidate, bytes_freed=freed)
+        # The compile cache keys blobs by opaque model hashes, so the deleted
+        # model's kernels cannot be reclaimed individually — clear it all and
+        # let the surviving models recompile once into a fresh cache.
+        cache_freed = clear_openvino_cache(resolve_openvino_cache_dir())
+        log.info(
+            "Deleted installed model",
+            model_id=candidate,
+            bytes_freed=freed,
+            compile_cache_bytes_freed=cache_freed,
+        )
         return freed
 
     def get_download_status(self, model_id: str) -> Optional[DownloadProgress]:

--- a/backend/app/services/openvino_cache.py
+++ b/backend/app/services/openvino_cache.py
@@ -7,7 +7,9 @@ between a worker that warms up once and one that gets killed mid-load on
 every start. Prefer the persistent models volume when it exists.
 """
 
+import contextlib
 import os
+import shutil
 
 _PERSISTENT_CACHE_DIR = "/data/models/.openvino_cache"
 _EPHEMERAL_CACHE_DIR = "/tmp/openvino_cache"
@@ -20,3 +22,32 @@ def resolve_openvino_cache_dir() -> str:
     if os.path.isdir("/data/models"):
         return _PERSISTENT_CACHE_DIR
     return _EPHEMERAL_CACHE_DIR
+
+
+def clear_openvino_cache(cache_dir: str | None = None) -> int:
+    """Empty the compile cache, returning the bytes reclaimed.
+
+    Blobs are keyed by opaque model hashes, so a deleted model's kernels
+    cannot be reclaimed individually; clearing everything is the honest
+    move — surviving models recompile once and re-cache. Safe to call when
+    the directory does not exist.
+    """
+    if cache_dir is None:
+        cache_dir = resolve_openvino_cache_dir()
+    if not os.path.isdir(cache_dir):
+        return 0
+    freed = 0
+    for entry in os.scandir(cache_dir):
+        try:
+            if entry.is_file(follow_symlinks=False):
+                freed += entry.stat(follow_symlinks=False).st_size
+                os.unlink(entry.path)
+            elif entry.is_dir(follow_symlinks=False):
+                for root, _dirs, files in os.walk(entry.path):
+                    for name in files:
+                        with contextlib.suppress(OSError):
+                            freed += os.path.getsize(os.path.join(root, name))
+                shutil.rmtree(entry.path, ignore_errors=True)
+        except OSError:
+            continue
+    return freed

--- a/backend/tests/test_model_deletion.py
+++ b/backend/tests/test_model_deletion.py
@@ -198,3 +198,32 @@ async def test_the_api_addresses_a_nested_region_variant(models_dir, monkeypatch
     assert response.status_code == 200
     assert not (models_dir / "medium_birds" / "eu").exists()
     assert (models_dir / "medium_birds" / "na" / "model.onnx").exists()
+
+
+def test_deleting_a_model_clears_the_openvino_compile_cache(models_dir, tmp_path, monkeypatch):
+    """Cache blobs are keyed by opaque model hashes, so a deleted model's
+    compiled kernels can never be mapped back and reclaimed individually.
+    Clearing the whole cache on delete keeps the persistent volume honest;
+    the surviving models pay one recompile, which the warm-up window covers."""
+    cache_dir = tmp_path / "ov_cache"
+    cache_dir.mkdir()
+    (cache_dir / "abc123.blob").write_bytes(b"y" * 64)
+    monkeypatch.setattr(
+        "app.services.model_manager.resolve_openvino_cache_dir",
+        lambda: str(cache_dir),
+    )
+
+    _install(models_dir, "spare_model")
+    model_manager.delete_installed_model("spare_model", active_model_id="other")
+
+    assert not any(cache_dir.iterdir())
+
+
+def test_deleting_a_model_survives_a_missing_cache_directory(models_dir, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.model_manager.resolve_openvino_cache_dir",
+        lambda: str(tmp_path / "never_created"),
+    )
+    _install(models_dir, "spare_model")
+    freed = model_manager.delete_installed_model("spare_model", active_model_id="other")
+    assert freed > 0


### PR DESCRIPTION
## Outcome

Follow-up to #350's persistent OpenVINO cache. Cache blobs are keyed by opaque model hashes, so a deleted model's compiled kernels — hundreds of MB for a large model — would sit on the persistent volume forever, unmappable to their owner. Deleting a model now clears the compile cache; surviving models recompile once (inside the new warm-up window) and re-cache fresh.

Model *switching* is unaffected and safe by construction: the hash keying means a blob is only ever reused by the exact model that produced it, so co-installed models' blobs coexist without any poisoning risk.

## Verification

Two new tests: deletion empties the cache directory, and deletion survives the cache directory not existing. Full backend suite green: 2,600 tests; repo-wide ruff clean.