### PR TITLE
Let the species seek reach rows only the taxonomy cache identifies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A species filter finds every visit again
+  ([#365](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/365)).** 2.19.0 made a bare
+  species filter answer by index seek, and that seek checked only the taxon id stored on the
+  detection itself. Where those ids are patchy the filter reported "no visits match these filters"
+  for a species with plenty of visits - and adding a date range appeared to fix it, because a date
+  range routes back to the older query, which resolves the taxon through the taxonomy cache. The
+  seek now reaches those rows too, on the same terms the older query used: a cached name identifies
+  a row only where the row carries no taxon of its own. The filter is still scan-free.
+
 ## [2.19.1] - 2026-08-31
 
 ### Fixed

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1890,9 +1890,10 @@ class DetectionRepository:
         species: str | None,
         species_any: list[str] | None,
         taxa_id: int | None,
-    ) -> tuple[list[int], list[str]]:
+    ) -> tuple[list[int], list[str], list[str]]:
         taxa_ids: list[int] = []
         names: list[str] = []
+        cache_names: list[str] = []
 
         def _add_taxa(value: int | None) -> None:
             if value is not None and value not in taxa_ids:
@@ -1912,13 +1913,30 @@ class DetectionRepository:
             _add_name(alias_info.get("scientific_name"))
             for name in alias_info.get("match_names") or []:
                 _add_name(name)
