### PR TITLE
Serve the settings a viewer needs from one public projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- **One public projection of the settings a viewer needs.** `/api/settings` is owner-only, so the
+  interface had no way to read a display preference as a guest, and every setting that shapes what
+  a visitor sees had been copied onto the auth status payload one field at a time as somebody
+  noticed it was missing. That pattern only ever finds a defect after a visitor has already been
+  given the wrong interface. `GET /api/settings/public` now serves those preferences identically to
+  a guest and an owner, as a named allowlist rather than a filtered copy, so a new preference is
+  public or owner-only by decision.
+
 ### Fixed
+
+- **A guest sees the interface the owner configured, not the built-in defaults.** Three settings
+  never reached a visitor. Detections needing a person were never flagged, because the review check
+  answers "no" when it has no threshold and a guest had none, while the layout standard names that
+  flag as one of the three signals a visit carries: the guest view was making a claim it could not
+  support. Nearby sightings always read "last 14 days" whatever the owner set, beside a radius that
+  did travel publicly. And clip playback was withheld whatever the owner configured, independently
+  of the setting that is supposed to decide it.
 
 - **A species IOC has moved to another genus now resolves.** `Anas strepera (Gadwall)` failed on
   its scientific name because IOC calls the bird `Mareca strepera`, while the common name the same

--- a/apps/ui/src/App.svelte
+++ b/apps/ui/src/App.svelte
@@ -23,6 +23,7 @@
   import { layoutStore } from './lib/stores/layout.svelte';
 import { accessibilityPreview } from './lib/stores/accessibility_preview.svelte';
   import { settingsStore } from './lib/stores/settings.svelte';
+  import { publicSettingsStore } from './lib/stores/public_settings.svelte';
   import { detectionsStore } from './lib/stores/detections.svelte';
   import { authStore } from './lib/stores/auth.svelte';
   import { notificationCenter } from './lib/stores/notification_center.svelte';
@@ -533,6 +534,9 @@ import { accessibilityPreview } from './lib/stores/accessibility_preview.svelte'
               } else {
                   settingsStore.clear();
               }
+              // Everyone reads the public projection, so a guest sees the interface the
+              // owner configured rather than the built-in defaults.
+              void publicSettingsStore.load();
               detectionsStore.loadInitial();
               connectSSE();
               if (authStore.showSettings) {

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -1215,6 +1215,12 @@ export interface components {
     authorization_url: string;
     state?: string | null;
 };
+    PublicSettings: {
+    classification_threshold: number;
+    clips_enabled: boolean;
+    ebird_default_days_back: number;
+    recording_clip_enabled: boolean;
+};
     PurgeMissingMediaResponse: {
     checked: number;
     cleared_missing_count: number;
@@ -3547,6 +3553,15 @@ export interface paths {
       query: never;
       requestBody: components['schemas']['NotificationTestRequest'];
       response: components['schemas']['ActionStatusResponse'];
+    };
+  };
+  "/api/settings/public": {
+    get: {
+      operationId: "get_public_settings_api_settings_public_get";
+      path: never;
+      query: never;
+      requestBody: unknown;
+      response: components['schemas']['PublicSettings'];
     };
   };
   "/api/setup/state": {

--- a/apps/ui/src/lib/api/settings.ts
+++ b/apps/ui/src/lib/api/settings.ts
@@ -254,3 +254,16 @@ export async function importConfigBackup(payload: unknown): Promise<ConfigBackup
     });
     return handleResponse<ConfigBackupImportResult>(response);
 }
+
+/** The display preferences a viewer needs, served to guest and owner alike. */
+export interface PublicSettings {
+    classification_threshold: number;
+    ebird_default_days_back: number;
+    clips_enabled: boolean;
+    recording_clip_enabled: boolean;
+}
+
+export async function fetchPublicSettings(): Promise<PublicSettings> {
+    const response = await apiFetch(`${API_BASE}/settings/public`);
+    return handleResponse<PublicSettings>(response);
+}

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -41,6 +41,7 @@
     import VideoAnalysisFilmReel from './VideoAnalysisFilmReel.svelte';
     import { detectionsStore, type ReclassificationProgress } from '../stores/detections.svelte';
     import { settingsStore } from '../stores/settings.svelte';
+    import { publicSettingsStore } from '../stores/public_settings.svelte';
     import { authStore } from '../stores/auth.svelte';
     import { toastStore } from '../stores/toast.svelte';
     import { getBirdNames } from '../naming';
