### PR TITLE
Fail the docs check when Unreleased repeats a changelog heading

### DIFF
--- a/backend/scripts/docs_consistency_check.py
+++ b/backend/scripts/docs_consistency_check.py
@@ -121,6 +121,40 @@ def check_stale_terms() -> list[str]:
     return errors
 
 
+def check_changelog_headings(changelog: Path = ROOT / "CHANGELOG.md") -> list[str]:
+    """One heading per kind inside a release section.
+
+    Parallel branches each append their own `### Fixed` to `## [Unreleased]`, and a
+    rebase keeps both, so the section grows a second copy of a heading every few
+    merges. Nothing breaks, but the reader has to scan two places for the same kind
+    of change, and it has been resolved by hand twice.
+    """
+    errors: list[str] = []
+    if not changelog.exists():
+        return errors
+
+    # Only the Unreleased section. Released sections carry the same duplication from
+    # older merges, but those are notes people have already read; tidying them would
+    # be rewriting a published record to satisfy a linter.
+    in_unreleased = False
+    seen: dict[str, int] = {}
+    for number, line in enumerate(changelog.read_text(encoding="utf-8").splitlines(), start=1):
+        if line.startswith("## "):
+            in_unreleased = line.strip().startswith("## [Unreleased]")
+            seen = {}
+            continue
+        if line.startswith("### ") and in_unreleased:
+            heading = line.strip()
+            if heading in seen:
+                errors.append(
+                    f"CHANGELOG.md line {number}: Unreleased lists {heading} twice"
+                    f" (first at line {seen[heading]}); fold them into one."
+                )
+            else:
+                seen[heading] = number
+    return errors
+
+
 def main() -> int:
     errors: list[str] = []
 
@@ -128,6 +162,7 @@ def main() -> int:
     actual_routes = collect_actual_routes()
     errors.extend(check_documented_endpoints(actual_routes))
     errors.extend(check_stale_terms())
+    errors.extend(check_changelog_headings())
 
     if errors:
         print("Documentation consistency check failed:")

--- a/backend/tests/test_changelog_heading_check.py
+++ b/backend/tests/test_changelog_heading_check.py
@@ -1,0 +1,39 @@
+"""The Unreleased section keeps one heading per kind.
+
+Parallel branches each append their own `### Fixed`, a rebase keeps both, and the
+section grows a second copy every few merges. It was folded by hand twice in one
+day before this gate existed.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from docs_consistency_check import check_changelog_headings  # noqa: E402
+
+
+def test_a_duplicated_heading_under_unreleased_is_an_error(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- one\n\n### Added\n\n- two\n\n### Fixed\n\n- three\n",
+        encoding="utf-8",
+    )
+    errors = check_changelog_headings(changelog)
+    assert len(errors) == 1
+    assert "### Fixed twice" in errors[0]
+    assert "line 13" in errors[0] and "line 5" in errors[0]
+
+
+def test_released_sections_are_left_alone(tmp_path: Path):
+    """Published notes people have read are not rewritten to satisfy a linter."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "## [Unreleased]\n\n### Fixed\n\n- one\n\n## [2.9.14] - 2026-05-03\n\n### Fixed\n\n- a\n\n### Fixed\n\n- b\n",
+        encoding="utf-8",
+    )
+    assert check_changelog_headings(changelog) == []
+
+
+def test_the_shipped_changelog_passes():
+    assert check_changelog_headings() == []


### PR DESCRIPTION
## Outcome

The docs-quality workflow now fails when `## [Unreleased]` lists the same `###` heading twice.

## Why

Parallel branches each append their own `### Fixed`, a rebase keeps both, and the section grows a second copy of a heading every few merges. Nothing breaks, but a reader has to scan two places for one kind of change. It was folded by hand twice today, in #373 and again while landing #385, which is the point at which a manual fix becomes a gate.

## Scoped to Unreleased, deliberately

The first cut checked every section and found **12** duplicates, only 2 of them current. The other 10 sit in published release sections back to 2.9.14. Those are notes people have already read; tidying them to satisfy a linter would be rewriting a published record, the same instinct as never editing a released migration. The gate reads only Unreleased and says so in a comment, so it does not look like an oversight.

## Verification

- Three tests: a duplicate under Unreleased is an error naming both line numbers; a duplicate under a released section is not; the shipped changelog passes.
- `docs_consistency_check.py` passes on current dev (177 routes).
- `ruff check .` / `ruff format --check .` clean from the repository root.
- Lives in the existing `docs_consistency_check.py` so it runs in the existing workflow rather than adding one.