### PR TITLE
Give the database connection back before asking Frigate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Asking Frigate about a page of visits no longer blocks everything else
+  ([#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)).** Loading the events
+  list asks Frigate about every event on the page, one network round trip each, and it did that
+  while holding one of the five pooled database connections. On a real install that hold reached 27
+  seconds, and every other request needing the database queued behind it, which is what an owner
+  experienced as the whole interface being slow. Resetting the database appeared to fix it only
+  because a smaller history asks about fewer events. The rows are read first and the connection
+  given back before Frigate is asked, and a test now fails if a connection is ever held across that
+  wait.
+
+
+### Fixed
+
 - **The frame picker names pictures instead of subsystems
   ([#256](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/256)).** Choosing the
   photograph for a visit offered "Frigate hint crop", "Model crop" and "Full snapshot" - which part

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -705,13 +705,19 @@ async def get_events(
             frigate_event=event_id,
         )
 
-        # Batch fetch clip availability from Frigate (eliminates N individual HEAD requests)
         event_ids = [e.frigate_event for e in events]
-        clip_availability = await batch_check_clips(event_ids)
         from app.repositories.manual_observation_repository import ManualObservationRepository
 
         manual_observation_metadata = await ManualObservationRepository(db).metadata_by_event_ids(event_ids)
 
+    # Asking Frigate about every event on the page is a network round trip per
+    # event, and the pool has five connections. Holding one across that made a
+    # busy page block everything else needing the database, which is what an
+    # owner experienced as the whole interface being slow (#300). The rows are
+    # already read, so the connection is given back first.
+    clip_availability = await batch_check_clips(event_ids)
+
+    async with get_db() as db:
         # Get labels that should be displayed as "Unknown Bird"
         unknown_labels = settings.classification.unknown_bird_labels
 

--- a/backend/tests/test_events_connection_hold.py
+++ b/backend/tests/test_events_connection_hold.py
@@ -1,0 +1,62 @@
+"""A pooled connection must not be held across a network round trip (#300).
+
+The events list asks Frigate about every event on the page, and it did so
+inside the block holding one of five pooled database connections. On a busy
+history that hold reached 27 seconds on a real install, and everything else
+needing the database queued behind it, which is what the owner experienced as
+the whole interface being slow. Resetting the database appeared to fix it
+because a small history asks Frigate about fewer events.
+"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import close_db, get_db, init_db
+from app.main import app
+
+FRIGATE_DELAY_SECONDS = 0.4
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def seeded_db():
+    await init_db()
+    try:
+        async with get_db() as db:
+            await db.execute("DELETE FROM detections")
+            for index in range(6):
+                await db.execute(
+                    """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index,
+                       score, display_name, category_name, is_hidden)
+                       VALUES (?, 'cam1', ?, 1, 0.9, 'Robin', 'Robin', 0)""",
+                    (f"evt_{index}", f"2026-08-31 10:0{index}:00"),
+                )
+            await db.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_frigate_round_trips_do_not_happen_while_a_connection_is_held(monkeypatch):
+    from app.routers import events as events_router
+
+    async def slow_frigate(event_id, timeout=None):
+        await asyncio.sleep(FRIGATE_DELAY_SECONDS)
+        return None, "event_not_found"
+
+    monkeypatch.setattr(events_router.frigate_client, "get_event_with_error", slow_frigate)
+
+    from app.database import get_db_pool_status
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/events?limit=6")
+        assert res.status_code == 200
+
+    hold_max_ms = get_db_pool_status()["hold_ms_max"]
+    assert hold_max_ms < FRIGATE_DELAY_SECONDS * 1000 * 0.5, (
+        f"a connection was held for {hold_max_ms} ms while Frigate took "
+        f"{FRIGATE_DELAY_SECONDS * 1000} ms, so the wait was inside the hold"
+    )


### PR DESCRIPTION
## Outcome

Addresses the still-live cause behind [#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300), reopened after the reporter found a database reset was what actually helped.

**Diagnosis from his own diagnostics bundle**, not theory:

| metric | value |
|---|---|
| `hold_ms_max` | **27,128 ms** |
| `hold_ms_avg` | 1,331 ms |
| `slow_hold_count` | 15 (threshold 1,000 ms) |
| `slow_hold_last_label` | **`app.routers.events:get_events`** |
| `acquire_wait_max_ms` | 6.55 |

Nobody waits *for* a connection; the work itself is slow. `get_events` asks Frigate about every event on the page (up to 50 round trips, 24 at a time, 2s timeout each) **inside** the `async with get_db()` block, holding one of five pooled connections throughout. Everything else needing the database queues behind it. A smaller history asks about fewer events, which is exactly why the reset appeared to fix it.

## Included

The rows are read and the connection released before Frigate is asked.

## Verification

A test drives the endpoint with a deliberately slow Frigate and asserts, through the pool's own instrumentation, that no connection was held across the wait. Before: **405 ms held for a 400 ms Frigate delay**. After: passes. Full backend suite green: 2,648; ruff clean.

## Not claimed as finished

Localized-name resolution still holds a connection while it works, and that scales with the number of distinct species in a history. Recorded on the issue rather than presented as done.