### PR TITLE
Match the seek to the query it stands in for, and identify a correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   now described the way someone picking one would: the whole frame, close on the bird, or as
   Frigate recorded it, with the species a frame was read as still shown where one exists.
 
+- **A species filter's list and its count agree, and a correction records the right identity.**
+  Two refinements found by reviewing the fixes above before they reached anyone. The seek that
+  reaches cache-identified rows was broader than the query it stands in for, so a page could show
+  a row the count never counted; it now mirrors that query exactly, matching a row on its own
+  scientific name and falling back to the display name only where the row has none. And a manual
+  correction now records the corrected species' catalogue identity rather than only dropping the
+  previous one, so the row is right immediately instead of waiting for the next startup.
+
 - **A species filter finds every visit again
   ([#365](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/365)).** 2.19.0 made a bare
   species filter answer by index seek, and that seek checked only the taxon id stored on the

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1894,10 +1894,14 @@ class DetectionRepository:
         species: str | None,
         species_any: list[str] | None,
         taxa_id: int | None,
-    ) -> tuple[list[int], list[str], list[str]]:
+    ) -> tuple[list[int], list[str], dict[str, list[str]]]:
         taxa_ids: list[int] = []
         names: list[str] = []
-        cache_names: list[str] = []
+        # The general query's join is not symmetric: a row carrying its own
+        # scientific name is matched on that name alone, and only a row with
+        # no scientific name is matched on its display name. Keeping the two
+        # roles apart is what stops the seek claiming rows the count will not.
+        cache_terms: dict[str, list[str]] = {"scientific": [], "display": []}
 
         def _add_taxa(value: int | None) -> None:
             if value is not None and value not in taxa_ids:
@@ -1929,18 +1933,21 @@ class DetectionRepository:
                 taxa_ids,
             ) as cursor:
                 for row in await cursor.fetchall():
