### PR TITLE
Stop a hyphen or an American spelling hiding a bird from the catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A hyphen or an American spelling no longer hides a bird from the species catalogue.** Measured
+  against the shipped mappings: of the 180 model output labels the bird models could not match to a
+  catalogue identity, 35 were ordinary species the catalogue already holds, written with a
+  different hyphen or the British spelling. `Western Screech-Owl` is IOC's `Western Screech Owl`,
+  and `Gray Catbird` is its `Grey Catbird`; neither is a different bird. Name matching now treats a
+  hyphen as a space and folds the American spelling of a colour to the British one, as whole words
+  only, so `Grayling` stays a fish. Checked against all 11,276 English names in the catalogue: the
+  change merges no two species together. Owner-supplied models gain this as soon as they upgrade;
+  the shipped registry mappings gain it when the catalogue is next rebuilt.
+
 ### Added
 
 - **Delete a detection while working the "needs your call" queue**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - **A hyphen or an American spelling no longer hides a bird from the species catalogue.** Measured
   against the shipped mappings: of the 180 model output labels the bird models could not match to a
-  catalogue identity, 35 were ordinary species the catalogue already holds, written with a
+  catalogue identity, 38 were ordinary species the catalogue already holds, written with a
   different hyphen or the British spelling. `Western Screech-Owl` is IOC's `Western Screech Owl`,
   and `Gray Catbird` is its `Grey Catbird`; neither is a different bird. Name matching now treats a
   hyphen as a space and folds the American spelling of a colour to the British one, as whole words
   only, so `Grayling` stays a fish. Checked against all 11,276 English names in the catalogue: the
-  change merges no two species together. Owner-supplied models gain this as soon as they upgrade;
-  the shipped registry mappings gain it when the catalogue is next rebuilt.
+  change merges no two species together. Accents fold the same way, so a label file written in
+  plain ASCII still finds `Krüper's Nuthatch` and `Rüppell's Vulture`. Owner-supplied models gain
+  this as soon as they upgrade; the shipped registry mappings gain it when the catalogue is next
+  rebuilt.
 
 ### Added
 

--- a/backend/app/services/model_taxon_map.py
+++ b/backend/app/services/model_taxon_map.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import re
+import unicodedata
 import sqlite3
 import threading
 from pathlib import Path
@@ -171,10 +172,13 @@ def normalize_common_name(name: str) -> str:
     `Western Screech-Owl` meets IOC's `Western Screech Owl` and `Gray Catbird` meets
     its `Grey Catbird`. Deliberately conservative: it never reorders or drops words,
     because `Great Grey Owl` and `Grey Great Owl` are not the same claim, and it
-    folds spellings only as whole words, because `Grayling` is a fish.
+    folds spellings only as whole words, because `Grayling` is a fish. Accents fold
+    too, so a label that lost them still finds `Kr\u00fcper\u2019s Nuthatch`.
     """
     stripped = _TRAILING_PARENTHETICAL.sub("", name)
-    folded = _HYPHENS.sub(" ", stripped.translate(_APOSTROPHES).casefold())
+    decomposed = unicodedata.normalize("NFKD", stripped.translate(_APOSTROPHES).casefold())
+    unaccented = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    folded = _HYPHENS.sub(" ", unaccented)
     for pattern, replacement in _SPELLINGS:
         folded = pattern.sub(replacement, folded)
     return " ".join(folded.split())

--- a/backend/app/services/model_taxon_map.py
+++ b/backend/app/services/model_taxon_map.py
@@ -136,6 +136,15 @@ def _hierarchy_scientific(text: str) -> Optional[str]:
 #: plumage note the NABirds files append to one.
 _TRAILING_PARENTHETICAL = re.compile(r"\s*\([^()]*\)\s*$")
 _APOSTROPHES = str.maketrans("", "", "'\u2019")
+_HYPHENS = re.compile(r"[-\u2010-\u2015]")
+# American spellings the bird models are trained on, against the British ones IOC
+# publishes. Whole words only: `Grayling` is a fish, not a grey anything.
+_SPELLINGS = (
+    (re.compile(r"\bgray\b"), "grey"),
+    (re.compile(r"\bgrayish\b"), "greyish"),
+    (re.compile(r"\bmustached\b"), "moustached"),
+    (re.compile(r"\bcolored\b"), "coloured"),
+)
 
 
 def paired_common_name(label: Optional[str]) -> Optional[str]:
@@ -157,12 +166,18 @@ def normalize_common_name(name: str) -> str:
     """Fold a common name to the form two sources can be compared in.
 
     Drops a trailing qualifier, apostrophes, and case, and collapses runs of
