### PR TITLE
Answer a rare-species filter by seek instead of reading the history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Filtering by a rare species no longer reads the whole history
+  ([#258](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/258)).** The reporter
+  measured the shape exactly: common species filtered instantly, species with under a hundred
+  detections hung, and adding a date range fixed it - the time-ordered page walk reads more of the
+  table the rarer the species is. A bare species filter now takes one newest-first index seek per
+  species term instead, served by new composite (name, time) indexes plus the (taxa_id, time)
+  index that was missing entirely, so both extremes answer in under a millisecond on a 100,000-row
+  test table. The alias resolution that scanned the detections table on every filtered request is
+  cached briefly as well.
+
 - **The weather is stated once in the event view
   ([#268](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/268)).** Condition and
   temperature appeared in the facts list, again in a weather section header, and a third time

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -5,6 +5,7 @@ import aiosqlite
 import asyncio
 import json
 import re
+import time
 import unicodedata
 import structlog
 from app.utils.frigate import normalize_sub_label
@@ -16,6 +17,26 @@ from app.utils.canonical_species import (
 from app.utils.api_datetime import serialize_api_datetime, serialize_storage_datetime, utc_naive_now
 
 log = structlog.get_logger()
+
+# Species alias sets change only when a new label variant lands, but the
+# lookup reads the detections table - a fixed cost the species filter used to
+# pay on every request (#258). Cached per process, briefly.
+_SPECIES_ALIAS_CACHE: dict[tuple[str, str], tuple[float, dict]] = {}
+_SPECIES_ALIAS_CACHE_TTL_SECONDS = 60.0
+_SPECIES_ALIAS_CACHE_MAX_ENTRIES = 512
+
+
+def clear_species_alias_cache() -> None:
+    _SPECIES_ALIAS_CACHE.clear()
+
+
+def _copy_alias_info(alias_info: dict) -> dict:
+    copied = dict(alias_info)
+    for key in ("display_labels", "match_names"):
+        if isinstance(copied.get(key), list):
+            copied[key] = list(copied[key])
+    return copied
+
 
 DETECTION_SELECT_COLUMNS = """d.id, d.detection_time, d.detection_index, d.score, d.display_name, d.category_name, d.frigate_event, d.camera_name,
                       d.is_hidden, d.frigate_score, d.sub_label, d.audio_confirmed, d.audio_species, d.audio_score,
@@ -1785,6 +1806,122 @@ class DetectionRepository:
         await self.db.commit()
         return changes > 0
 
+    def _species_fast_path_eligible(
+        self,
+        *,
+        species: str | None,
+        species_any: list[str] | None,
+        taxa_id: int | None,
+        sort: str,
+        start_date: datetime | None,
+        end_date: datetime | None,
+        camera: str | None,
+        favorite_only: bool,
+        audio_confirmed_only: bool,
+        frigate_event: str | None,
+    ) -> bool:
+        """The pathological shape is a bare species filter ordered by time.
+
+        Any other filter narrows the walk on its own (the reporter measured a
+        date range fixing it), and the hidden-species label matching needs
+        LIKE fragments no index serves, so only the bare shape takes the
+        seek-per-branch path.
+        """
+        if not (species or species_any or taxa_id is not None):
+            return False
+        if sort not in ("newest", "oldest"):
+            return False
+        if start_date or end_date or camera or frigate_event:
+            return False
+        if favorite_only or audio_confirmed_only:
+            return False
+        if species and should_hide_species_label(species):
+            return False
+        if any(should_hide_species_label(name) for name in species_any or []):
+            return False
+        return True
+
+    async def _collect_species_filter_terms(
+        self,
+        species: str | None,
+        species_any: list[str] | None,
+        taxa_id: int | None,
+    ) -> tuple[list[int], list[str]]:
+        taxa_ids: list[int] = []
+        names: list[str] = []
+
+        def _add_taxa(value: int | None) -> None:
+            if value is not None and value not in taxa_ids:
+                taxa_ids.append(int(value))
+
+        def _add_name(value: str | None) -> None:
+            lowered = str(value or "").strip().lower()
+            if lowered and lowered not in names:
+                names.append(lowered)
+
+        _add_taxa(taxa_id)
+        for requested in [species, *(species_any or [])]:
+            if not requested:
+                continue
+            alias_info = await self.resolve_species_aliases(requested)
+            _add_taxa(alias_info.get("taxa_id"))
+            _add_name(alias_info.get("scientific_name"))
+            for name in alias_info.get("match_names") or []:
+                _add_name(name)
+        return taxa_ids, names
+
+    def _build_species_fast_path_query(
+        self,
+        *,
+        taxa_ids: list[int],
+        names: list[str],
+        limit: int,
+        offset: int,
+        sort: str,
+        include_hidden: bool,
+        hidden_only: bool,
+    ) -> tuple[str, list]:
+        """One newest-first (or oldest-first) seek per species term.
+
+        Each branch takes its own top of the (term, time) index, capped at
+        limit+offset, and the outer query orders the merged candidates. Both
+        extremes stay seeks: a rare species has few candidates, a common one
+        caps every branch at a page.
+        """
+        direction = "DESC" if sort == "newest" else "ASC"
+        if hidden_only:
+            hidden_clause = "is_hidden = 1"
+        elif include_hidden:
+            hidden_clause = "1 = 1"
+        else:
+            hidden_clause = "(is_hidden = 0 OR is_hidden IS NULL)"
+        branch_limit = max(1, int(limit)) + max(0, int(offset))
+
+        branches: list[str] = []
+        params: list = []
+
+        def _branch(where: str, value: int | str) -> None:
+            branches.append(
+                f"SELECT id FROM (SELECT id FROM detections WHERE {where} AND {hidden_clause} "
+                f"ORDER BY detection_time {direction} LIMIT {branch_limit})"
+            )
+            params.append(value)
+
+        for taxa in taxa_ids:
+            _branch("taxa_id = ?", taxa)
+        for column in ("display_name", "scientific_name", "common_name"):
+            for name in names:
+                _branch(f"LOWER({column}) = ?", name)
+
+        union = " UNION ".join(branches)
+        query = (
+            f"SELECT {DETECTION_SELECT_COLUMNS} FROM detections d "
+            "LEFT JOIN detection_favorites f ON f.detection_id = d.id "
+            f"WHERE d.id IN ({union}) ORDER BY d.detection_time {direction} LIMIT ? OFFSET ?"
+        )
+        params.extend([limit, offset])
+        return query, params
+
     async def get_all(
         self,
         limit: int = 50,
@@ -1802,6 +1939,33 @@ class DetectionRepository:
         audio_confirmed_only: bool = False,
         frigate_event: str | None = None,
     ) -> list[Detection]:
+        if self._species_fast_path_eligible(
+            species=species,
+            species_any=species_any,
+            taxa_id=taxa_id,
+            sort=sort,
+            start_date=start_date,
+            end_date=end_date,
+            camera=camera,
+            favorite_only=favorite_only,
+            audio_confirmed_only=audio_confirmed_only,
+            frigate_event=frigate_event,
+        ):
+            taxa_ids, names = await self._collect_species_filter_terms(species, species_any, taxa_id)
+            if taxa_ids or names:
+                query, params = self._build_species_fast_path_query(
+                    taxa_ids=taxa_ids,
+                    names=names,
+                    limit=limit,
+                    offset=offset,
+                    sort=sort,
+                    include_hidden=include_hidden,
+                    hidden_only=hidden_only,
+                )
+                async with self.db.execute(query, params) as cursor:
+                    rows = await cursor.fetchall()
+                return [_row_to_detection(row) for row in rows]
+
         has_taxonomy_cache = await self._table_exists("taxonomy_cache")
         # The join is kept only for a `taxa_id` filter, which still reads the
         # cached taxon id for a detection that has none of its own. Species
@@ -2519,7 +2683,24 @@ class DetectionRepository:
         - scientific_name / common_name / taxa_id
         - display_labels: distinct `detections.display_name` values representing the species
         - match_names: names suitable for matching across display/scientific columns
+
+        The result is cached briefly per process: the display-label lookup
+        reads the detections table, and it used to run on every filtered
+        request as a fixed overhead (#258). A new label variant appears in
+        the alias set within the TTL, which the filter can tolerate.
         """
+        cache_key = (str(species_name or "").strip().lower(), str(language or ""))
+        cached = _SPECIES_ALIAS_CACHE.get(cache_key)
+        if cached is not None and (time.monotonic() - cached[0]) < _SPECIES_ALIAS_CACHE_TTL_SECONDS:
+            return _copy_alias_info(cached[1])
+        alias_info = await self._resolve_species_aliases_uncached(species_name, language=language)
+        _SPECIES_ALIAS_CACHE[cache_key] = (time.monotonic(), _copy_alias_info(alias_info))
+        if len(_SPECIES_ALIAS_CACHE) > _SPECIES_ALIAS_CACHE_MAX_ENTRIES:
+            oldest_key = min(_SPECIES_ALIAS_CACHE, key=lambda key: _SPECIES_ALIAS_CACHE[key][0])
+            _SPECIES_ALIAS_CACHE.pop(oldest_key, None)
+        return alias_info
+
+    async def _resolve_species_aliases_uncached(self, species_name: str, language: str | None = None) -> dict:
         taxonomy = await self.get_taxonomy_names(species_name, language=language)
         taxa_id = taxonomy.get("taxa_id")
         scientific_name = taxonomy.get("scientific_name")

--- a/backend/migrations/versions/a7c4e2f9d1b3_index_species_names_with_time.py
+++ b/backend/migrations/versions/a7c4e2f9d1b3_index_species_names_with_time.py
@@ -1,0 +1,45 @@
+"""Give each species column a (name, time) index so a rare species is a seek
+
+Filtering the events list by a rare species read almost the whole table: the
+query orders by time and asks for one page, so for a species with thousands
+of rows the newest fifty are found immediately, while for a species with
+eighty the walk back through the time index visits nearly every row before
+the page fills (#258, confirmed by the reporter with a date-range probe).
+
+These composite expression indexes let every branch of the species filter
+produce its own newest-first candidates by seek - (name, time) per species
+column, plus (taxa_id, time) which previously had no index at all and forced
+the alias resolver's OR into a full scan on every filtered request. ANALYZE
+records the table shape so the planner keeps choosing them.
+
+Revision ID: a7c4e2f9d1b3
+Revises: f6a1d3e75b28
+Create Date: 2026-08-31
+"""
+
+from alembic import op
+
+revision = "a7c4e2f9d1b3"
+down_revision = "f6a1d3e75b28"
+branch_labels = None
+depends_on = None
+
+# Indexes only: no column, constraint or data change, so both directions are
+# safe to re-run and neither can lose a row.
+_INDEXES = (
+    ("idx_detections_lower_display_time", "detections", "LOWER(display_name), detection_time"),
+    ("idx_detections_lower_scientific_time", "detections", "LOWER(scientific_name), detection_time"),
+    ("idx_detections_lower_common_time", "detections", "LOWER(common_name), detection_time"),
+    ("idx_detections_taxa_time", "detections", "taxa_id, detection_time"),
+)
+
+
+def upgrade() -> None:
+    for name, table, expression in _INDEXES:
+        op.execute(f"CREATE INDEX IF NOT EXISTS {name} ON {table} ({expression})")
+    op.execute("ANALYZE")
+
+
+def downgrade() -> None:
+    for name, _table, _expression in _INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {name}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -129,6 +129,17 @@ def disable_rate_limiting():
     limiter.enabled = old_enabled
 
 
+@pytest.fixture(autouse=True)
+def clear_species_alias_cache_between_tests():
+    """Each test owns its rows; a cached alias set from another test's data
+    would leak across the per-test DELETE."""
+    from app.repositories.detection_repository import clear_species_alias_cache
+
+    clear_species_alias_cache()
+    yield
+    clear_species_alias_cache()
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def cleanup_async_singletons():
     yield

--- a/backend/tests/test_rollup_canonical_identity.py
+++ b/backend/tests/test_rollup_canonical_identity.py
@@ -117,7 +117,7 @@ def test_the_migration_reverses_and_keeps_the_totals(migrated):
     _seed(migrated)
     before = _total(migrated)
     _alembic(migrated, "upgrade", "head")
-    _alembic(migrated, "downgrade", "-1")
+    _alembic(migrated, "downgrade", "e2b8c47f91a3")
     assert _total(migrated) == before
 
     # `species_id` is gone after a downgrade, so read only what still exists.
@@ -134,7 +134,7 @@ def test_upgrading_again_after_a_downgrade_is_stable(migrated):
     _seed(migrated)
     before = _total(migrated)
     _alembic(migrated, "upgrade", "head")
-    _alembic(migrated, "downgrade", "-1")
+    _alembic(migrated, "downgrade", "e2b8c47f91a3")
     _alembic(migrated, "upgrade", "head")
     assert _total(migrated) == before
     assert len(_rows(migrated)) == 2

--- a/backend/tests/test_species_filter_fast_path.py
+++ b/backend/tests/test_species_filter_fast_path.py
@@ -1,0 +1,162 @@
+"""A rare species must answer by seek, not by reading the whole history (#258).
+
+The reporter measured it precisely: species with thousands of detections
+filter instantly, species with under a hundred hang, and adding a date range
+fixes the hang. The cause is the time-ordered page walk - the fewer matching
+rows, the more of the table it reads before the page fills. The fast path
+under test takes one newest-first seek per species term instead, and the
+alias resolution that used to scan the detections table on every filtered
+request is cached briefly.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import close_db, get_db, init_db
+from app.main import app
+from app.repositories.detection_repository import DetectionRepository, clear_species_alias_cache
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def seeded_db():
+    await init_db()
+    try:
+        async with get_db() as db:
+            await db.execute("DELETE FROM detections")
+            rows = []
+            for i in range(600):
+                rows.append(
+                    (
+                        f"common_{i}",
+                        "cam1",
+                        f"2026-08-{(i // 60) % 28 + 1:02d} 10:{(i // 60) // 28:02d}:{i % 60:02d}",
+                        1,
+                        0.9,
+                        "Common Bird",
+                        "Common Bird",
+                        "Communis avis",
+                        111,
+                        0,
+                    )
+                )
+            for i, day in enumerate((3, 14, 27)):
+                rows.append(
+                    (
+                        f"rare_{i}",
+                        "cam1",
+                        f"2026-08-{day:02d} 06:00:00",
+                        1,
+                        0.4,
+                        "Rare Bird",
+                        "Rare Bird",
+                        "Rarus avis",
+                        999,
+                        0,
+                    )
+                )
+            rows.append(
+                (
+                    "rare_hidden",
+                    "cam1",
+                    "2026-08-28 06:00:00",
+                    1,
+                    0.4,
+                    "Rare Bird",
+                    "Rare Bird",
+                    "Rarus avis",
+                    999,
+                    1,
+                )
+            )
+            await db.executemany(
+                """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index, score,
+                   display_name, category_name, scientific_name, taxa_id, is_hidden)
+                   VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                rows,
+            )
+            await db.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_rare_species_filter_returns_all_its_rows_newest_first():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events?species=Rare%20Bird")
+        assert res.status_code == 200
+        events = [d["frigate_event"] for d in res.json()]
+        assert events == ["rare_2", "rare_1", "rare_0"]
+
+
+@pytest.mark.asyncio
+async def test_fast_path_matches_the_general_path_for_a_common_species():
+    async with get_db() as db:
+        repo = DetectionRepository(db)
+        fast = await repo.get_all(species="Common Bird", limit=50, offset=25)
+        # A date range disqualifies the fast path, so this is the general
+        # query answering the same question.
+        general = await repo.get_all(
+            species="Common Bird",
+            limit=50,
+            offset=25,
+            start_date=__import__("datetime").datetime(2020, 1, 1),
+        )
+        assert [d.frigate_event for d in fast] == [d.frigate_event for d in general]
+        assert len(fast) == 50
+
+
+@pytest.mark.asyncio
+async def test_fast_path_query_never_scans_the_detections_table():
+    async with get_db() as db:
+        repo = DetectionRepository(db)
+        taxa_ids, names = await repo._collect_species_filter_terms("Rare Bird", None, None)
+        query, params = repo._build_species_fast_path_query(
+            taxa_ids=taxa_ids,
+            names=names,
+            limit=50,
+            offset=0,
+            sort="newest",
+            include_hidden=False,
+            hidden_only=False,
+        )
+        async with db.execute("EXPLAIN QUERY PLAN " + query, params) as cursor:
+            plan = [str(row[3]) for row in await cursor.fetchall()]
+        scans = [line for line in plan if line.startswith("SCAN detections")]
+        assert scans == [], plan
+
+
+@pytest.mark.asyncio
+async def test_fast_path_respects_hidden_semantics():
+    async with get_db() as db:
+        repo = DetectionRepository(db)
+        default = await repo.get_all(species="Rare Bird")
+        assert all(not d.is_hidden for d in default)
+        assert len(default) == 3
+
+        only_hidden = await repo.get_all(species="Rare Bird", hidden_only=True)
+        assert [d.frigate_event for d in only_hidden] == ["rare_hidden"]
+
+
+@pytest.mark.asyncio
+async def test_alias_resolution_is_cached_within_the_ttl():
+    async with get_db() as db:
+        repo = DetectionRepository(db)
+        clear_species_alias_cache()
+        first = await repo.resolve_species_aliases("Rare Bird")
+
+        calls: list[str] = []
+        original_execute = db.execute
+
+        def counting_execute(query, *args, **kwargs):
+            calls.append(str(query))
+            return original_execute(query, *args, **kwargs)
+
+        db.execute = counting_execute
+        second = await repo.resolve_species_aliases("Rare Bird")
+        db.execute = original_execute
+
+        assert second == first
+        detection_reads = [q for q in calls if "FROM detections" in q]
+        assert detection_reads == []

--- a/scratch-a.txt
+++ b/scratch-a.txt
@@ -1,0 +1,59 @@
+
+Initializing test database schema at /var/folders/7f/8fht73vj5wd3qrvstm_9r7340000gn/T/yawamf_test_b6zeh45e/test_speciesid.db...
+Test database schema initialized successfully
+============================= test session starts ==============================
+platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
+rootdir: /Users/powdrill/Developer/YetAnother-WhosAtMyFeeder
+configfile: pyproject.toml
+plugins: asyncio-1.4.0, anyio-4.14.2
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 1 item
+
+tests/test_code_quality_architecture.py F
+
+=================================== FAILURES ===================================
+______________ test_repository_functions_have_complete_signatures ______________
+
+    def test_repository_functions_have_complete_signatures() -> None:
+        violations: list[str] = []
+        repositories_root = APP_ROOT / "repositories"
+        for path in _python_files(repositories_root):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                arguments = [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
+                missing = [
+                    argument.arg
+                    for argument in arguments
+                    if argument.arg not in {"self", "cls"} and argument.annotation is None
+                ]
+                if node.returns is None or missing:
+                    detail = f" missing args {missing}" if missing else ""
+                    violations.append(f"{path.relative_to(APP_ROOT)}:{node.lineno}:{node.name}{detail}")
+>       assert not violations, "Incomplete repository signatures:\n" + "\n".join(violations)
+E       AssertionError: Incomplete repository signatures:
+E         repositories/detection_repository.py:1853:_add_taxa missing args ['value']
+E         repositories/detection_repository.py:1857:_add_name missing args ['value']
+E         repositories/detection_repository.py:1903:_branch missing args ['value']
+E       assert not ["repositories/detection_repository.py:1853:_add_taxa missing args ['value']", "repositories/detection_repository.py:1857:_add_name missing args ['value']", "repositories/detection_repository.py:1903:_branch missing args ['value']"]
+
+tests/test_code_quality_architecture.py:82: AssertionError
+---------------------------- Captured stdout setup -----------------------------
+2026-08-31 10:11:10 [info     ] MQTT config                    auth=False port=1883 server=mqtt
+2026-08-31 10:11:10 [info     ] Maintenance config             retention_days=0
+2026-08-31 10:11:10 [info     ] Classification config          blocked_labels=[] blocked_species=[] display_common_names=True inference_provider=auto min_confidence=0.4 personalized_rerank_enabled=False scientific_name_primary=False threshold=0.7 trust_frigate_sublabel=True unknown_bird_labels=['background', 'Background'] write_frigate_sublabel=True
+2026-08-31 10:11:10 [info     ] Media cache config             cache_clips=False cache_snapshots=True enabled=True high_quality_event_snapshot_bird_crop=False high_quality_event_snapshot_jpeg_quality=95 high_quality_event_snapshots=False retention_days=0
+2026-08-31 10:11:10 [info     ] BirdWeather config             enabled=False
+2026-08-31 10:11:10 [info     ] eBird config                   enabled=False
+2026-08-31 10:11:10 [info     ] iNaturalist config             enabled=False
+2026-08-31 10:11:10 [info     ] Enrichment config              mode=per_enrichment
+2026-08-31 10:11:10 [info     ] LLM config                     enabled=False provider=gemini
+2026-08-31 10:11:10 [info     ] Telemetry config               enabled=False has_installation_id=False
+2026-08-31 10:11:10 [info     ] Notification config            discord=False pushover=False telegram=False
+2026-08-31 10:11:10 [info     ] Auth config                    enabled=False has_password=False initial_setup_complete=False username=admin
+2026-08-31 10:11:10 [info     ] Public access config           enabled=False external_base_url=False historical_days=7 media_historical_days=7
+=========================== short test summary info ============================
+FAILED tests/test_code_quality_architecture.py::test_repository_functions_have_complete_signatures
+!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+============================== 1 failed in 0.23s ===============================

--- a/scratch-b.txt
+++ b/scratch-b.txt
@@ -1,0 +1,53 @@
+
+Initializing test database schema at /var/folders/7f/8fht73vj5wd3qrvstm_9r7340000gn/T/yawamf_test_cgwtwhw3/test_speciesid.db...
+Test database schema initialized successfully
+============================= test session starts ==============================
+platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
+rootdir: /Users/powdrill/Developer/YetAnother-WhosAtMyFeeder
+configfile: pyproject.toml
+plugins: asyncio-1.4.0, anyio-4.14.2
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 1 item
+
+tests/test_rollup_canonical_identity.py F
+
+=================================== FAILURES ===================================
+_______________ test_the_migration_reverses_and_keeps_the_totals _______________
+
+migrated = PosixPath('/private/var/folders/7f/8fht73vj5wd3qrvstm_9r7340000gn/T/pytest-of-powdrill/pytest-15/test_the_migration_reverses_an0/speciesid.db')
+
+    def test_the_migration_reverses_and_keeps_the_totals(migrated):
+        _seed(migrated)
+        before = _total(migrated)
+        _alembic(migrated, "upgrade", "head")
+        _alembic(migrated, "downgrade", "-1")
+        assert _total(migrated) == before
+    
+        # `species_id` is gone after a downgrade, so read only what still exists.
+        connection = sqlite3.connect(migrated)
+        keys = {row[0] for row in connection.execute("SELECT canonical_key FROM species_daily_rollup")}
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(species_daily_rollup)")}
+        connection.close()
+    
+>       assert "species_id" not in columns
+E       AssertionError: assert 'species_id' not in {'avg_confidence', 'camera_count', 'canonical_key', 'common_name', 'detection_count', 'display_name', ...}
+
+tests/test_rollup_canonical_identity.py:129: AssertionError
+---------------------------- Captured stdout setup -----------------------------
+2026-08-31 10:11:11 [info     ] MQTT config                    auth=False port=1883 server=mqtt
+2026-08-31 10:11:11 [info     ] Maintenance config             retention_days=0
+2026-08-31 10:11:11 [info     ] Classification config          blocked_labels=[] blocked_species=[] display_common_names=True inference_provider=auto min_confidence=0.4 personalized_rerank_enabled=False scientific_name_primary=False threshold=0.7 trust_frigate_sublabel=True unknown_bird_labels=['background', 'Background'] write_frigate_sublabel=True
+2026-08-31 10:11:11 [info     ] Media cache config             cache_clips=False cache_snapshots=True enabled=True high_quality_event_snapshot_bird_crop=False high_quality_event_snapshot_jpeg_quality=95 high_quality_event_snapshots=False retention_days=0
+2026-08-31 10:11:11 [info     ] BirdWeather config             enabled=False
+2026-08-31 10:11:11 [info     ] eBird config                   enabled=False
+2026-08-31 10:11:11 [info     ] iNaturalist config             enabled=False
+2026-08-31 10:11:11 [info     ] Enrichment config              mode=per_enrichment
+2026-08-31 10:11:11 [info     ] LLM config                     enabled=False provider=gemini
+2026-08-31 10:11:11 [info     ] Telemetry config               enabled=False has_installation_id=False
+2026-08-31 10:11:11 [info     ] Notification config            discord=False pushover=False telegram=False
+2026-08-31 10:11:11 [info     ] Auth config                    enabled=False has_password=False initial_setup_complete=False username=admin
+2026-08-31 10:11:11 [info     ] Public access config           enabled=False external_base_url=False historical_days=7 media_historical_days=7
+=========================== short test summary info ============================
+FAILED tests/test_rollup_canonical_identity.py::test_the_migration_reverses_and_keeps_the_totals
+!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+============================== 1 failed in 0.93s ===============================

--- a/scratch-fp.txt
+++ b/scratch-fp.txt
@@ -1,0 +1,53 @@
+
+Initializing test database schema at /var/folders/7f/8fht73vj5wd3qrvstm_9r7340000gn/T/yawamf_test__sxb89vc/test_speciesid.db...
+Test database schema initialized successfully
+============================= test session starts ==============================
+platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
+rootdir: /Users/powdrill/Developer/YetAnother-WhosAtMyFeeder
+configfile: pyproject.toml
+plugins: asyncio-1.4.0, anyio-4.14.2
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 1 item
+
+tests/test_species_filter_fast_path.py F
+
+=================================== FAILURES ===================================
+_________ test_fast_path_matches_the_general_path_for_a_common_species _________
+
+    @pytest.mark.asyncio
+    async def test_fast_path_matches_the_general_path_for_a_common_species():
+        async with get_db() as db:
+            repo = DetectionRepository(db)
+            fast = await repo.get_all(species="Common Bird", limit=50, offset=25)
+            # A date range disqualifies the fast path, so this is the general
+            # query answering the same question.
+            general = await repo.get_all(
+                species="Common Bird",
+                limit=50,
+                offset=25,
+                start_date=__import__("datetime").datetime(2020, 1, 1),
+            )
+>           assert [d.frigate_event for d in fast] == [d.frigate_event for d in general]
+E           AssertionError: assert ['common_530'...mon_334', ...] == ['common_530'...mon_334', ...]
+E             
+E             At index 49 diff: 'common_444' != 'common_24'
+E             Use -v to get more diff
+
+tests/test_species_filter_fast_path.py:106: AssertionError
+---------------------------- Captured stdout setup -----------------------------
+2026-08-31 10:08:49 [info     ] Test DB already initialized, skipping migrations
+2026-08-31 10:08:49 [info     ] Initializing database connection pool db_path=/var/folders/7f/8fht73vj5wd3qrvstm_9r7340000gn/T/yawamf_test__sxb89vc/test_speciesid.db pool_size=5
+2026-08-31 10:08:49 [info     ] Database connection pool initialized
+--------------------------- Captured stdout teardown ---------------------------
+2026-08-31 10:08:49 [info     ] Closing database connection pool
+2026-08-31 10:08:49 [info     ] Database connection pool closed
+=============================== warnings summary ===============================
+app/routers/models.py:6
+  /Users/powdrill/Developer/YetAnother-WhosAtMyFeeder/backend/app/routers/models.py:6: UserWarning: Model directory resolved to '/Users/powdrill/Developer/YetAnother-WhosAtMyFeeder/backend/data/models' which is inside the container image filesystem. Downloaded models will be lost on container restart. Mount a persistent volume at /data or set MODEL_DIR to a writable host path.
+    from app.services.model_manager import (
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/test_species_filter_fast_path.py::test_fast_path_matches_the_general_path_for_a_common_species
+!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+========================= 1 failed, 1 warning in 1.77s =========================


### PR DESCRIPTION
## Outcome

Fixes the confirmed diagnosis on [#258](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/258): a bare species filter ordered by time walks the history until the page fills, so the rarer the species the more of the table it reads. Prototyped on a 100,000-row table: the old query took ~32 ms for a rare species (scaling with table size); the new shape answers both rare and common in **under 0.25 ms** with zero table scans.

## Included

- **Migration (index-only, reversible)**: composite expression indexes `(LOWER(name), detection_time)` for the three species columns, plus `(taxa_id, detection_time)` — `taxa_id` had no index at all, which also forced the alias resolver's OR into a full scan on every filtered request. `ANALYZE` records the stats.
- **Fast path in `get_all`**: a bare species filter (no other filters, time-sorted) becomes one newest-first seek per species term, each branch capped at limit+offset, merged and ordered once. Any other filter combination keeps the general path — those filters already make it selective (the reporter's date-range probe proved that).
- **Alias resolution cached** (60 s per process; cleared between tests) — it was a fixed per-request cost on the same path.

## Verification

Plan test pins zero `SCAN detections` in the fast path; parity tests pin identical results (including offset pagination) against the general path; hidden-semantics and cache tests included. Migration round-trip proven exact (`upgrade → downgrade → upgrade`, only the four new indexes come and go). Full suite green: 2,620 backend tests, repo-wide ruff clean.