-        return taxa_ids, names
+
+        # The general query reaches a row whose own taxon id was never filled
+        # by joining the taxonomy cache; these names let the fast path reach
+        # the same rows by seek, and they are applied only where the row has
+        # no taxon of its own, which is exactly what that COALESCE means.
+        if taxa_ids and await self._table_exists("taxonomy_cache"):
+            placeholders = ",".join("?" for _ in taxa_ids)
+            async with self.db.execute(
+                f"SELECT scientific_name, common_name FROM taxonomy_cache WHERE taxa_id IN ({placeholders})",
+                taxa_ids,
+            ) as cursor:
+                for row in await cursor.fetchall():
+                    for value in (row[0], row[1]):
+                        lowered = str(value or "").strip().lower()
+                        if lowered and lowered not in names and lowered not in cache_names:
+                            cache_names.append(lowered)
+        return taxa_ids, names, cache_names
 
     def _build_species_fast_path_query(
         self,
         *,
         taxa_ids: list[int],
         names: list[str],
+        cache_names: list[str] | None = None,
         limit: int,
         offset: int,
         sort: str,
@@ -1956,6 +1974,11 @@ class DetectionRepository:
         for column in ("display_name", "scientific_name", "common_name"):
             for name in names:
                 _branch(f"LOWER({column}) = ?", name)
+            # A cache-derived name identifies a row only where the row itself
+            # carries no taxon, matching the general query's COALESCE rather
+            # than widening the filter to rows that named a different taxon.
+            for name in cache_names or []:
+                _branch(f"LOWER({column}) = ? AND taxa_id IS NULL", name)
 
         union = " UNION ".join(branches)
         query = (
@@ -1995,11 +2018,12 @@ class DetectionRepository:
             audio_confirmed_only=audio_confirmed_only,
             frigate_event=frigate_event,
         ):
-            taxa_ids, names = await self._collect_species_filter_terms(species, species_any, taxa_id)
+            taxa_ids, names, cache_names = await self._collect_species_filter_terms(species, species_any, taxa_id)
             if taxa_ids or names:
                 query, params = self._build_species_fast_path_query(
                     taxa_ids=taxa_ids,
                     names=names,
+                    cache_names=cache_names,
                     limit=limit,
                     offset=offset,
                     sort=sort,

--- a/backend/tests/test_species_filter_fast_path.py
+++ b/backend/tests/test_species_filter_fast_path.py
@@ -111,10 +111,11 @@ async def test_fast_path_matches_the_general_path_for_a_common_species():
 async def test_fast_path_query_never_scans_the_detections_table():
     async with get_db() as db:
         repo = DetectionRepository(db)
-        taxa_ids, names = await repo._collect_species_filter_terms("Rare Bird", None, None)
+        taxa_ids, names, cache_names = await repo._collect_species_filter_terms("Rare Bird", None, None)
         query, params = repo._build_species_fast_path_query(
             taxa_ids=taxa_ids,
             names=names,
+            cache_names=cache_names,
             limit=50,
             offset=0,
             sort="newest",

--- a/backend/tests/test_species_filter_taxonomy_cache.py
+++ b/backend/tests/test_species_filter_taxonomy_cache.py
@@ -1,0 +1,85 @@
+"""A taxon filter must find rows that only the taxonomy cache can identify (#365).
+
+The general query resolves a taxon through the cache -
+COALESCE(d.taxa_id, tc_filter.taxa_id) - so a detection whose own taxa_id was
+never filled still answers a `taxa:` filter. The seek-per-term fast path added
+for #258 checked only the row's own column, so on a database where those ids
+are patchy the same filter returned nothing at all - and adding a date range
+"fixed" it, because that routes back to the general query.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import close_db, get_db, init_db
+from app.main import app
+
+TAXON = 13988
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def seeded_db():
+    await init_db()
+    try:
+        async with get_db() as db:
+            await db.execute("DELETE FROM detections")
+            await db.execute("DELETE FROM taxonomy_cache")
+            # The row carries a name but never received its own taxon id.
+            await db.execute(
+                """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index,
+                   score, display_name, category_name, scientific_name, taxa_id, is_hidden)
+                   VALUES ('cache_only', 'cam1', '2026-08-30 09:00:00', 1, 0.9,
+                           'Dunnock', 'Dunnock', 'Prunella modularis', NULL, 0)"""
+            )
+            await db.execute(
+                """INSERT INTO taxonomy_cache (scientific_name, common_name, taxa_id)
+                   VALUES ('Prunella modularis', 'Dunnock', ?)""",
+                (TAXON,),
+            )
+            await db.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_taxon_filter_finds_a_cache_identified_row_without_a_date_range():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(f"/api/events?species=taxa:{TAXON}")
+        assert res.status_code == 200
+        assert [d["frigate_event"] for d in res.json()] == ["cache_only"]
+
+
+@pytest.mark.asyncio
+async def test_the_date_range_answer_and_the_bare_answer_agree():
+    """The reporter's own diagnostic: a date range must not change what exists."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        bare = await client.get(f"/api/events?species=taxa:{TAXON}")
+        dated = await client.get(f"/api/events?species=taxa:{TAXON}&start_date=2020-01-01")
+        assert [d["frigate_event"] for d in bare.json()] == [d["frigate_event"] for d in dated.json()]
+
+
+@pytest.mark.asyncio
+async def test_the_cache_branches_are_still_seeks():
+    """#258's whole point was that this filter stops reading the table; the
+    cache-identified branches must not quietly bring the scan back."""
+    from app.repositories.detection_repository import DetectionRepository
+
+    async with get_db() as db:
+        repo = DetectionRepository(db)
+        taxa_ids, names, cache_names = await repo._collect_species_filter_terms(None, None, TAXON)
+        assert cache_names, "expected the cache to contribute names for this taxon"
+        query, params = repo._build_species_fast_path_query(
+            taxa_ids=taxa_ids,
+            names=names,
+            cache_names=cache_names,
+            limit=50,
+            offset=0,
+            sort="newest",
+            include_hidden=False,
+            hidden_only=False,
+        )
+        async with db.execute("EXPLAIN QUERY PLAN " + query, params) as cursor:
+            plan = [str(row[3]) for row in await cursor.fetchall()]
+        assert [line for line in plan if line.startswith("SCAN detections")] == [], plan


### PR DESCRIPTION
## Outcome

Fixes [#365](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/365) — a regression I shipped in 2.19.0 with the #258 speed work.

The fast path matched a taxon with a bare `d.taxa_id = ?`. The general query it replaced uses `COALESCE(d.taxa_id, tc_filter.taxa_id)`, reaching rows whose own taxon id was never filled. On a database where those ids are patchy the filter returned **nothing** — and the reporter's own diagnostic (a date range makes it work) is explained exactly: a date range disqualifies the fast path and routes back to the general query.

## Included

- The term collector adds the taxonomy cache's names for the filtered taxon; the query adds those as branches guarded by `taxa_id IS NULL`, mirroring the COALESCE semantics rather than widening the filter to rows that named a different taxon.

## Verification

Reproduced first: a row with `taxa_id NULL` plus a cache entry, filtered by `taxa:` — bare filter returned nothing, dated filter returned the row. Both now agree. A plan test asserts the filter is still scan-free (the point of #258). Full backend suite green: 2,642; ruff clean.