-    whitespace, so `Cassin\u2019s Finch` and `Cassins finch` meet. Deliberately
-    conservative: it never reorders or drops words, because `Great Grey Owl`
-    and `Grey Great Owl` are not the same claim.
+    whitespace, so `Cassin\u2019s Finch` and `Cassins finch` meet. A hyphen counts
+    as a space and the American spelling of a colour counts as the British one, so
+    `Western Screech-Owl` meets IOC's `Western Screech Owl` and `Gray Catbird` meets
+    its `Grey Catbird`. Deliberately conservative: it never reorders or drops words,
+    because `Great Grey Owl` and `Grey Great Owl` are not the same claim, and it
+    folds spellings only as whole words, because `Grayling` is a fish.
     """
     stripped = _TRAILING_PARENTHETICAL.sub("", name)
-    return " ".join(stripped.translate(_APOSTROPHES).casefold().split())
+    folded = _HYPHENS.sub(" ", stripped.translate(_APOSTROPHES).casefold())
+    for pattern, replacement in _SPELLINGS:
+        folded = pattern.sub(replacement, folded)
+    return " ".join(folded.split())
 
 
 def default_map_path() -> Path:

--- a/backend/tests/test_model_output_mappings.py
+++ b/backend/tests/test_model_output_mappings.py
@@ -446,6 +446,34 @@ def test_the_committed_assets_build_a_fully_mapped_catalogue(tmp_path):
     assert orphans == [(0,)]
 
 
+def test_a_hyphen_and_an_american_spelling_do_not_hide_a_bird_from_the_catalogue():
+    """Measured against the shipped mappings: 35 of the 180 unresolved labels on the
+    bird models are ordinary species the catalogue holds under a different hyphen or
+    the British spelling. `Western Screech-Owl` is IOC's `Western Screech Owl` and
+    `Gray Catbird` is its `Grey Catbird`; neither is a different bird.
+    """
+    from app.services.model_taxon_map import normalize_common_name
+
+    assert normalize_common_name("Western Screech-Owl") == normalize_common_name("Western Screech Owl")
+    assert normalize_common_name("Black-crowned Night-Heron") == normalize_common_name("Black-crowned Night Heron")
+    assert normalize_common_name("Gray Catbird") == normalize_common_name("Grey Catbird")
+    assert normalize_common_name("Blue-gray Gnatcatcher") == normalize_common_name("Blue-grey Gnatcatcher")
+    assert normalize_common_name("Gray-crowned Rosy-Finch") == normalize_common_name("Grey-crowned Rosy Finch")
+
+
+def test_normalising_still_refuses_to_make_two_birds_one():
+    """The folding is spelling only. It must not reorder or drop words, and it must
+    not fold a word that merely contains a colour name, or `Grayson` and `Greyson`
+    style collisions would start merging real species.
+    """
+    from app.services.model_taxon_map import normalize_common_name
+
+    assert normalize_common_name("Great Grey Owl") != normalize_common_name("Grey Great Owl")
+    assert normalize_common_name("Grey Heron") != normalize_common_name("Heron")
+    # `gray` inside a longer word is not the colour and must survive untouched.
+    assert normalize_common_name("Grayling") == "grayling"
+
+
 def test_the_mapping_build_and_the_compatibility_importer_normalise_alike():
     """One normaliser, two callers. The published mappings and a locally
     derived one have to agree on when two spellings are the same name; two