@@ -844,7 +845,9 @@
     const ebirdRadius = $derived(
         settingsStore.settings?.ebird_default_radius_km ?? authStore.ebirdDefaultRadiusKm ?? 25
     );
-    const ebirdDaysBack = $derived(settingsStore.settings?.ebird_default_days_back ?? 14);
+    const ebirdDaysBack = $derived(
+        settingsStore.settings?.ebird_default_days_back ?? publicSettingsStore.settings?.ebird_default_days_back ?? 14
+    );
     const showEbirdNearby = $derived(
         enrichmentSightingsProvider === 'ebird' || enrichmentSeasonalityProvider === 'ebird'
     );

--- a/apps/ui/src/lib/components/DetectionRow.svelte
+++ b/apps/ui/src/lib/components/DetectionRow.svelte
@@ -18,6 +18,7 @@
     import { needsReview } from '../utils/visit-grouping';
     import DetectionPreview from './DetectionPreview.svelte';
     import { settingsStore } from '../stores/settings.svelte';
+    import { publicSettingsStore } from '../stores/public_settings.svelte';
     import { authStore } from '../stores/auth.svelte';
 
     interface Props {
@@ -75,7 +76,11 @@
      * dashboard's review queue and field log already apply. Inventing a number
      * here would flag a different set of rows to the rest of the app.
      */
-    const reviewThreshold = $derived(settingsStore.settings?.classification_threshold ?? null);
+    // Read from the public projection: the owner-only settings gave a guest null, and
+    // needsReview() answers false on null, so no visitor ever saw a row needing a person.
+    const reviewThreshold = $derived(
+        settingsStore.settings?.classification_threshold ?? publicSettingsStore.settings?.classification_threshold ?? null
+    );
     const needsAttention = $derived(needsReview(detection, reviewThreshold));
 
     /** The bands the visual standard sets: under 60 amber, under 85 brand, above green. */

--- a/apps/ui/src/lib/components/NotableNearby.svelte
+++ b/apps/ui/src/lib/components/NotableNearby.svelte
@@ -6,6 +6,7 @@
     import { getErrorMessage } from '../utils/error-handling';
     import { authStore } from '../stores/auth.svelte';
     import { settingsStore } from '../stores/settings.svelte';
+    import { publicSettingsStore } from '../stores/public_settings.svelte';
     import { formatDistance, resolveWeatherUnitSystem } from '../utils/weather-units';
 
     interface Props {
@@ -38,7 +39,9 @@
     const radius = $derived(
         settingsStore.settings?.ebird_default_radius_km ?? authStore.ebirdDefaultRadiusKm ?? 25
     );
-    const daysBack = $derived(settingsStore.settings?.ebird_default_days_back ?? 14);
+    const daysBack = $derived(
+        settingsStore.settings?.ebird_default_days_back ?? publicSettingsStore.settings?.ebird_default_days_back ?? 14
+    );
     const weatherUnitSystem = $derived(
         resolveWeatherUnitSystem(
             settingsStore.settings?.location_weather_unit_system ?? authStore.locationWeatherUnitSystem,

--- a/apps/ui/src/lib/components/SpeciesDetailModal.svelte
+++ b/apps/ui/src/lib/components/SpeciesDetailModal.svelte
@@ -17,6 +17,7 @@
     } from '../api';
     import { getBirdNames } from '../naming';
     import { settingsStore } from '../stores/settings.svelte';
+    import { publicSettingsStore } from '../stores/public_settings.svelte';
     import { authStore } from '../stores/auth.svelte';
     import { detectionsStore } from '../stores/detections.svelte';
     import { toastStore } from '../stores/toast.svelte';
@@ -123,7 +124,9 @@
     const ebirdRadius = $derived(
         settingsStore.settings?.ebird_default_radius_km ?? authStore.ebirdDefaultRadiusKm ?? 25
     );
-    const ebirdDaysBack = $derived(settingsStore.settings?.ebird_default_days_back ?? 14);
+    const ebirdDaysBack = $derived(
+        settingsStore.settings?.ebird_default_days_back ?? publicSettingsStore.settings?.ebird_default_days_back ?? 14
+    );
     const ebirdWeatherUnitSystem = $derived(
         resolveWeatherUnitSystem(
             settingsStore.settings?.location_weather_unit_system ?? authStore.locationWeatherUnitSystem,

--- a/apps/ui/src/lib/pages/Events.svelte
+++ b/apps/ui/src/lib/pages/Events.svelte
@@ -25,6 +25,7 @@
     import { explorerViewStore } from '../stores/explorer_view.svelte';
     import { explorerFiltersStore } from '../stores/explorer_filters.svelte';
     import { settingsStore } from '../stores/settings.svelte';
+    import { publicSettingsStore } from '../stores/public_settings.svelte';
     import { pageRefreshAction } from '../stores/page_refresh_action.svelte';
     import { fullVisitStore } from '../stores/full-visit.svelte';
     import { authStore } from '../stores/auth.svelte';
@@ -92,8 +93,8 @@
     let fullVisitAvailability = $derived(fullVisitStore.availability);
     let fullVisitFetchState = $derived(fullVisitStore.fetchState);
     let recordingClipFetchEnabled = $derived(
-        (settingsStore.settings?.recording_clip_enabled ?? false) &&
-        (settingsStore.settings?.clips_enabled ?? false)
+        (settingsStore.settings?.recording_clip_enabled ?? publicSettingsStore.settings?.recording_clip_enabled ?? false) &&
+        (settingsStore.settings?.clips_enabled ?? publicSettingsStore.settings?.clips_enabled ?? false)
     );
     let selectedEventFullVisitHandler = $derived.by(() => {
         const current = selectedEvent;

--- a/apps/ui/src/lib/stores/public_settings.svelte.ts
+++ b/apps/ui/src/lib/stores/public_settings.svelte.ts
@@ -1,0 +1,33 @@
+import { fetchPublicSettings, type PublicSettings } from '../api/settings';
+
+/**
+ * The display preferences a viewer needs, read by guest and owner alike.
+ *
+ * `settingsStore` is fed by the owner-only `/api/settings`, so every read of the
+ * form `settingsStore.settings?.x ?? fallback` silently gave a guest the fallback
+ * rather than what the owner configured. Reads that shape what a visitor sees
+ * belong here instead.
+ */
+class PublicSettingsStore {
+    settings = $state<PublicSettings | null>(null);
+    private request: Promise<void> | null = null;
+
+    async load(): Promise<void> {
+        // One flight at a time; several components ask for this on the same paint.
+        if (this.request) return this.request;
+        this.request = (async () => {
+            try {
+                this.settings = await fetchPublicSettings();
+            } catch {
+                // A viewer who cannot read the projection keeps the built-in defaults
+                // rather than an empty interface.
+                this.settings = null;
+            } finally {
+                this.request = null;
+            }
+        })();
+        return this.request;
+    }
+}
+
+export const publicSettingsStore = new PublicSettingsStore();

--- a/backend/app/models/public_settings.py
+++ b/backend/app/models/public_settings.py
@@ -1,0 +1,46 @@
+"""The settings a viewer legitimately needs, and nothing else.
+
+`/api/settings` is owner-only and returns everything, so the SPA had no way to read
+a single display preference as a guest. Every setting that shapes what a visitor
+sees was therefore copied onto `/api/auth/status` one field at a time as somebody
+noticed it was missing, which only ever finds a defect after a visitor has already
+been given the wrong interface.
+
+This module is the decision point. A setting is public because it is declared here,
+not because anyone remembered, and because the projection names its fields rather
+than filtering a copy of the settings, a secret added later cannot arrive in it by
+accident.
+"""
+
+from pydantic import BaseModel, Field
+
+from app.config import settings
+
+
+class PublicSettings(BaseModel):
+    """Display preferences served identically to a guest and to an owner."""
+
+    # Below this score a visit is flagged as needing a person. Without it a guest
+    # saw no row flagged at all, while the layout standard names that flag as one
+    # of the three signals a visit carries.
+    classification_threshold: float = Field(description="Score below which a detection is flagged as needing review")
+    # The window the nearby-sightings panel reports. The radius beside it already
+    # travelled publicly, so a guest read a real radius against a default window.
+    ebird_default_days_back: int = Field(description="Days back used for nearby eBird sightings")
+    # Whether clips exist at all. Whether a guest may download one is a separate
+    # decision that `public_access_allow_clip_downloads` already makes.
+    clips_enabled: bool = Field(description="Whether Frigate clip capture is enabled")
+    recording_clip_enabled: bool = Field(description="Whether recording-backed clips are enabled")
+
+
+PUBLIC_SETTING_FIELDS: tuple[str, ...] = tuple(PublicSettings.model_fields)
+
+
+def build_public_settings() -> PublicSettings:
+    """Read the projection from configuration. Pure enough to test on its own."""
+    return PublicSettings(
+        classification_threshold=settings.classification.threshold,
+        ebird_default_days_back=settings.ebird.default_days_back,
+        clips_enabled=settings.frigate.clips_enabled,
+        recording_clip_enabled=settings.frigate.recording_clip_enabled,
+    )

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -18,6 +18,7 @@ from app.auth import (
     validate_bcrypt_password_length,
 )
 from app.database import get_db
+from app.models.public_settings import PublicSettings, build_public_settings
 from app.repositories.detection_repository import DetectionRepository
 
 from app.services.canonical_identity_repair_service import canonical_identity_repair_service
@@ -1306,6 +1307,18 @@ async def import_settings(
         changed_fields=changed_fields,
     )
     return SettingsImportResponse(status="imported", changed_fields=changed_fields)
+
+
+@router.get("/settings/public", response_model=PublicSettings)
+async def get_public_settings() -> PublicSettings:
+    """The display preferences a viewer needs, served to guest and owner alike.
+
+    Deliberately unauthenticated. `/api/settings` is owner-only, so a guest could
+    read no display preference at all and every one that shaped their view had to
+    be copied onto the auth status payload by hand. The projection names its
+    fields, so what is public is a decision rather than an oversight.
+    """
+    return build_public_settings()
 
 
 @router.get("/settings", response_model=SettingsResponse)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8411,6 +8411,39 @@
         "title": "OAuthAuthorizeResponse",
         "type": "object"
       },
+      "PublicSettings": {
+        "description": "Display preferences served identically to a guest and to an owner.",
+        "properties": {
+          "classification_threshold": {
+            "description": "Score below which a detection is flagged as needing review",
+            "title": "Classification Threshold",
+            "type": "number"
+          },
+          "clips_enabled": {
+            "description": "Whether Frigate clip capture is enabled",
+            "title": "Clips Enabled",
+            "type": "boolean"
+          },
+          "ebird_default_days_back": {
+            "description": "Days back used for nearby eBird sightings",
+            "title": "Ebird Default Days Back",
+            "type": "integer"
+          },
+          "recording_clip_enabled": {
+            "description": "Whether recording-backed clips are enabled",
+            "title": "Recording Clip Enabled",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "classification_threshold",
+          "ebird_default_days_back",
+          "clips_enabled",
+          "recording_clip_enabled"
+        ],
+        "title": "PublicSettings",
+        "type": "object"
+      },
       "PurgeMissingMediaResponse": {
         "properties": {
           "checked": {
@@ -23285,6 +23318,36 @@
           }
         ],
         "summary": "Test Notification"
+      }
+    },
+    "/api/settings/public": {
+      "get": {
+        "description": "The display preferences a viewer needs, served to guest and owner alike.\n\nDeliberately unauthenticated. `/api/settings` is owner-only, so a guest could\nread no display preference at all and every one that shaped their view had to\nbe copied onto the auth status payload by hand. The projection names its\nfields, so what is public is a decision rather than an oversight.",
+        "operationId": "get_public_settings_api_settings_public_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSettings"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          },
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ],
+        "summary": "Get Public Settings"
       }
     },
     "/api/setup/state": {

--- a/backend/tests/test_public_settings_projection.py
+++ b/backend/tests/test_public_settings_projection.py
@@ -1,0 +1,66 @@
+"""One public projection of the settings a viewer needs.
+
+`/api/settings` is owner-only and returns everything, so every display preference
+a visitor needs has been copied onto `/api/auth/status` one field at a time as
+somebody noticed it was missing. That pattern only finds a defect after a visitor
+has already been given the wrong interface. This projection is the decision point:
+a setting is public because it is declared here, not because anyone remembered.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.models.public_settings import PUBLIC_SETTING_FIELDS, PublicSettings, build_public_settings
+
+
+@pytest.mark.asyncio
+async def test_a_guest_and_an_owner_resolve_the_same_value_for_every_public_setting():
+    """The whole point of the projection. If these ever diverge, a visitor is being
+    shown an interface the owner did not configure."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        guest = await client.get("/api/settings/public")
+        owner = await client.get("/api/settings/public", headers={"X-API-Key": "not-required-here"})
+
+    assert guest.status_code == 200
+    assert owner.status_code == 200
+    assert guest.json() == owner.json()
+    for field in PUBLIC_SETTING_FIELDS:
+        assert field in guest.json(), f"{field} is declared public but not served"
+
+
+@pytest.mark.asyncio
+async def test_the_projection_carries_the_three_settings_a_guest_was_denied():
+    """Each of these shaped what a visitor saw and none of them reached one.
+
+    The review flag is the worst: `needsReview` returns False when the threshold is
+    null, so a guest never saw a row flagged as needing a person, while the layout
+    standard names that flag as one of the three signals a visit carries. The guest
+    view was making a claim it could not support.
+    """
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        body = (await client.get("/api/settings/public")).json()
+
+    assert "classification_threshold" in body
+    assert "ebird_default_days_back" in body
+    assert "recording_clip_enabled" in body
+    assert "clips_enabled" in body
+
+
+def test_the_projection_is_an_allowlist_and_can_never_carry_a_secret():
+    """A filtered copy of the settings would leak a new secret the day one is added.
+    The projection names its fields, so a secret can only appear by someone writing
+    it here on purpose."""
+    declared = set(PublicSettings.model_fields)
+    assert declared == set(PUBLIC_SETTING_FIELDS)
+    for field in declared:
+        assert not any(marker in field for marker in ("key", "token", "password", "secret", "credential")), (
+            f"{field} looks like a secret and must not be in a public projection"
+        )
+
+
+def test_building_the_projection_needs_no_database_or_request():
+    """Pure, so the decision about what is public is testable on its own."""
+    projection = build_public_settings()
+    assert isinstance(projection, PublicSettings)
+    assert projection.model_dump().keys() == set(PUBLIC_SETTING_FIELDS)

--- a/docs/api.md
+++ b/docs/api.md
@@ -344,6 +344,10 @@ model metadata. Passing undeclared rows are reported as `declared: false` and un
 ### Settings and Maintenance
 
 - `GET /api/settings` (owner)
+- `GET /api/settings/public` — the display preferences a viewer needs, served identically to a
+  guest and to an owner. Deliberately unauthenticated, and an allowlist rather than a filtered
+  copy: a setting is public because it is named in `backend/app/models/public_settings.py`, so a
+  new one is public or owner-only by decision rather than by whether anyone remembered.
 - `POST /api/settings` (owner)
 - `POST /api/settings/birdnet/test` (owner) — synchronously proves a mock detection can
   enter the audio-correlation buffer and complete a database insert/delete; returns `502`


### PR DESCRIPTION
The UI design work you picked. Roadmap item "A public projection of the settings a viewer needs".

## The problem

`/api/settings` is owner-only, so the interface had no way to read a single display preference as a guest. Every setting that shapes what a visitor sees has therefore been copied onto `/api/auth/status` one field at a time as somebody noticed it was missing. That payload now carries around twenty display preferences and is not really an auth endpoint any more, and the pattern only finds a defect **after a visitor has already been given the wrong interface**.

## The three still open, all verified

| Setting | What a guest actually got |
|---|---|
| `classification_threshold` | **No detection ever flagged as needing a person.** `needsReview()` answers `false` when it has no threshold, and a guest had none. The layout standard names that flag as one of the three signals a visit carries, so the guest view was making a claim it could not support. |
| `ebird_default_days_back` | Always "last 14 days" whatever the owner set, beside a radius that *does* travel publicly. Three components read it. |
| `clips_enabled` + `recording_clip_enabled` | Playback withheld whatever the owner configured, independently of `public_access_allow_clip_downloads`, which is the setting supposed to decide it. |

All three share one root cause: `settingsStore.settings?.x ?? fallback`, where the store is fed by the owner-only endpoint, so a guest silently gets the fallback.

## The design

`GET /api/settings/public`, unauthenticated, served identically to guest and owner.

The important property is that it is **an allowlist, not a filtered copy**. `backend/app/models/public_settings.py` names its fields, so:

- A secret added to settings later cannot arrive in the projection by accident. A test asserts no field name looks like a credential.
- A new display preference is public or owner-only **by decision**, which is the outcome the roadmap asks for.
- `build_public_settings()` is pure, so what is public is testable without HTTP or a database.

A test asserts a guest and an owner resolve the same value for every field, which is the guard that stops this drifting back.

## Excluded, deliberately

Migrating the ~20 display preferences already on `/api/auth/status` is its own change. This adds the place they belong and proves it with the three that were still broken; moving the rest touches every reader of `authStore` and deserves its own review. The roadmap item stays open until that lands.

## Verification

- `pytest` 2663 passed, 49 skipped (4 new tests).
- `npm run check` 0 errors, 0 warnings across 630 files; `npm test` 991 passed.
- `ruff check .` / `ruff format --check .` clean from the repository root.
- OpenAPI artifacts regenerated (`backend/openapi.json`, `apps/ui/src/lib/api/generated/openapi.ts`), so the contract gate stays green.
- `docs_consistency_check.py` passed, 177 routes validated, and `docs/api.md` documents the endpoint.