### PR TITLE
Resolve a species IOC has moved to another genus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A species IOC has moved to another genus now resolves.** `Anas strepera (Gadwall)` failed on
+  its scientific name because IOC calls the bird `Mareca strepera`, while the common name the same
+  label carries is current. Taking that common name on its own would trust an English name two
+  birds can share, so the specific epithet has to survive the move as well: `strepera` stays
+  `strepera`. Both halves of the label then agree and nothing is authored by hand. 9 outputs gain
+  an identity. `Caracara cheriway` is deliberately not one of them, because IOC's bird is
+  `Caracara plancus` and a changed epithet is a lump, not a move; it stays unresolved for a person.
+
 - **A subspecies now resolves to the species IOC actually recognises.** A trinomial like
   `Anas crecca carolinensis` is not automatically its first two words: IOC treats it as the
   separate species `Anas carolinensis`, so dropping the third epithet would have filed an American

--- a/backend/app/services/model_taxon_map.py
+++ b/backend/app/services/model_taxon_map.py
@@ -228,6 +228,29 @@ def corroborates(catalogue_name: str, label_common_name: Optional[str]) -> bool:
     return bool(left & right)
 
 
+_GENUS_EPITHET = re.compile(r"^([A-Z][a-z]+) ([a-z]+)\b")
+
+
+def shares_specific_epithet(label: str, catalogue_scientific_name: Optional[str]) -> bool:
+    """Whether a label's scientific name and the catalogue's differ only by genus.
+
+    IOC moves species between genera, so `Anas strepera` is now `Mareca strepera`
+    and the label's scientific name resolves to nothing while its common name is
+    still current. The epithet surviving the move is what separates a reassignment
+    from two unrelated birds that happen to share an English name, so a label with
+    no scientific half corroborates nothing.
+    """
+    if not isinstance(label, str) or not catalogue_scientific_name:
+        return False
+    if paired_common_name(label) is None:
+        return False
+    left = _GENUS_EPITHET.match(label.strip())
+    right = _GENUS_EPITHET.match(catalogue_scientific_name.strip())
+    if not left or not right:
+        return False
+    return left.group(2) == right.group(2) and left.group(1) != right.group(1)
+
+
 def default_map_path() -> Path:
     configured = os.environ.get("DB_PATH")
     if configured:

--- a/backend/scripts/build_model_output_mappings.py
+++ b/backend/scripts/build_model_output_mappings.py
@@ -41,6 +41,7 @@ from app.services.model_registry_inventory import registry_artifacts  # noqa: E4
 from app.services.model_taxon_map import normalize_common_name as _normalize_common  # noqa: E402
 from app.services.model_taxon_map import paired_common_name  # noqa: E402
 from app.services.model_taxon_map import corroborates, subspecies_candidates  # noqa: E402
+from app.services.model_taxon_map import shares_specific_epithet  # noqa: E402
 from app.services.model_taxon_map import scientific_name_from_label  # noqa: E402
 
 DEFAULT_OUTPUT = _BACKEND_DIR / "app" / "assets" / "model_output_mappings.json"