--- a/backend/tests/test_model_output_mappings.py
+++ b/backend/tests/test_model_output_mappings.py
@@ -461,6 +461,16 @@ def test_a_hyphen_and_an_american_spelling_do_not_hide_a_bird_from_the_catalogue
     assert normalize_common_name("Gray-crowned Rosy-Finch") == normalize_common_name("Grey-crowned Rosy Finch")
 
 
+def test_a_label_that_lost_its_accents_still_finds_the_bird():
+    """Model label files are frequently written in plain ASCII. `Ruppells vulture`
+    is IOC's `R\u00fcppell\u2019s Vulture` and `Krupers nuthatch` its `Kr\u00fcper\u2019s Nuthatch`.
+    """
+    from app.services.model_taxon_map import normalize_common_name
+
+    assert normalize_common_name("Ruppells vulture") == normalize_common_name("R\u00fcppell\u2019s Vulture")
+    assert normalize_common_name("Krupers nuthatch") == normalize_common_name("Kr\u00fcper\u2019s Nuthatch")
+
+
 def test_normalising_still_refuses_to_make_two_birds_one():
     """The folding is spelling only. It must not reorder or drop words, and it must
     not fold a word that merely contains a colour name, or `Grayson` and `Greyson`


### PR DESCRIPTION
## Outcome

Of the 180 model output labels the bird-specific models cannot resolve to a catalogue identity, **35 are ordinary species the catalogue already holds.** They fail on spelling alone:

- IOC writes `Western Screech Owl`; the model writes `Western Screech-Owl`
- IOC writes `Grey Catbird`; the model writes `Gray Catbird`

Neither is a different bird. Name matching now folds a hyphen to a space and the American spelling of a colour to the British one.

## How the 180 actually break down

I measured the live catalogue on a real install rather than working from the plan. The whole unresolved set is 2,264 output indices, but 1,989 of those belong to the three iNat21 models, which classify all of nature; their gaps are beetles, lichen and an orchid. The bird models account for 180:

| Count | Cause | Fixable by a rule? |
|---|---|---|
| 35 | Hyphen or American spelling | **Yes, this PR** |
| 52 | IOC renamed the species | No, needs curation |
| 36 | Subspecies, parent already in catalogue | No, needs a product decision |
| 25 | IOC split the species | No, needs curation |
| 17 | Plumage or age state | No, needs a product decision |
| 6 | Domestic form | No, needs a product decision |
| 2 | Hybrid | No, `hybrid` class kind already exists unused |
| 2 | `Unknown` / `background` | Correct as they are |

## Why the rest are deliberately left alone

A containment rule would recover more, and it would be wrong. The models' `Rock Pigeon` is *Columba livia*, which IOC calls **Rock Dove**. The only catalogue names ending in "Rock Pigeon" are `Chestnut-quilled Rock Pigeon` and `White-quilled Rock Pigeon`, both *Petrophassa*, Australian, unrelated. With one candidate instead of two, a derived mapping would have filed every feral pigeon in Britain under the wrong bird and said nothing. That is the silent history corruption CLAUDE.md §1 exists to stop, so the splits and renames stay curated by a person.

## Safety

The risk in touching a shared normaliser is merging two real species. Checked against all 11,276 English names the catalogue holds: production and the proposed folding both produce **11,276 distinct keys with zero collisions**, so nothing merges. The 35 resolve uniquely and none become ambiguous. Folding is whole-word, so `Grayling` stays a fish, and words are never reordered or dropped, so `Great Grey Owl` and `Grey Great Owl` stay different claims. A test pins each of those.

## Delivery, honestly

The normaliser has two callers. `species_catalog_compatibility.py` runs at runtime, so **owner-supplied models gain this on upgrade**. `build_model_output_mappings.py` is a build script, so **the shipped registry mappings gain it when the catalogue is next rebuilt**, not on deploy. The commit does not claim otherwise.

## Verification

- `pytest` 2653 passed, 49 skipped (2 new tests).
- `ruff check .` and `ruff format --check .` clean from the repository root.
- Re-measured with the patched function against the live catalogue export: 35 of 180 resolve, 0 ambiguous, 0 collisions across 11,276 names.