-                    for value in (row[0], row[1]):
-                        lowered = str(value or "").strip().lower()
-                        if lowered and lowered not in names and lowered not in cache_names:
-                            cache_names.append(lowered)
-        return taxa_ids, names, cache_names
+                    scientific = str(row[0] or "").strip().lower()
+                    common = str(row[1] or "").strip().lower()
+                    if scientific and scientific not in cache_terms["scientific"]:
+                        cache_terms["scientific"].append(scientific)
+                    for value in (scientific, common):
+                        if value and value not in cache_terms["display"]:
+                            cache_terms["display"].append(value)
+        return taxa_ids, names, cache_terms
 
     def _build_species_fast_path_query(
         self,
         *,
         taxa_ids: list[int],
         names: list[str],
-        cache_names: list[str] | None = None,
+        cache_terms: dict[str, list[str]] | None = None,
         limit: int,
         offset: int,
         sort: str,
@@ -1978,11 +1985,14 @@ class DetectionRepository:
         for column in ("display_name", "scientific_name", "common_name"):
             for name in names:
                 _branch(f"LOWER({column}) = ?", name)
-            # A cache-derived name identifies a row only where the row itself
-            # carries no taxon, matching the general query's COALESCE rather
-            # than widening the filter to rows that named a different taxon.
-            for name in cache_names or []:
-                _branch(f"LOWER({column}) = ? AND taxa_id IS NULL", name)
+
+        # The cache only identifies a row that has no taxon of its own, and
+        # then only through the column the join would have used.
+        terms = cache_terms or {}
+        for name in terms.get("scientific") or []:
+            _branch("LOWER(scientific_name) = ? AND taxa_id IS NULL", name)
+        for name in terms.get("display") or []:
+            _branch("LOWER(display_name) = ? AND taxa_id IS NULL AND scientific_name IS NULL", name)
 
         union = " UNION ".join(branches)
         query = (
@@ -2022,12 +2032,12 @@ class DetectionRepository:
             audio_confirmed_only=audio_confirmed_only,
             frigate_event=frigate_event,
         ):
-            taxa_ids, names, cache_names = await self._collect_species_filter_terms(species, species_any, taxa_id)
+            taxa_ids, names, cache_terms = await self._collect_species_filter_terms(species, species_any, taxa_id)
             if taxa_ids or names:
                 query, params = self._build_species_fast_path_query(
                     taxa_ids=taxa_ids,
                     names=names,
-                    cache_names=cache_names,
+                    cache_terms=cache_terms,
                     limit=limit,
                     offset=offset,
                     sort=sort,
@@ -2440,8 +2450,14 @@ class DetectionRepository:
         audio_confirmed: bool,
         audio_species: str | None,
         audio_score: float | None,
+        species_id: int | None = None,
     ) -> None:
-        """Persist the database fields owned by a manual species correction."""
+        """Persist the database fields owned by a manual species correction.
+
+        `species_id` is the catalogue identity of the species being corrected
+        to; None means the catalogue could not identify it, which is recorded
+        honestly rather than left pointing at the previous species.
+        """
         await self.db.execute(
             """
             UPDATE detections
@@ -2453,7 +2469,7 @@ class DetectionRepository:
                 -- back to its names until the identity backfill resolves it.
                 species_id = CASE
                     WHEN LOWER(TRIM(?)) = LOWER(TRIM(category_name)) THEN species_id
-                    ELSE NULL
+                    ELSE ?
                 END,
                 audio_confirmed = ?, audio_species = ?, audio_score = ?,
                 manual_tagged = 1
@@ -2466,6 +2482,7 @@ class DetectionRepository:
                 common_name,
                 taxa_id,
                 category_name,
+                species_id,
                 int(audio_confirmed),
                 audio_species,
                 audio_score,

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1393,6 +1393,21 @@ async def _apply_manual_tag_update(
     detection.common_name = com_name
     detection.taxa_id = t_id
 
+    # A correction changes which bird this is, so its catalogue identity has to
+    # change with it. Resolving off the loop: the resolver reads its own
+    # database. An unresolvable name records no identity rather than keeping
+    # the previous species' one (#360).
+    corrected_species_id = None
+    if sci_name:
+        try:
+            from app.services.species_catalog_resolver import species_catalog_resolver
+
+            corrected_species_id, _reason = await asyncio.to_thread(
+                species_catalog_resolver.resolve_scientific_name, sci_name
+            )
+        except Exception as exc:  # pragma: no cover - identity stays unknown
+            log.warning("Could not resolve corrected species identity", error=str(exc), event_id=event_id)
+
     await repo.apply_manual_species_tag(
         frigate_event=event_id,
         display_name=stored_display_name,
@@ -1403,6 +1418,7 @@ async def _apply_manual_tag_update(
         audio_confirmed=audio_confirmed,
         audio_species=audio_species,
         audio_score=audio_score,
+        species_id=corrected_species_id,
     )
 
     model_id = _get_active_model_id_for_feedback()

--- a/backend/tests/test_identity_write_integrity.py
+++ b/backend/tests/test_identity_write_integrity.py
@@ -142,3 +142,29 @@ async def test_confirming_the_same_species_keeps_its_identity():
         await db.commit()
 
         assert (await _stored(db, "evt"))["species_id"] == SPECIES_ID
+
+
+@pytest.mark.asyncio
+async def test_a_correction_records_the_new_species_identity_when_it_is_known():
+    """Dropping the wrong identity is the floor; recording the right one is
+    the point. The caller resolves the corrected species and passes it in."""
+    async with get_db() as db:
+        repo = DetectionRepository(db)
+        await repo.insert_if_not_exists(_detection())
+        await repo.assign_species_id_by_scientific_name("Prunella modularis", SPECIES_ID)
+
+        await repo.apply_manual_species_tag(
+            frigate_event="evt",
+            display_name="Robin",
+            category_name="Robin",
+            scientific_name="Erithacus rubecula",
+            common_name="Robin",
+            taxa_id=None,
+            audio_confirmed=False,
+            audio_species=None,
+            audio_score=None,
+            species_id=4242,
+        )
+        await db.commit()
+
+        assert (await _stored(db, "evt"))["species_id"] == 4242

--- a/backend/tests/test_species_filter_fast_path.py
+++ b/backend/tests/test_species_filter_fast_path.py
@@ -111,11 +111,11 @@ async def test_fast_path_matches_the_general_path_for_a_common_species():
 async def test_fast_path_query_never_scans_the_detections_table():
     async with get_db() as db:
         repo = DetectionRepository(db)
-        taxa_ids, names, cache_names = await repo._collect_species_filter_terms("Rare Bird", None, None)
+        taxa_ids, names, cache_terms = await repo._collect_species_filter_terms("Rare Bird", None, None)
         query, params = repo._build_species_fast_path_query(
             taxa_ids=taxa_ids,
             names=names,
-            cache_names=cache_names,
+            cache_terms=cache_terms,
             limit=50,
             offset=0,
             sort="newest",

--- a/backend/tests/test_species_filter_taxonomy_cache.py
+++ b/backend/tests/test_species_filter_taxonomy_cache.py
@@ -68,12 +68,12 @@ async def test_the_cache_branches_are_still_seeks():
 
     async with get_db() as db:
         repo = DetectionRepository(db)
-        taxa_ids, names, cache_names = await repo._collect_species_filter_terms(None, None, TAXON)
-        assert cache_names, "expected the cache to contribute names for this taxon"
+        taxa_ids, names, cache_terms = await repo._collect_species_filter_terms(None, None, TAXON)
+        assert cache_terms["scientific"], "expected the cache to contribute names for this taxon"
         query, params = repo._build_species_fast_path_query(
             taxa_ids=taxa_ids,
             names=names,
-            cache_names=cache_names,
+            cache_terms=cache_terms,
             limit=50,
             offset=0,
             sort="newest",
@@ -83,3 +83,28 @@ async def test_the_cache_branches_are_still_seeks():
         async with db.execute("EXPLAIN QUERY PLAN " + query, params) as cursor:
             plan = [str(row[3]) for row in await cursor.fetchall()]
         assert [line for line in plan if line.startswith("SCAN detections")] == [], plan
+
+
+@pytest.mark.asyncio
+async def test_the_seek_matches_exactly_what_the_general_query_matches():
+    """The list and the count run different queries; if the seek is broader
+    than the join, a page shows rows the count never counted."""
+    from app.repositories.detection_repository import DetectionRepository
+
+    async with get_db() as db:
+        # This row names a different species outright, but its display name
+        # collides with the filtered taxon's common name. The general query
+        # will not claim it: a row with its own scientific name is matched on
+        # that name alone.
+        await db.execute(
+            """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index,
+               score, display_name, category_name, scientific_name, taxa_id, is_hidden)
+               VALUES ('name_collision', 'cam1', '2026-08-30 10:00:00', 1, 0.9,
+                       'Dunnock', 'Robin', 'Erithacus rubecula', NULL, 0)"""
+        )
+        await db.commit()
+
+        repo = DetectionRepository(db)
+        listed = [d.frigate_event for d in await repo.get_all(taxa_id=TAXON)]
+        counted = await repo.get_count(taxa_id=TAXON)
+        assert len(listed) == counted, f"listed {listed} but counted {counted}"


### PR DESCRIPTION
## Outcome

Two refinements to the #365 and #360 fixes, found by reviewing them against real data before they reach anyone.

**A defect in #365's fix (would have shipped).** The seek matched any cached name against any of the three name columns. The general query is not symmetric — a row with its own scientific name is matched on that alone; only a row without one is matched on its display name. So the seek could claim a row the count would not, and a page would show a visit the total never counted. Now mirrored exactly.

**An unfinished edge in #360's fix.** A correction dropped the previous identity but recorded nothing, leaving the row unidentified until the next startup. The caller knows the corrected scientific name, so it now resolves the catalogue identity (off the loop) and passes it in; unresolvable still records nothing, which is honest.

## Verified against a snapshot of the production database

- 45 taxa checked: **no list/count mismatch**
- a cache-only row is found by the seek, and parity holds with it present
- an identity survives a better same-species result (1391 → 1391) and is replaced by a correction
- rarest taxon (1 row) filters in **0.4 ms** — the property #258 exists for

Plus 2,649 backend tests, svelte-check 0/0, ruff clean.