@@ -152,6 +153,33 @@ def resolve_subspecies(results: dict[str, LabelFileResult], resolver: "CatalogRe
     return recovered
 
 
+def resolve_moved_genus(results: dict[str, LabelFileResult], resolver: "CatalogResolver") -> int:
+    """Resolve a paired label whose genus IOC has since changed.
+
+    `Anas strepera (Gadwall)` fails on its scientific name because IOC now calls the
+    bird `Mareca strepera`, while the common name the same label carries is current.
+    Taking the common name alone would trust an English name two birds can share, so
+    the specific epithet has to survive the move as well. Both halves of the label
+    then agree, and neither had to be authored by hand.
+    """
+    recovered = 0
+    for result in results.values():
+        for position, row in enumerate(result.rows):
+            if row.unresolved is None or row.kind != "species":
+                continue
+            common = paired_common_name(row.label)
+            if not common:
+                continue
+            reference, ambiguous = resolver.resolve_common(common)
+            if not reference or ambiguous:
+                continue
+            if not shares_specific_epithet(row.label, resolver.scientific_name_for(reference)):
+                continue
+            result.rows[position] = replace(row, provider=reference[0], taxon=reference[1], unresolved=None)
+            recovered += 1
+    return recovered
+
+
 class CatalogResolver:
     """Lookup tables built once from a seed catalogue.
 
@@ -164,6 +192,7 @@ class CatalogResolver:
         connection = sqlite3.connect(f"file:{seed_path}?mode=ro", uri=True)
         try:
             concept_ref: dict[int, tuple[str, str]] = {}
+            self._scientific_by_reference: dict[tuple[str, str], str] = {}
             self._by_scientific: dict[str, object] = {}
             for species_id, provider, taxon_id, scientific in connection.execute(
                 "SELECT species_id, provider, provider_taxon_id, scientific_name FROM species_concepts"
@@ -171,6 +200,7 @@ class CatalogResolver:
             ):
                 concept_ref.setdefault(species_id, (provider, taxon_id))
                 self._put(self._by_scientific, scientific.casefold(), concept_ref[species_id])
+                self._scientific_by_reference.setdefault(concept_ref[species_id], scientific)
 
             self._by_alias: dict[str, object] = {}
             for alias, species_id in connection.execute(
@@ -200,6 +230,10 @@ class CatalogResolver:
     def common_name_for(self, reference: Optional[tuple[str, str]]) -> Optional[str]:
         """The catalogue's English name for a resolved concept, if it has one."""
         return self._common_by_reference.get(reference) if reference else None
+
+    def scientific_name_for(self, reference: Optional[tuple[str, str]]) -> Optional[str]:
+        """The catalogue's scientific name for a resolved concept, if it has one."""
+        return self._scientific_by_reference.get(reference) if reference else None
 
     @staticmethod
     def _put(table: dict[str, object], key: str, reference: tuple[str, str]) -> None:
@@ -324,6 +358,7 @@ def compile_mappings(labels_dir: Path, seed_path: Path) -> dict[str, object]:
     # A trinomial is last: the two passes above may already have named it, and this
     # one deliberately settles for the parent species when nothing better fits.
     subspecies = resolve_subspecies(compiled, resolver)
+    moved_genus = resolve_moved_genus(compiled, resolver)
 
     for labels_sha256, result in compiled.items():
         label_files[labels_sha256] = {
@@ -335,6 +370,7 @@ def compile_mappings(labels_dir: Path, seed_path: Path) -> dict[str, object]:
     return {
         "bridged_common_names": bridged,
         "resolved_subspecies": subspecies,
+        "resolved_moved_genus": moved_genus,
         "schema_version": 1,
         "label_files": label_files,
         "artifacts": [

--- a/backend/tests/test_model_output_mappings.py
+++ b/backend/tests/test_model_output_mappings.py
@@ -446,6 +446,23 @@ def test_the_committed_assets_build_a_fully_mapped_catalogue(tmp_path):
     assert orphans == [(0,)]
 
 
+def test_a_moved_genus_resolves_through_the_name_the_label_pairs_with_it():
+    """`Anas strepera (Gadwall)` fails on its scientific name because IOC now calls
+    it `Mareca strepera`. The label's own common name is current, and the specific
+    epithet survives the move, so the two halves of the label corroborate each other
+    and the reassignment resolves without anyone authoring an alias.
+    """
+    from app.services.model_taxon_map import shares_specific_epithet
+
+    assert shares_specific_epithet("Anas strepera (Gadwall)", "Mareca strepera")
+    assert shares_specific_epithet("Charadrius nivosus (Snowy Plover)", "Anarhynchus nivosus")
+    # A different bird that merely shares a common name must not pass.
+    assert not shares_specific_epithet("Anas strepera (Gadwall)", "Mareca penelope")
+    # Nothing to compare is not corroboration.
+    assert not shares_specific_epithet("Gadwall", "Mareca strepera")
+    assert not shares_specific_epithet("Anas strepera (Gadwall)", None)
+
+
 def test_a_subspecies_resolves_to_the_species_ioc_actually_recognises():
     """A trinomial is not automatically its first two words. IOC treats
     `Anas crecca carolinensis` as the separate species `Anas carolinensis`, so


### PR DESCRIPTION
Closes the last of the mechanical catalogue recoveries.

## Outcome

`Anas strepera (Gadwall)` failed on its scientific name because IOC now calls the bird `Mareca strepera`. The common name the same label carries is current, and the specific epithet survives the move, so the two halves of the label corroborate each other. **9 outputs gain an identity.**

With the two passes already merged, unresolved falls from **1,548 to 1,370**.

## Why the epithet check is the whole point

Resolving on the paired common name alone would trust an English name two birds can share, which is the same shape of mistake as mapping `Rock Pigeon` to an Australian *Petrophassa*. Requiring `strepera` to stay `strepera` across the genus move makes the agreement independent evidence rather than a coincidence of spelling.

It refuses what it should:

- **`Caracara cheriway (Crested Caracara)` does not resolve.** IOC's bird is `Caracara plancus`. A changed epithet is a lump, not a genus move, so it stays unresolved for a person rather than being guessed. I predicted 10 recoveries and got 9 for exactly this reason, which is the guard working.
- A label with no scientific half corroborates nothing and is skipped, so the existing invariant that a `scientific_binomial` label never matches by common name is untouched.

## What it recovers

*Charadrius* plovers moved to *Anarhynchus* (Snowy, Wilson's, Mountain), `Anas` ducks split to *Mareca* and *Spatula* (Gadwall, Cinnamon Teal), `Ammodramus nelsoni` to *Ammospiza*, `Lonchura oryzivora` to *Padda*, `Amazilia violiceps` to *Ramosomyia*, `Euphonia elegantissima` to *Chlorophonia*.

## Verification

- `pytest` 2659 passed, 49 skipped (1 new test covering the match and three refusals).
- `ruff check .` / `ruff format --check .` clean from the repository root.
- Run against the real `model_output_mappings.json`: bridge 127, subspecies 42, moved genus 9; 1,548 → 1,370. Spot-checked that `Anas strepera` lands on Gadwall (*Mareca strepera*) and `Caracara cheriway` stays unresolved.

## A bug this caught in itself

The first cut named its regex `_BINOMIAL`, which already exists in that module and is used by the scientific-name parser. Module-level rebinding meant the new definition silently won and two unrelated tests failed. Renamed to `_GENUS_EPITHET`. Nothing but the existing tests would have caught it.