### PR TITLE
Load the Home Assistant weather settings that were saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   outside UTC saw a sighting's clock shifted by their offset. Those times are now explicit UTC,
   like every other timestamp the API returns.
 
+- **Home Assistant weather settings survive a restart.** The settings loader builds each section
+  explicitly, and the Home Assistant section was never passed to it - so the block saved in
+  `config.json` was read and thrown away on every start. The configuration appeared to save, then
+  came back blank after the next restart, and the following save wrote the defaults over it for
+  good. The section is now loaded like every other one, with environment variables still winning
+  over the file.
+
 ### Added
 
 - **The Frigate labels YA-WAMF acts on are configurable

--- a/backend/app/config_loader.py
+++ b/backend/app/config_loader.py
@@ -11,6 +11,7 @@ from .config_models import (
     AccessibilitySettings,
     AppearanceSettings,
     BirdWeatherSettings,
+    HomeAssistantWeatherSettings,
     ClassificationSettings,
     DEFAULT_AI_ANALYSIS_PROMPT,
     DEFAULT_AI_CONVERSATION_PROMPT,
@@ -307,6 +308,15 @@ def load_settings_instance(settings_cls: type[Any], config_path: Path) -> Any:
         "station_token": os.environ.get("BIRDWEATHER__STATION_TOKEN", None),
     }
 
+    # Home Assistant weather settings (#277). Every field is optional: an
+    # absent section means the forecast provider stays the source.
+    ha_weather_data = {
+        "enabled": os.environ.get("HA_WEATHER__ENABLED", "false").lower() == "true",
+        "base_url": os.environ.get("HA_WEATHER__BASE_URL", None),
+        "access_token": os.environ.get("HA_WEATHER__ACCESS_TOKEN", None),
+        "weather_entity": os.environ.get("HA_WEATHER__WEATHER_ENTITY", None),
+    }
+
     # eBird settings
     ebird_data = {
         "enabled": os.environ.get("EBIRD__ENABLED", "false").lower() == "true",
@@ -548,6 +558,12 @@ def load_settings_instance(settings_cls: type[Any], config_path: Path) -> Any:
                     env_key = f"BIRDWEATHER__{key.upper()}"
                     if env_key not in os.environ:
                         birdweather_data[key] = value
+
+            if "ha_weather" in file_data:
+                for key, value in file_data["ha_weather"].items():
+                    env_key = f"HA_WEATHER__{key.upper()}"
+                    if env_key not in os.environ:
+                        ha_weather_data[key] = value
 
             if "ebird" in file_data:
                 for key, value in file_data["ebird"].items():
@@ -804,6 +820,7 @@ def load_settings_instance(settings_cls: type[Any], config_path: Path) -> Any:
         media_cache=MediaCacheSettings(**media_cache_data),
         location=LocationSettings(**location_data),
         birdweather=BirdWeatherSettings(**birdweather_data),
+        ha_weather=HomeAssistantWeatherSettings(**ha_weather_data),
         ebird=EbirdSettings(**ebird_data),
         inaturalist=InaturalistSettings(**inaturalist_data),
         enrichment=EnrichmentSettings(**enrichment_data),

--- a/backend/tests/test_config_env_mapping.py
+++ b/backend/tests/test_config_env_mapping.py
@@ -532,3 +532,55 @@ def test_media_cache_high_quality_event_snapshot_jpeg_quality_env_overrides_file
     loaded = Settings.load()
 
     assert loaded.media_cache.high_quality_event_snapshot_jpeg_quality == 81
+
+
+def test_home_assistant_weather_survives_a_restart(monkeypatch, tmp_path):
+    """Configuration the owner saved must come back when the process does.
+
+    The loader builds each section explicitly, and a section it never passes
+    silently takes model defaults - so the stored block was read and thrown
+    away, the settings page showed blank after a restart, and the next save
+    wrote the defaults over the owner's configuration for good.
+    """
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "ha_weather": {
+                    "enabled": True,
+                    "base_url": "https://homeassistant.example.com",
+                    "access_token": "stored-token",
+                    "weather_entity": "weather.forecast_home",
+                    "temperature_entity": "sensor.feeder_temp",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    for name in ("HA_WEATHER__ENABLED", "HA_WEATHER__BASE_URL", "HA_WEATHER__ACCESS_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+
+    loaded = Settings.load()
+
+    assert loaded.ha_weather.enabled is True
+    assert loaded.ha_weather.base_url == "https://homeassistant.example.com"
+    assert loaded.ha_weather.access_token == "stored-token"
+    assert loaded.ha_weather.weather_entity == "weather.forecast_home"
+    assert loaded.ha_weather.temperature_entity == "sensor.feeder_temp"
+
+
+def test_home_assistant_weather_env_overrides_the_file(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"ha_weather": {"enabled": False, "base_url": "https://from-file.example.com"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setenv("HA_WEATHER__ENABLED", "true")
+    monkeypatch.setenv("HA_WEATHER__BASE_URL", "https://from-env.example.com")
+
+    loaded = Settings.load()
+
+    assert loaded.ha_weather.enabled is True
+    assert loaded.ha_weather.base_url == "https://from-env.example.com"


### PR DESCRIPTION
## Outcome

Fixes a data-loss bug in #277, found from a live report: HA weather configuration vanished and the settings card rendered blank.

**Root cause.** `load_settings_instance` builds `Settings` section by section and never passed `ha_weather`, so it always took model defaults — the stored block was read from `config.json` and thrown away. The failure is delayed and destructive: the save looks fine, the values work until the next restart, then the section reads as defaults (blank page) and the *next* save serialises those defaults over the owner's configuration permanently — taking the URL, entity, and long-lived token with it.

Verified on the reference instance: stored block present in `config.json`, API reporting all-null, and a single settings POST reproducing the permanent wipe.

## Included

- `ha_weather` built from env like every other section, merged from the file with env winning, and **passed to the Settings constructor** — the missing step.

## Notes

`frigate.ingest_labels` (#252) was checked for the same hole and is safe: the frigate merge loop iterates every key in the stored section.

## Verification

Two tests pin it: a stored block survives a load (the restart case), and env still overrides the file. Full backend suite green (2,639); ruff clean.