### PR TITLE
Name the delete control's effect before it acts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The delete control names its own effect
+  ([#256](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/256)).** It said "Delete
+  Detection" and asked "Delete this Robin detection?" - never saying whether that removed the
+  identification or the whole visit, that the media goes with it, that it is permanent, or that
+  hiding exists for the reversible case. It now says all four, in every locale.
+
 - **Filtering by a rare species no longer reads the whole history
   ([#258](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/258)).** The reporter
   measured the shape exactly: common species filtered instantly, species with under a hundred

--- a/apps/ui/src/lib/components/delete-names-its-effect.layout.test.ts
+++ b/apps/ui/src/lib/components/delete-names-its-effect.layout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import en from '../i18n/locales/en.json';
+
+describe('the delete control names its own effect (#256)', () => {
+    // A destructive action is the worst place to be vague: the old wording
+    // never said whether it removed the identification or the whole visit,
+    // nor that the media goes with it, nor that hiding is the reversible way.
+    it('says what leaves, that it is permanent, and what the alternative is', () => {
+        const actions = (en as unknown as Record<string, Record<string, string>>).actions;
+        expect(actions.delete_detection.toLowerCase()).toContain('permanently');
+        expect(actions.confirm_delete).toContain('whole');
+        expect(actions.confirm_delete.toLowerCase()).toContain('permanently');
+        expect(actions.confirm_delete.toLowerCase()).toContain('media');
+        expect(actions.confirm_delete.toLowerCase()).toContain('hiding');
+    });
+});

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -1691,13 +1691,13 @@
     "clear_notifications": "Benachrichtigungen löschen"
   },
   "actions": {
-    "confirm_delete": "Diese {species} Erkennung löschen?",
+    "confirm_delete": "Diesen gesamten {species}-Besuch löschen? Der Eintrag und seine Medien verschwinden dauerhaft aus der Historie. Ausblenden behält den Eintrag stattdessen.",
     "play_video": "Video abspielen",
     "deep_reclassify": "Tiefen-Reklassifizierung",
     "manual_tag": "Manuelles Tag",
     "reclassify": "Reklassifizieren",
     "species_info": "Spezies-Info",
-    "delete_detection": "Erkennung löschen",
+    "delete_detection": "Diesen Besuch dauerhaft löschen",
     "hide_detection": "Erkennung ausblenden",
     "unhide_detection": "Erkennung einblenden",
     "read_more_wikipedia": "Mehr auf Wikipedia lesen",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -1700,13 +1700,13 @@
     "clear_notifications": "Clear notifications"
   },
   "actions": {
-    "confirm_delete": "Delete this {species} detection?",
+    "confirm_delete": "Delete this whole {species} visit? The record and its media leave the history permanently. Hiding it instead keeps the record.",
     "play_video": "Play Video",
     "deep_reclassify": "Deep Reclassify",
     "manual_tag": "Manual Tag",
     "reclassify": "Reclassify",
     "species_info": "Species Info",
-    "delete_detection": "Delete Detection",
+    "delete_detection": "Delete this visit permanently",
     "hide_detection": "Hide Detection",
     "unhide_detection": "Unhide Detection",
     "read_more_wikipedia": "Read more on Wikipedia",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -1691,13 +1691,13 @@
     "clear_notifications": "Borrar notificaciones"
   },
   "actions": {
-    "confirm_delete": "¿Eliminar esta detección de {species}?",
+    "confirm_delete": "¿Eliminar toda esta visita de {species}? El registro y sus medios desaparecen de la historia permanentemente. Ocultarla, en cambio, conserva el registro.",
     "play_video": "Reproducir Video",
     "deep_reclassify": "Reclasificación Profunda",
     "manual_tag": "Etiquetado Manual",
     "reclassify": "Reclasificar",
     "species_info": "Información de la Especie",
-    "delete_detection": "Eliminar Detección",
+    "delete_detection": "Eliminar esta visita permanentemente",
     "hide_detection": "Ocultar Detección",
     "unhide_detection": "Mostrar Detección",
     "read_more_wikipedia": "Leer más en Wikipedia",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -1691,13 +1691,13 @@
     "clear_notifications": "Effacer les notifications"
   },
   "actions": {
-    "confirm_delete": "Supprimer cette détection de {species} ?",
+    "confirm_delete": "Supprimer toute cette visite de {species} ? L'enregistrement et ses médias quittent l'historique définitivement. Masquer conserve l'enregistrement.",
     "play_video": "Lire la vidéo",
     "deep_reclassify": "Reclassification profonde",
     "manual_tag": "Étiquette manuelle",
     "reclassify": "Reclassifier",
     "species_info": "Infos sur l'espèce",
-    "delete_detection": "Supprimer la détection",
+    "delete_detection": "Supprimer cette visite définitivement",
     "hide_detection": "Masquer la détection",
     "unhide_detection": "Afficher la détection",
     "read_more_wikipedia": "Lire la suite sur Wikipédia",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -1700,13 +1700,13 @@
     "clear_notifications": "Cancella notifiche"
   },
   "actions": {
-    "confirm_delete": "Eliminare questo rilevamento di {species}?",
+    "confirm_delete": "Eliminare l'intera visita di {species}? Il record e i suoi contenuti multimediali escono dalla cronologia definitivamente. Nasconderla invece conserva il record.",
     "play_video": "Riproduci Video",
     "deep_reclassify": "Riclassificazione Profonda",
     "manual_tag": "Tag Manuale",
     "reclassify": "Riclassifica",
     "species_info": "Info Specie",
-    "delete_detection": "Elimina Rilevamento",
+    "delete_detection": "Elimina questa visita definitivamente",
     "hide_detection": "Nascondi Rilevamento",
     "unhide_detection": "Mostra Rilevamento",
     "read_more_wikipedia": "Leggi altro su Wikipedia",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -1691,13 +1691,13 @@
     "clear_notifications": "通知をクリア"
   },
   "actions": {
-    "confirm_delete": "この {species} の検出を削除しますか？",
+    "confirm_delete": "この{species}の来訪をまるごと削除しますか？記録とメディアは履歴から完全に消えます。代わりに非表示にすれば記録は残ります。",
     "play_video": "ビデオを再生",
     "deep_reclassify": "詳細な再分類",
     "manual_tag": "手動タグ付け",
     "reclassify": "再分類",
     "species_info": "種の情報",
-    "delete_detection": "検出を削除",
+    "delete_detection": "この来訪を完全に削除",
     "hide_detection": "検出を非表示",
     "unhide_detection": "検出を再表示",
     "read_more_wikipedia": "ウィキペディアで続きを読む",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -1700,13 +1700,13 @@
     "clear_notifications": "Limpar notificações"
   },
   "actions": {
-    "confirm_delete": "Excluir esta detecção de {species}?",
+    "confirm_delete": "Excluir toda esta visita de {species}? O registro e suas mídias saem do histórico permanentemente. Ocultá-la, em vez disso, mantém o registro.",
     "play_video": "Reproduzir Vídeo",
     "deep_reclassify": "Reclassificação Profunda",
     "manual_tag": "Tag Manual",
     "reclassify": "Reclassificar",
     "species_info": "Info da Espécie",
-    "delete_detection": "Excluir Detecção",
+    "delete_detection": "Excluir esta visita permanentemente",
     "hide_detection": "Ocultar Detecção",
     "unhide_detection": "Mostrar Detecção",
     "read_more_wikipedia": "Leia mais na Wikipedia",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -1700,13 +1700,13 @@
     "clear_notifications": "Очистить уведомления"
   },
   "actions": {
-    "confirm_delete": "Удалить это обнаружение {species}?",
+    "confirm_delete": "Удалить весь визит {species}? Запись и её медиа навсегда исчезнут из истории. Скрытие, напротив, сохраняет запись.",
     "play_video": "Воспроизвести видео",
     "deep_reclassify": "Глубокая реклассификация",
     "manual_tag": "Ручная метка",
     "reclassify": "Реклассифицировать",
     "species_info": "Информация о виде",
-    "delete_detection": "Удалить обнаружение",
+    "delete_detection": "Удалить этот визит навсегда",
     "hide_detection": "Скрыть обнаружение",
     "unhide_detection": "Показать обнаружение",
     "read_more_wikipedia": "Читать больше в Википедии",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -1691,13 +1691,13 @@
     "clear_notifications": "清除通知"
   },
   "actions": {
-    "confirm_delete": "删除此 {species} 检测记录？",
+    "confirm_delete": "删除这次{species}的完整到访记录？该记录及其媒体将永久从历史中消失。改为隐藏则会保留记录。",
     "play_video": "播放视频",
     "deep_reclassify": "深度重新分类",
     "manual_tag": "手动标记",
     "reclassify": "重新分类",
     "species_info": "物种信息",
-    "delete_detection": "删除检测",
+    "delete_detection": "永久删除此次到访",
     "hide_detection": "隐藏检测",
     "unhide_detection": "取消隐藏检测",
     "read_more_wikipedia": "在维基百科上阅读更多",


### PR DESCRIPTION
## Outcome

Fixes the bug half of [#256](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/256)'s follow-ups: the delete control was vague on a destructive action. It now says what leaves (the whole visit and its media), that it is permanent, and that hiding is the reversible alternative — in all nine locales.

## Verification

A test pins the wording to the four facts; full frontend suite green (996 tests, svelte-check 0/0).