### PR TITLE
Record the background-work surface, and close out the April shortlist

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -218,8 +218,8 @@ until saved configuration loads successfully, authenticated MQTT is supported in
 and the final review is localized from structured readiness codes.
 
 #### UI simplification & polish ✨
-**Priority:** P1 | **Effort:** L | **Status:** 🔄 In progress — Settings simplification complete;
-primary owner and guest journeys next
+**Priority:** P1 | **Effort:** L | **Status:** 🔄 In progress — Settings simplification and the
+background-work surface complete; the remaining primary owner and guest journeys next
 ([design](docs/plans/2026-07-16-settings-navigation-simplification-design.md))
 
 Make the whole UI clean, coherent, and calm — **especially Settings**, which is currently
@@ -234,6 +234,16 @@ now cover every Settings tab. Optional services are toggle-first, inactive crede
 hidden, maintenance/analytics/destructive tools no longer compete with routine policy, nested card
 noise and structural emoji are reduced, and the Settings type floor is 12px. The remaining work is
 the primary owner/guest journey review, including their loading, empty, error, and destructive states.
+
+✅ **Background work pass:** the separate jobs view is gone. It showed the same work three times
+over, as four counters, a "Work Lanes" list and an "Active Work" list, with two lanes sharing the
+title "Analyze Unknowns" and rows named after raw Frigate event ids. The notifications timeline
+already carried every job with its live progress, so the second view mostly disagreed with the
+first. Notifications is now the single surface for background work, and the one control the jobs
+view held alone, resuming a queue the circuit breaker paused, sits at the top of it where work
+needing a person belongs. Jobs are named by the work rather than the event, with the event kept as
+detail so two clips analysed at once are still told apart. Remaining on this surface: the empty
+state still describes only bird visits and does not yet mention the background work it now owns.
 
 #### A public projection of the settings a viewer needs 👥
 **Priority:** P1 | **Effort:** S

--- a/docs/plans/2026-04-17-pre-3.0-shortlist.md
+++ b/docs/plans/2026-04-17-pre-3.0-shortlist.md
@@ -1,5 +1,12 @@
 # Pre-3.0 Shortlist Implementation Plan
 
+Date: 2026-04-17
+Status: Delivered. All four items shipped and are in the current code: OAuth token encryption
+(`backend/app/services/oauth_token_crypto.py`, used by the SMTP and iNaturalist services), OAuth
+cleanup on logout (`OAuthTokenRepository.delete_all()` in `backend/app/routers/auth.py`), a typed
+`SettingsResponse` on `GET /api/settings`, and the 365-day range cap in `backend/app/routers/stats.py`.
+Kept as the record of the work; the live plan of record is [`ROADMAP.md`](../../ROADMAP.md).
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Implement the pre-3.0 shortlist: OAuth token encryption at rest, OAuth cleanup on logout, a typed `/api/settings` response model, and a 365-day server-side date range cap.


### PR DESCRIPTION
## Outcome

Documentation only. Two things had fallen out of step with the code.

The notifications consolidation (#377) is UI simplification work and is one of the seven 3.0 exit criteria, but the roadmap did not mention it. That criterion now records what landed and, honestly, what it did not: the empty state still describes only bird visits and does not mention the background work the page now owns.

The April pre-3.0 shortlist has been delivered in full for months and still read as an open plan. All four items are in the current code, verified rather than assumed:

- OAuth token encryption at rest: `backend/app/services/oauth_token_crypto.py`, used by the SMTP and iNaturalist services
- OAuth cleanup on logout: `OAuthTokenRepository(db).delete_all()` in `backend/app/routers/auth.py:406`
- Typed settings response: `SettingsResponse` on `GET /api/settings`
- 365-day range cap: `backend/app/routers/stats.py:432`

It now carries the delivered status the other plan docs use, and points at `ROADMAP.md` as the live plan of record.

## Excluded

No code, no behaviour change. The empty-state copy itself is not fixed here; it needs new wording in nine languages and is recorded as remaining work rather than guessed at.

## Verification

`docs_consistency_check.py` passed, 176 routes validated.

## Risk

None. Markdown only.