### PR TITLE
Keep one bird one row, and keep the dashboard alive either way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A duplicated species can no longer take down the lower dashboard.** When catalogue identity
+  is patchy across a species' rows - written between ingest and the next identity backfill - the
+  canonical grouping split one Dunnock into two summary rows, and the top-visitors list crashed
+  on the duplicate key, killing everything rendered after it. The daily summary now folds rows
+  that share a taxon (or a name when the taxon is missing) back into one bird, and the list
+  dedupes defensively besides, so a bad payload degrades to a merged row instead of a dead page.
+
 - **The delete control names its own effect
   ([#256](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/256)).** It said "Delete
   Detection" and asked "Delete this Robin detection?" - never saying whether that removed the

--- a/apps/ui/src/lib/components/TopVisitors.svelte
+++ b/apps/ui/src/lib/components/TopVisitors.svelte
@@ -51,14 +51,31 @@
         const showCommon = settingsStore.settings?.display_common_names ?? authStore.displayCommonNames ?? true;
         const preferSci = settingsStore.settings?.scientific_name_primary ?? authStore.scientificNamePrimary ?? false;
 
-        return species.slice(0, 5).map((item) => {
-            const naming = getBirdNames(item, showCommon, preferSci);
-            return {
-                ...item,
-                displayName: naming.primary,
-                subName: naming.secondary
-            };
-        });
+        // The API once returned the same species twice when catalogue identity
+        // was patchy across its rows, and a duplicate key here took the whole
+        // lower dashboard down. Merge duplicates instead of trusting the list.
+        const merged = new Map<string, (typeof species)[number]>();
+        for (const item of species) {
+            const key = (item.species ?? '').trim().toLowerCase();
+            const existing = merged.get(key);
+            if (existing) {
+                merged.set(key, { ...existing, count: existing.count + item.count });
+            } else {
+                merged.set(key, item);
+            }
+        }
+
+        return [...merged.values()]
+            .sort((left, right) => right.count - left.count)
+            .slice(0, 5)
+            .map((item) => {
+                const naming = getBirdNames(item, showCommon, preferSci);
+                return {
+                    ...item,
+                    displayName: naming.primary,
+                    subName: naming.secondary
+                };
+            });
     });
 
     $effect(() => {

--- a/apps/ui/src/lib/components/top-visitors-duplicate-safety.layout.test.ts
+++ b/apps/ui/src/lib/components/top-visitors-duplicate-safety.layout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import topVisitorsSource from './TopVisitors.svelte?raw';
+
+describe('the top-visitors list survives a duplicated species', () => {
+    // A duplicate key in a keyed each is a runtime crash in Svelte 5, and it
+    // took the lower half of the dashboard down when the API split one bird
+    // into two rows. The list dedupes before keying instead of trusting the
+    // payload.
+    it('merges duplicate species before the keyed each', () => {
+        expect(topVisitorsSource).toContain('const merged = new Map');
+        expect(topVisitorsSource).toContain('existing.count + item.count');
+        const dedupeAt = topVisitorsSource.indexOf('const merged = new Map');
+        const eachAt = topVisitorsSource.indexOf('(item.species)');
+        expect(dedupeAt).toBeGreaterThan(-1);
+        expect(eachAt).toBeGreaterThan(dedupeAt);
+    });
+});

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -30,6 +30,50 @@ def clear_species_alias_cache() -> None:
     _SPECIES_ALIAS_CACHE.clear()
 
 
+def merge_species_count_rows(rows: list[dict]) -> list[dict]:
+    """Fold count rows that are the same bird under different identity keys.
+
+    The canonical key prefers catalogue identity, but a row written between
+    ingest and the next identity backfill can lack `species_id` while its
+    neighbours carry it - and one Dunnock then arrives as two rows, which the
+    dashboard's keyed list cannot survive. Same taxon, or same name when a
+    taxon is missing, means the same bird here.
+    """
+    by_taxa: dict[int, dict] = {}
+    by_name: dict[str, dict] = {}
+    merged: list[dict] = []
+    for row in rows:
+        taxa_id = row.get("taxa_id")
+        name = str(row.get("species") or "").strip().lower()
+        target = None
+        if taxa_id is not None and taxa_id in by_taxa:
+            target = by_taxa[taxa_id]
+        elif name and name in by_name:
+            target = by_name[name]
+        if target is None:
+            entry = dict(row)
+            merged.append(entry)
+            if taxa_id is not None:
+                by_taxa[taxa_id] = entry
+            if name:
+                by_name[name] = entry
+            continue
+        target["count"] = int(target.get("count") or 0) + int(row.get("count") or 0)
+        row_time = row.get("latest_detection_time")
+        target_time = target.get("latest_detection_time")
+        if row_time is not None and (target_time is None or row_time > target_time):
+            target["latest_detection_time"] = row_time
+            target["latest_event"] = row.get("latest_event")
+        if target.get("taxa_id") is None and taxa_id is not None:
+            target["taxa_id"] = taxa_id
+            by_taxa[taxa_id] = target
+        for field in ("scientific_name", "common_name"):
+            if not target.get(field) and row.get(field):
+                target[field] = row.get(field)
+    merged.sort(key=lambda entry: int(entry.get("count") or 0), reverse=True)
+    return merged
+
+
 def _copy_alias_info(alias_info: dict) -> dict:
     copied = dict(alias_info)
     for key in ("display_labels", "match_names"):
@@ -4318,18 +4362,20 @@ class DetectionRepository:
         """
         async with self.db.execute(query, (start_date.isoformat(sep=" "), end_date.isoformat(sep=" "))) as cursor:
             rows = await cursor.fetchall()
-            return [
-                {
-                    "species": row[6],
-                    "count": row[1],
-                    "latest_event": row[2],
-                    "latest_detection_time": _parse_datetime(row[3]) if row[3] else None,
-                    "scientific_name": row[4],
-                    "common_name": row[5],
-                    "taxa_id": row[7],
-                }
-                for row in rows
-            ]
+            return merge_species_count_rows(
+                [
+                    {
+                        "species": row[6],
+                        "count": row[1],
+                        "latest_event": row[2],
+                        "latest_detection_time": _parse_datetime(row[3]) if row[3] else None,
+                        "scientific_name": row[4],
+                        "common_name": row[5],
+                        "taxa_id": row[7],
+                    }
+                    for row in rows
+                ]
+            )
 
     async def insert_audio_detection(
         self,

--- a/backend/tests/test_species_count_merge.py
+++ b/backend/tests/test_species_count_merge.py
@@ -1,0 +1,56 @@
+"""One bird must never arrive as two summary rows.
+
+Observed live: the canonical key prefers catalogue identity, and rows written
+between ingest and the next identity backfill lack species_id while their
+neighbours carry it - the same Dunnock then grouped as two rows, and the
+dashboard's keyed species list crashed on the duplicate, taking the lower
+half of the page with it.
+"""
+
+from datetime import datetime
+
+from app.repositories.detection_repository import merge_species_count_rows
+
+
+def _row(species, count, taxa_id=None, at="2026-08-31 09:00:00", event="e1", **extra):
+    return {
+        "species": species,
+        "count": count,
+        "latest_event": event,
+        "latest_detection_time": datetime.fromisoformat(at),
+        "scientific_name": extra.get("scientific_name"),
+        "common_name": extra.get("common_name"),
+        "taxa_id": taxa_id,
+    }
+
+
+def test_same_taxon_under_two_identity_keys_becomes_one_row():
+    rows = [
+        _row("Dunnock", 5, taxa_id=13988, at="2026-08-31 08:50:00", event="older"),
+        _row("Dunnock", 2, taxa_id=13988, at="2026-08-31 09:19:00", event="newer"),
+    ]
+    merged = merge_species_count_rows(rows)
+    assert len(merged) == 1
+    assert merged[0]["count"] == 7
+    assert merged[0]["latest_event"] == "newer"
+
+
+def test_same_name_without_taxon_still_merges_and_adopts_the_taxon():
+    rows = [
+        _row("Dunnock", 3, taxa_id=13988, scientific_name="Prunella modularis"),
+        _row("Dunnock", 1, taxa_id=None),
+    ]
+    merged = merge_species_count_rows(rows)
+    assert len(merged) == 1
+    assert merged[0]["taxa_id"] == 13988
+    assert merged[0]["scientific_name"] == "Prunella modularis"
+    assert merged[0]["count"] == 4
+
+
+def test_distinct_species_stay_distinct_and_sorted_by_count():
+    rows = [
+        _row("Dunnock", 2, taxa_id=13988),
+        _row("Jungle Babbler", 6, taxa_id=1289423),
+    ]
+    merged = merge_species_count_rows(rows)
+    assert [entry["species"] for entry in merged] == ["Jungle Babbler", "Dunnock"]


### PR DESCRIPTION
## Outcome

Fixes the live break reported this morning: the lower dashboard rendered as a bare skeleton. Console showed Svelte's `each_key_duplicate` — the daily summary returned **two Dunnock rows** (rows with and without catalogue `species_id` group under different canonical keys), and the top-visitors keyed list crashed on the duplicate, killing everything after it.

## Included

- `merge_species_count_rows`: the daily species counts fold rows sharing a taxon (or a name when the taxon is missing) into one bird — counts summed, later sighting kept, missing taxonomy adopted.
- `TopVisitors` dedupes before keying, so even a bad payload degrades to a merged row instead of a dead page.

## Follow-up

Why identity goes patchy — evidence points at a post-classification write clobbering a backfill-healed `species_id` with null — is filed separately as its own investigation.

## Verification

Three unit tests pin the merge (same taxon, name-only adoption, distinct stay distinct); a layout test pins the dedupe-before-keying. Full suites green: 2,636 backend, 996 frontend, svelte-check 0/0, ruff clean.