### PR TITLE
Let a first boot take the time a first boot takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A slow first boot is no longer mistaken for a broken container.** The image declared itself
+  unhealthy about seventy five seconds after starting, and a first boot on a Raspberry Pi, or on an
+  emulated arm64 build, spends longer than that running migrations and seeding the species
+  catalogue before it can answer at all. The container was called unhealthy while it was starting
+  normally, which failed a release build and, on a real Pi, invites whatever is supervising the
+  container to kill it. The health check now allows a first boot the time it actually needs, and
+  the steady-state check that follows is unchanged.
+
+### Fixed
+
 - **Asking Frigate about a page of visits no longer blocks everything else
   ([#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)).** Loading the events
   list asks Frigate about every event on the page, one network round trip each, and it did that

--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,17 @@ USER appuser
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=10s --timeout=10s --start-period=15s --retries=6 \
+# The start period covers a first boot, not a steady-state check. A slow host
+# (a Raspberry Pi, or an emulated arm64 build) has to run every migration and
+# seed the species catalogue before it can answer, which was measured at over
+# a minute on emulated arm64. With a 15s start period and six retries the
+# container was declared unhealthy at around 75 seconds while it was still
+# starting normally, which fails a build and, on a real Pi, invites an
+# orchestrator to kill a container that was doing nothing wrong. Failures
+# inside the start period do not count against the retries, so a generous
+# value costs a slow first boot nothing and does not weaken the steady-state
+# check that follows it.
+HEALTHCHECK --interval=10s --timeout=10s --start-period=300s --retries=6 \
     CMD /usr/local/bin/yawamf-healthcheck.sh || exit 1
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/yawamf-entrypoint.sh"]

--- a/backend/tests/test_container_healthcheck_start_period.py
+++ b/backend/tests/test_container_healthcheck_start_period.py
@@ -1,0 +1,28 @@
+"""A slow first boot must not be mistaken for an unhealthy container.
+
+A Raspberry Pi, or an emulated arm64 build, runs every migration and seeds the
+species catalogue before it can answer a health check. That was measured at
+over a minute on emulated arm64, and a 15 second start period with six retries
+declared the container unhealthy at around 75 seconds while it was starting
+normally. Docker does not count failures inside the start period, so the only
+cost of a generous value is that a genuinely broken first boot takes longer to
+be called broken; the steady-state check afterwards is unchanged.
+"""
+
+import re
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).resolve().parents[2] / "Dockerfile"
+MINIMUM_START_PERIOD_SECONDS = 180
+
+
+def test_the_healthcheck_allows_a_slow_first_boot():
+    healthcheck = [line for line in DOCKERFILE.read_text().splitlines() if line.startswith("HEALTHCHECK")]
+    assert healthcheck, "the image must define a health check"
+
+    match = re.search(r"--start-period=(\d+)s", healthcheck[0])
+    assert match, f"health check must state a start period: {healthcheck[0]}"
+    assert int(match.group(1)) >= MINIMUM_START_PERIOD_SECONDS, (
+        f"start period is {match.group(1)}s; a first boot on a slow host needs at least "
+        f"{MINIMUM_START_PERIOD_SECONDS}s before the container may be called unhealthy"
+    )


### PR DESCRIPTION
## Outcome

The 2.19.2 tag build failed on `build-monolith-rpi`. The app was starting normally: migrations took 9.7s, the species catalogue seeded, and the catalogue release imported at 14:05:57. The smoke test died at 14:05:58 because Docker had already marked the container **unhealthy**.

`--start-period=15s --retries=6 --interval=10s` declares a container unhealthy roughly 75 seconds in. An emulated arm64 first boot needs longer than that before it can answer at all.

This is not only a CI problem. On a real Raspberry Pi, a first boot doing the same work can cross the same threshold, and whatever supervises the container sees "unhealthy" for a container that is starting exactly as designed.

## Included

Start period raised to 300s. Failures inside the start period do not count against retries, so this costs a healthy boot nothing and leaves the steady-state check (10s interval, 6 retries) exactly as it was. A test pins the minimum, because this failure only shows up on hardware slower than a developer machine.

## Verification

2,651 backend tests, ruff clean.

## Release note

2.19.2's monolith images promoted and `latest` moved before the rpi job failed, so that release is out for every flavour except Raspberry Pi. Handling that separately.