### PR TITLE
Send the review queue's times as explicit UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **The review queue shows the right time
+  ([#363](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/363)).** The new-species
+  entries carried a timestamp without a timezone, which a browser reads as local time - so anyone
+  outside UTC saw a sighting's clock shifted by their offset. Those times are now explicit UTC,
+  like every other timestamp the API returns.
+
 ### Added
 
 - **The Frigate labels YA-WAMF acts on are configurable

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -972,7 +972,9 @@ async def get_new_species_queue(
                 scientific_name=detection.scientific_name,
                 taxa_id=detection.taxa_id,
                 camera_name=detection.camera_name,
-                detection_time=str(detection.detection_time),
+                # Explicit UTC, like every other timestamp this API returns: a
+                # naive string is read as local time by the browser (#363).
+                detection_time=serialize_api_datetime(detection.detection_time) or "",
                 score=float(detection.score or 0.0),
                 manual_tagged=bool(detection.manual_tagged),
                 is_hidden=bool(detection.is_hidden),

--- a/backend/tests/test_new_species_queue_api.py
+++ b/backend/tests/test_new_species_queue_api.py
@@ -83,3 +83,18 @@ async def test_new_species_thresholds_are_honoured():
         res = await client.get("/api/events/new-species?window_days=90")
         names = {item["display_name"] for item in res.json()["items"]}
         assert "Gray Catbird" in names
+
+
+@pytest.mark.asyncio
+async def test_new_species_times_are_explicit_utc():
+    """A naive timestamp is read by the browser as local time, so the queue
+    showed the wrong clock to anyone outside UTC (#363). Every other endpoint
+    serialises detection times as explicit UTC; this one must too."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events/new-species")
+        assert res.status_code == 200
+        times = [item["detection_time"] for item in res.json()["items"]]
+        assert times, "expected newcomers in the fixture"
+        for value in times:
+            assert value.endswith("Z"), value
+            assert "T" in value, value


### PR DESCRIPTION
## Outcome

Fixes [#363](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/363), reported hours after #310 shipped. The new-species queue serialised `detection_time` with a bare `str()` — a naive `2026-08-31 09:19:13` with no zone marker, which browsers parse as **local** time. Anyone outside UTC saw the sighting's clock shifted by their offset.

## Included

- The endpoint now uses `serialize_api_datetime`, the same explicit-UTC serialiser every other timestamp in this API goes through.

## Verification

New API test asserts the queue's times carry an explicit zone (`...Z`, ISO `T` separator). Full backend suite green (2,638); svelte-check 0/0; ruff clean.