### PR TITLE
Give Model Evaluation the visual language the rest of the app uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,29 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   a guest and an owner, as a named allowlist rather than a filtered copy, so a new preference is
   public or owner-only by decision.
 
+- **Delete a detection while working the "needs your call" queue**
+  ([#375](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/375)). The queue offered a
+  species, a block, or hiding, and hiding is right for a real bird the classifier scored badly. It
+  is not right for a rock. Deleting one meant leaving the queue for Explorer and losing your place.
+  There is now a Delete permanently action beside the others, confirmed with the same wording used
+  everywhere else: it says the record and its media leave the history for good, and that hiding
+  keeps the record instead.
+
 ### Changed
 
 - **Model Evaluation looks like the rest of the app.** It was the only page on a different grey,
   used a blue the app does not use anywhere else, styled its buttons as one-off utility classes
   instead of the shared kit, and had no control large enough to hit comfortably on a phone. Same
   palette, same controls, same touch-target floor as every other page now.
+
+- **Background work is now shown once, on the Notifications page.** The separate jobs view listed
+  the same work three times over: four counters at the top, a "Work Lanes" list, and an "Active
+  Work" list below it, with two lanes both titled "Analyze Unknowns" and rows named after raw
+  Frigate event ids like `1788274081.133679-ycxd6p`. Nothing there was missing from the
+  notifications timeline, which already carried every job with its live progress, so the second
+  view existed mainly to disagree with the first. The jobs view is gone and its one irreplaceable
+  control, resuming a queue the circuit breaker has paused, now sits at the top of Notifications
+  where work that needs a person belongs. Old jobs links still work and land on the timeline.
 
 ### Fixed
 
@@ -81,29 +98,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   plain ASCII still finds `Krüper's Nuthatch` and `Rüppell's Vulture`. Owner-supplied models gain
   this as soon as they upgrade; the shipped registry mappings gain it when the catalogue is next
   rebuilt.
-
-### Added
-
-- **Delete a detection while working the "needs your call" queue**
-  ([#375](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/375)). The queue offered a
-  species, a block, or hiding, and hiding is right for a real bird the classifier scored badly. It
-  is not right for a rock. Deleting one meant leaving the queue for Explorer and losing your place.
-  There is now a Delete permanently action beside the others, confirmed with the same wording used
-  everywhere else: it says the record and its media leave the history for good, and that hiding
-  keeps the record instead.
-
-### Changed
-
-- **Background work is now shown once, on the Notifications page.** The separate jobs view listed
-  the same work three times over: four counters at the top, a "Work Lanes" list, and an "Active
-  Work" list below it, with two lanes both titled "Analyze Unknowns" and rows named after raw
-  Frigate event ids like `1788274081.133679-ycxd6p`. Nothing there was missing from the
-  notifications timeline, which already carried every job with its live progress, so the second
-  view existed mainly to disagree with the first. The jobs view is gone and its one irreplaceable
-  control, resuming a queue the circuit breaker has paused, now sits at the top of Notifications
-  where work that needs a person belongs. Old jobs links still work and land on the timeline.
-
-### Fixed
 
 - **Background work is named by what it is, not by an event id.** Jobs were titled with the Frigate
   event they belonged to, which told an owner nothing about whether the row mattered to them. They

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   a guest and an owner, as a named allowlist rather than a filtered copy, so a new preference is
   public or owner-only by decision.
 
+### Changed
+
+- **Model Evaluation looks like the rest of the app.** It was the only page on a different grey,
+  used a blue the app does not use anywhere else, styled its buttons as one-off utility classes
+  instead of the shared kit, and had no control large enough to hit comfortably on a phone. Same
+  palette, same controls, same touch-target floor as every other page now.
+
 ### Fixed
 
 - **A guest sees the interface the owner configured, not the built-in defaults.** Three settings

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -235,6 +235,15 @@ hidden, maintenance/analytics/destructive tools no longer compete with routine p
 noise and structural emoji are reduced, and the Settings type floor is 12px. The remaining work is
 the primary owner/guest journey review, including their loading, empty, error, and destructive states.
 
+✅ **Less-frequent owner journeys pass:** Model Evaluation now speaks the same visual language as
+the rest of the app. It was the only page on Tailwind's `gray` ramp while every other page uses
+`slate`, used Tailwind blue where the app's accent is `brand`, styled its controls as raw utility
+classes rather than the kit in `app.css`, and had no control meeting the touch-target floor. Add
+observation was checked against the Evidence page shape and already follows it: slim bar, the
+1.35fr media and 0.85fr decision rail, and a confirm that names the bird it will add. Remaining on
+this surface: Model Evaluation carries no translations at all, which is its own piece of work
+rather than part of the visual pass.
+
 ✅ **Background work pass:** the separate jobs view is gone. It showed the same work three times
 over, as four counters, a "Work Lanes" list and an "Active Work" list, with two lanes sharing the
 title "Analyze Unknowns" and rows named after raw Frigate event ids. The notifications timeline

--- a/apps/ui/src/lib/pages/ModelEvaluation.svelte
+++ b/apps/ui/src/lib/pages/ModelEvaluation.svelte
@@ -39,12 +39,12 @@
     }
 
     function deviceCell(row: MatrixRow | undefined, dev: string): { label: string; cls: string } {
-        if (!row || row.error) return { label: '—', cls: 'text-gray-400' };
+        if (!row || row.error) return { label: '—', cls: 'text-slate-400' };
         const e = row.providers?.[dev] ?? row.devices?.[dev];
-        if (!e) return { label: '—', cls: 'text-gray-400' };
+        if (!e) return { label: '—', cls: 'text-slate-400' };
         if (!e.compiles) return { label: '✗ fails', cls: 'text-red-600 dark:text-red-400' };
         if (e.finite === false) return { label: '⚠ NaN', cls: 'text-red-600 dark:text-red-400' };
-        if (e.baseline || dev === row.baseline_provider || dev === 'CPU') return { label: `✓ baseline (${e.images_evaluated ?? 0})`, cls: 'text-gray-600 dark:text-gray-400' };
+        if (e.baseline || dev === row.baseline_provider || dev === 'CPU') return { label: `✓ baseline (${e.images_evaluated ?? 0})`, cls: 'text-slate-600 dark:text-slate-400' };
         const n = e.images_compared;
         if (row.comparison_kind === 'crop_box' && e.matches_cpu && n) {
             const iou = e.mean_box_iou;
@@ -79,7 +79,7 @@
     function severityColor(severity: ModelEvalWarning['severity']): string {
         if (severity === 'critical') return 'text-red-600 dark:text-red-400';
         if (severity === 'warning') return 'text-amber-600 dark:text-amber-400';
-        return 'text-blue-600 dark:text-blue-400';
+        return 'text-brand-600 dark:text-brand-400';
     }
 
     async function refresh() {
@@ -185,20 +185,20 @@
         </div>
     {/if}
 
-    <section class="rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-5">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Model Evaluation</h2>
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+    <section class="rounded-xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-5">
+        <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100">Model Evaluation</h2>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
             Run every installed classifier against auto-fetched, taxonomy-verified bird images
             from iNaturalist (with Wikimedia Commons fallback). Progress is reported live; full
-            artifacts persist under <code class="px-1 rounded bg-gray-100 dark:bg-gray-900">/config/yawamf-eval/&lt;run_id&gt;/</code>.
+            artifacts persist under <code class="px-1 rounded bg-slate-100 dark:bg-slate-900">/config/yawamf-eval/&lt;run_id&gt;/</code>.
         </p>
 
         <div class="mt-4 flex flex-wrap items-center gap-3">
-            <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
                 <input type="checkbox" bind:checked={includePerImage} class="rounded" />
                 Include per-image details (results.jsonl)
             </label>
-            <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300" title="Downloads every registry model, then validates each provider owned by this image against the CPU baseline. Slower.">
+            <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300" title="Downloads every registry model, then validates each provider owned by this image against the CPU baseline. Slower.">
                 <input type="checkbox" bind:checked={sweepDevices} class="rounded" />
                 Sweep image providers (auto-downloads all models)
             </label>
@@ -206,7 +206,7 @@
                 type="button"
                 disabled={!!active || loading}
                 onclick={startRun}
-                class="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400 dark:disabled:bg-gray-700 disabled:cursor-not-allowed text-sm font-medium"
+                class="btn btn-primary min-h-11 px-4 py-2 text-sm"
             >
                 {active ? 'Run in progress…' : 'Run Evaluation'}
             </button>
@@ -214,7 +214,7 @@
                 <button
                     type="button"
                     onclick={cancelRun}
-                    class="px-4 py-2 rounded-md bg-red-600 text-white hover:bg-red-700 text-sm font-medium"
+                    class="btn btn-secondary min-h-11 px-4 py-2 text-sm text-red-600 dark:text-red-400"
                 >
                     Cancel
                 </button>
@@ -223,25 +223,25 @@
 
         {#if active}
             <div class="mt-4">
-                <div class="flex justify-between text-xs text-gray-600 dark:text-gray-400">
+                <div class="flex justify-between text-xs text-slate-600 dark:text-slate-400">
                     <span>{active.phase} · {active.progress.label}</span>
                     <span>{active.progress.done} / {active.progress.total} ({progressPct}%)</span>
                 </div>
-                <div class="mt-1 h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
-                    <div class="h-full bg-blue-500 transition-all" style="width: {progressPct}%"></div>
+                <div class="mt-1 h-2 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
+                    <div class="h-full bg-brand-500 transition-all" style="width: {progressPct}%"></div>
                 </div>
             </div>
         {/if}
     </section>
 
     {#if selectedRun}
-        <section class="rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-5">
+        <section class="rounded-xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-5">
             <header class="flex items-start justify-between flex-wrap gap-2">
                 <div>
-                    <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                    <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100">
                         Run {selectedRun.run_id}
                     </h3>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                    <p class="text-xs text-slate-500 dark:text-slate-400">
                         {#if selectedRun.test_set}
                             {selectedRun.test_set.total_species} species · {selectedRun.test_set.total_images} images · region {selectedRun.test_set.region ?? '—'}
                         {/if}
@@ -251,11 +251,11 @@
                     </p>
                 </div>
                 <div class="flex flex-wrap gap-1 text-xs">
-                    <a class="text-blue-600 dark:text-blue-400 hover:underline" href={modelEvalArtifactUrl(selectedRun.run_id, 'summary.json')} target="_blank" rel="noopener">summary.json</a>
-                    <span class="text-gray-400">·</span>
-                    <a class="text-blue-600 dark:text-blue-400 hover:underline" href={modelEvalArtifactUrl(selectedRun.run_id, 'runtime.json')} target="_blank" rel="noopener">runtime.json</a>
-                    <span class="text-gray-400">·</span>
-                    <a class="text-blue-600 dark:text-blue-400 hover:underline" href={modelEvalArtifactUrl(selectedRun.run_id, 'confusions.csv')} target="_blank" rel="noopener">confusions.csv</a>
+                    <a class="text-brand-600 dark:text-brand-400 hover:underline" href={modelEvalArtifactUrl(selectedRun.run_id, 'summary.json')} target="_blank" rel="noopener">summary.json</a>
+                    <span class="text-slate-400">·</span>
+                    <a class="text-brand-600 dark:text-brand-400 hover:underline" href={modelEvalArtifactUrl(selectedRun.run_id, 'runtime.json')} target="_blank" rel="noopener">runtime.json</a>
+                    <span class="text-slate-400">·</span>
+                    <a class="text-brand-600 dark:text-brand-400 hover:underline" href={modelEvalArtifactUrl(selectedRun.run_id, 'confusions.csv')} target="_blank" rel="noopener">confusions.csv</a>
                 </div>
             </header>
 
@@ -268,7 +268,7 @@
             {#if selectedRun.models && selectedRun.models.length > 0}
                 <div class="mt-4 overflow-x-auto">
                     <table class="min-w-full text-sm">
-                        <thead class="text-xs uppercase text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                        <thead class="text-xs uppercase text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
                             <tr>
                                 <th class="text-left py-2 pr-4">Model</th>
                                 <th class="text-right px-2">Top-1</th>
@@ -282,8 +282,8 @@
                         </thead>
                         <tbody>
                             {#each selectedRun.models as model (model.model_id)}
-                                <tr class="border-b border-gray-100 dark:border-gray-700">
-                                    <td class="py-2 pr-4 font-mono text-xs text-gray-900 dark:text-gray-100">
+                                <tr class="border-b border-slate-100 dark:border-slate-700">
+                                    <td class="py-2 pr-4 font-mono text-xs text-slate-900 dark:text-slate-100">
                                         {model.model_id}
                                         {#if model.warnings && model.warnings.length > 0}
                                             <span class="ml-1 inline-flex items-center text-xs">
@@ -293,16 +293,16 @@
                                             </span>
                                         {/if}
                                     </td>
-                                    <td class="text-right px-2 text-gray-700 dark:text-gray-300">{pct(model.top1_accuracy)}</td>
-                                    <td class="text-right px-2 text-gray-700 dark:text-gray-300">{pct(model.top3_accuracy)}</td>
-                                    <td class="text-right px-2 text-gray-700 dark:text-gray-300">{pct(model.shared_core_top1)}</td>
-                                    <td class="text-right px-2 text-gray-700 dark:text-gray-300">{pct(model.regional_top1)}</td>
-                                    <td class="text-right px-2 text-gray-700 dark:text-gray-300">{ms(model.mean_latency_ms)}</td>
-                                    <td class="text-right px-2 text-gray-700 dark:text-gray-300">{ms(model.p95_latency_ms)}</td>
-                                    <td class="pl-4 text-xs text-gray-600 dark:text-gray-400">{model.active_provider ?? '—'}</td>
+                                    <td class="text-right px-2 text-slate-700 dark:text-slate-300">{pct(model.top1_accuracy)}</td>
+                                    <td class="text-right px-2 text-slate-700 dark:text-slate-300">{pct(model.top3_accuracy)}</td>
+                                    <td class="text-right px-2 text-slate-700 dark:text-slate-300">{pct(model.shared_core_top1)}</td>
+                                    <td class="text-right px-2 text-slate-700 dark:text-slate-300">{pct(model.regional_top1)}</td>
+                                    <td class="text-right px-2 text-slate-700 dark:text-slate-300">{ms(model.mean_latency_ms)}</td>
+                                    <td class="text-right px-2 text-slate-700 dark:text-slate-300">{ms(model.p95_latency_ms)}</td>
+                                    <td class="pl-4 text-xs text-slate-600 dark:text-slate-400">{model.active_provider ?? '—'}</td>
                                 </tr>
                                 {#if model.warnings && model.warnings.length > 0}
-                                    <tr class="border-b border-gray-100 dark:border-gray-700">
+                                    <tr class="border-b border-slate-100 dark:border-slate-700">
                                         <td colspan="8" class="py-1 pr-4 pl-4 text-xs">
                                             {#each model.warnings as w}
                                                 <div class={severityColor(w.severity)}>
@@ -335,9 +335,9 @@
     {/if}
 
     {#if deviceMatrix}
-        <section class="rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-5">
-            <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">Provider compatibility matrix</h3>
-            <p class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+        <section class="rounded-xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-5">
+            <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100">Provider compatibility matrix</h3>
+            <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
                 Image {deviceMatrix.image_flavor ?? 'unknown'} tested each packaged, detected, and
                 model-compatible provider in an isolated subprocess. Accelerators are compared with
                 the CPU baseline on {deviceMatrix.image_count ?? 0} varied real bird images. Classifiers
@@ -346,7 +346,7 @@
             </p>
             <div class="mt-3 overflow-x-auto">
                 <table class="w-full text-sm">
-                    <thead class="text-xs uppercase text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                    <thead class="text-xs uppercase text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
                         <tr>
                             <th class="text-left py-2 pr-4">Model</th>
                             {#each matrixProviders(deviceMatrix) as dev}
@@ -356,9 +356,9 @@
                     </thead>
                     <tbody>
                         {#each matrixRows(deviceMatrix) as [modelId, row]}
-                            <tr class="border-b border-gray-100 dark:border-gray-800">
-                                <td class="py-2 pr-4 font-medium text-gray-800 dark:text-gray-200">
-                                    {modelId}{#if row.comparison_kind === 'crop_box'} <span class="text-gray-400">· crop detector</span>{/if}
+                            <tr class="border-b border-slate-100 dark:border-slate-800">
+                                <td class="py-2 pr-4 font-medium text-slate-800 dark:text-slate-200">
+                                    {modelId}{#if row.comparison_kind === 'crop_box'} <span class="text-slate-400">· crop detector</span>{/if}
                                 </td>
                                 {#each matrixProviders(deviceMatrix) as dev}
                                     {@const c = deviceCell(row, dev)}
@@ -372,21 +372,21 @@
         </section>
     {/if}
 
-    <section class="rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-5">
-        <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">Run history</h3>
+    <section class="rounded-xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-5">
+        <h3 class="text-base font-semibold text-slate-900 dark:text-slate-100">Run history</h3>
         {#if runs.length === 0}
-            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">No runs yet.</p>
+            <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">No runs yet.</p>
         {:else}
-            <ul class="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
+            <ul class="mt-2 divide-y divide-slate-200 dark:divide-slate-700">
                 {#each runs as row (row.run_id)}
                     <li class="py-2 flex items-center justify-between text-sm">
                         <button
                             type="button"
                             onclick={() => { selectedRunId = row.run_id; refresh(); }}
-                            class="text-left flex-1 hover:text-blue-600 dark:hover:text-blue-400"
+                            class="btn btn-ghost min-h-11 flex-1 justify-start px-2 py-1 text-left hover:text-brand-600 dark:hover:text-brand-400"
                         >
                             <span class="font-mono">{row.run_id}</span>
-                            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">
+                            <span class="ml-2 text-xs text-slate-500 dark:text-slate-400">
                                 {#if row.duration_seconds}{Math.round(row.duration_seconds / 60)} min · {/if}
                                 {row.model_count ?? 0} models · {row.total_species ?? 0} species
                                 {#if row.region} · {row.region}{/if}
@@ -396,7 +396,7 @@
                         <button
                             type="button"
                             onclick={() => deleteRun(row.run_id)}
-                            class="ml-4 text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400"
+                            class="btn btn-ghost ml-4 min-h-11 px-2 py-1 text-xs text-slate-500 hover:text-red-600 dark:text-slate-400 dark:hover:text-red-400"
                             disabled={row.run_id === active?.run_id}
                         >
                             Delete

--- a/apps/ui/src/lib/pages/model-evaluation.layout.test.ts
+++ b/apps/ui/src/lib/pages/model-evaluation.layout.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import source from './ModelEvaluation.svelte?raw';
+import dashboard from './Dashboard.svelte?raw';
+
+/**
+ * Model Evaluation is an owner journey that never received the shared visual
+ * language. It was the only page in the app on Tailwind's `gray` ramp while every
+ * other page uses `slate`, styled its controls as raw utility classes rather than
+ * the kit in app.css, and had no control meeting the touch-target floor.
+ */
+/** Each `<button>`'s own class attribute, found without relying on the tag's end. */
+function buttonClasses(component: string): string[] {
+    return component
+        .split('<button')
+        .slice(1)
+        .map((tail) => tail.match(/class="([^"]*)"/)?.[1] ?? '');
+}
+
+describe('model evaluation speaks the same visual language as the rest of the app', () => {
+    it('uses the palette every other page uses', () => {
+        // Dashboard is the reference: slate for neutrals, brand for accent.
+        expect(dashboard).not.toMatch(/\bgray-\d/);
+        expect(source).not.toMatch(/\bgray-\d/);
+        expect(source).not.toMatch(/\bblue-\d/);
+    });
+
+    it('uses the shared control kit rather than hand-rolled utilities', () => {
+        // CLAUDE.md §5: the kit in app.css is the source of truth for controls.
+        // Matching to the tag's closing `>` is unreliable here because an inline
+        // `onclick={() => ...}` puts a `>` inside the tag, so read each button's
+        // own class attribute instead.
+        expect(buttonClasses(source).length).toBe(4);
+        for (const cls of buttonClasses(source)) {
+            expect(cls, `unstyled button: ${cls.slice(0, 60)}`).toMatch(/\bbtn\b/);
+        }
+    });
+
+    it('keeps every control at the repository touch-target minimum', () => {
+        for (const cls of buttonClasses(source)) {
+            expect(cls, `button below the touch floor: ${cls.slice(0, 60)}`).toContain('min-h-11');
+        }
+    });
+
+    it('names a destructive action by its effect rather than by colour alone', () => {
+        // Deleting a run cannot be undone. The word carries the meaning; the colour
+        // only reinforces it, which is what WCAG 2.2 AA asks for.
+        expect(source).toMatch(/>\s*Delete\s*</);
+        // Confirmed, and the confirmation says what leaves rather than just asking.
+        expect(source).toContain('Artifacts will be removed');
+        // Cannot delete the run that is currently producing results.
+        expect(source).toContain('disabled={row.run_id === active?.run_id}');
+    });
+
+    it('is still the page that has no translations, and says so where it is tracked', () => {
+        // Deliberately not fixed here: this page is entirely hardcoded English, which
+        // is its own piece of work and not the visual pass. Recorded on the roadmap
+        // rather than left for the next reader to rediscover.
+        expect(source).not.toContain("from 'svelte-i18n'");
+    });
+});


### PR DESCRIPTION
Second half of the UI design work: the less-frequent owner journeys.

## Outcome

Model Evaluation was visibly not part of the same application. Measured rather than eyeballed:

| | Model Evaluation | Dashboard | Events | Species |
|---|---|---|---|---|
| `gray-*` | **85** | 0 | 0 | 0 |
| `slate-*` | **0** | 10 | 72 | 186 |

It was the only page on Tailwind's `gray` ramp while every other page is the exact inverse. It also used Tailwind `blue` where the app's accent is `brand` (13 uses), styled its four buttons as one-off utility classes rather than the kit in `app.css`, and had **no** control meeting the `min-h-11` touch floor the rest of the interface holds to.

Now: same palette, same controls, same touch-target floor.

## Add observation was checked and left alone

I went in expecting to fix two pages. `ManualObservation` already follows the Evidence page shape from `docs/standards/layout-patterns.md`: the slim bar, the `1.35fr` media and `0.85fr` decision rail exactly as specified, `input-base` fields, and a confirm that names the bird it will add rather than saying "Save".

The metric that sent me looking — that it uses no `card-base` — was a poor proxy for whether a page follows the standard. Changing it would have been churn.

## Deliberately not fixed

**Model Evaluation carries no translations at all**: zero `$_()` calls, no `svelte-i18n` import, no `model_eval` key in any locale. Extracting fifty-odd technical strings and putting them through nine languages is its own piece of work, and doing it carelessly is exactly how a translation review ends up cleaning up machine-translation artefacts. Recorded on the roadmap, and a test asserts the state so it does not get half-done by accident.

## Verification

- `npm test` 996 passed across 180 files, including a new layout test pinning palette, control kit, touch targets and the destructive action.
- `npm run check` 0 errors, 0 warnings across 630 files.
- `docs_consistency_check.py` passed.

## A test bug worth noting

My first version matched button tags with `/<button[\s\S]*?>/`, which truncates on the `>` inside an inline `onclick={() => ...}`. It reported all four buttons as unstyled after I had correctly styled them. The test now reads each button's own `class` attribute instead. Worth flagging because the same pattern appears in other layout tests in this repo and is silently fragile wherever a button has an inline arrow function before its class.