### PR TITLE
Repair the identity a manual correction left behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A species corrected by hand no longer appears twice on the leaderboard
+  ([#386](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/386)).** Before
+  corrections carried catalogue identity, retagging a detection wrote the new name but kept the old
+  bird's `species_id`, so a Tree Sparrow you corrected to a Dunnock counted as a Dunnock with a Tree
+  Sparrow's identity and the leaderboard listed Dunnock twice, in every window and both feeds. The
+  code has written the right identity since 2.19.2, but rows corrected before then still carried the
+  wrong one. The startup identity backfill now repairs any row whose identity names a different bird
+  than the row's own scientific name, under the same rule it already trusts: the name must resolve to
+  exactly one catalogue identity, or the row is left alone. Runs once on the upgrade, is idempotent
+  after, and touches only `species_id`.
+
 ### Added
 
 - **One public projection of the settings a viewer needs.** `/api/settings` is owner-only, so the

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1795,6 +1795,34 @@ class DetectionRepository:
         await self.db.commit()
         return changed
 
+    async def distinct_scientific_names_with_identity(self) -> list[str]:
+        """Every distinct scientific name on rows that already carry an identity."""
+        cursor = await self.db.execute(
+            "SELECT DISTINCT scientific_name FROM detections"
+            " WHERE species_id IS NOT NULL AND scientific_name IS NOT NULL AND TRIM(scientific_name) != ''"
+        )
+        rows = await cursor.fetchall()
+        return [str(row[0]) for row in rows]
+
+    async def repair_species_id_by_scientific_name(self, scientific_name: str, species_id: int) -> int:
+        """Correct rows whose identity names a different bird than their own name.
+
+        Before manual corrections carried identity, a hand-retagged detection
+        kept the old bird's `species_id` under the new name, so the leaderboard
+        showed one species twice (#386). The row's scientific name is what the
+        owner asserted, so identity is re-derived from it. Only `species_id` is
+        written and only where it disagrees; agreeing rows are untouched.
+        """
+        await self.db.execute(
+            "UPDATE detections SET species_id = ?"
+            " WHERE species_id IS NOT NULL AND species_id != ?"
+            " AND LOWER(TRIM(scientific_name)) = LOWER(TRIM(?))",
+            (species_id, species_id, scientific_name),
+        )
+        changed = await self._last_statement_changes()
+        await self.db.commit()
+        return changed
+
     async def insert_if_not_exists(self, detection: Detection) -> bool:
         """Atomically insert a detection only if it doesn't already exist.
 

--- a/backend/app/services/species_catalog_backfill.py
+++ b/backend/app/services/species_catalog_backfill.py
@@ -4,8 +4,14 @@ Phase 3's conservative backfill: a detection whose `scientific_name` resolves
 to exactly one catalogue identity — through a concept or a recorded resolved
 synonym — gains a `species_id`. Everything else stays exactly as it is and is
 counted, never guessed. Name snapshots and artifact provenance are never
-touched, an identity already present is never replaced, and re-running is a
-no-op, so the backfill is safe to schedule on every startup.
+touched, and re-running is a no-op, so the backfill is safe to schedule on
+every startup.
+
+An identity already present is replaced in exactly one case: when it names a
+different bird than the row's own scientific name. Manual corrections made
+before they carried identity left the old bird's `species_id` under the new
+name (#386), and the name is what the owner asserted, so the identity is
+re-derived from it under the same "exactly one match" rule.
 """
 
 from __future__ import annotations
@@ -47,6 +53,8 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
         "names_ambiguous": 0,
         "names_unresolved": 0,
         "rows_identified": 0,
+        "names_repaired": 0,
+        "rows_repaired": 0,
     }
 
     names = await repository.distinct_scientific_names_without_identity()
@@ -63,6 +71,22 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
             summary["names_ambiguous"] += 1
         else:
             summary["names_unresolved"] += 1
+
+    # A row whose identity contradicts its own scientific name is a manual
+    # correction from before corrections carried identity. The name is the
+    # owner's word; the stale id is not, and it splits the leaderboard.
+    for name in await repository.distinct_scientific_names_with_identity():
+        species_id, reason = await asyncio.to_thread(active_resolver.resolve_scientific_name, name)
+        if reason == "unavailable":
+            summary["status"] = "unavailable"
+            _record_summary(summary)
+            return summary
+        if species_id is None:
+            continue
+        repaired = await repository.repair_species_id_by_scientific_name(name, species_id)
+        if repaired:
+            summary["names_repaired"] += 1
+            summary["rows_repaired"] += repaired
 
     # Audio detections carry the same identity, for the same reason: grouping
     # audio by identity while older rows have none would split a species at the

--- a/backend/tests/test_manual_retag_identity.py
+++ b/backend/tests/test_manual_retag_identity.py
@@ -1,0 +1,76 @@
+"""A manual correction must carry the corrected species' identity, never the old bird's.
+
+Reported as leaderboard duplicates (#386): a Dunnock retagged by hand kept the
+`species_id` of the Tree Sparrow or Jungle Babbler it had been called before, so
+the leaderboard grouped it as a separate species with the same name.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.database import close_db, get_db, init_db
+from app.repositories.detection_repository import DetectionRepository
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def db():
+    await init_db()
+    try:
+        async with get_db() as conn:
+            await conn.execute("DELETE FROM detections")
+            await conn.execute(
+                """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index, score,
+                   display_name, category_name, scientific_name, common_name, taxa_id, species_id, is_hidden)
+                   VALUES ('evt1','cam','2026-08-31 08:32:25',1,0.63,
+                   'Eurasian Tree Sparrow','Passer montanus','Passer montanus','Eurasian Tree Sparrow',555,9774,0)"""
+            )
+            await conn.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_retagging_to_another_species_replaces_the_identity():
+    async with get_db() as conn:
+        repo = DetectionRepository(conn)
+        await repo.apply_manual_species_tag(
+            frigate_event="evt1",
+            display_name="Dunnock",
+            category_name="Prunella modularis",
+            scientific_name="Prunella modularis",
+            common_name="Dunnock",
+            taxa_id=13988,
+            audio_confirmed=False,
+            audio_species=None,
+            audio_score=None,
+            species_id=10081,
+        )
+        await conn.commit()
+        async with conn.execute("SELECT display_name, species_id FROM detections WHERE frigate_event='evt1'") as cur:
+            row = await cur.fetchone()
+    assert row == ("Dunnock", 10081)
+
+
+@pytest.mark.asyncio
+async def test_retagging_without_a_resolved_identity_does_not_keep_the_old_birds():
+    """If the corrected name cannot be resolved, no identity is honest. The old
+    bird's identity is not."""
+    async with get_db() as conn:
+        repo = DetectionRepository(conn)
+        await repo.apply_manual_species_tag(
+            frigate_event="evt1",
+            display_name="Dunnock",
+            category_name="Prunella modularis",
+            scientific_name="Prunella modularis",
+            common_name="Dunnock",
+            taxa_id=13988,
+            audio_confirmed=False,
+            audio_species=None,
+            audio_score=None,
+            species_id=None,
+        )
+        await conn.commit()
+        async with conn.execute("SELECT species_id FROM detections WHERE frigate_event='evt1'") as cur:
+            (species_id,) = await cur.fetchone()
+    assert species_id is None

--- a/backend/tests/test_species_catalog_backfill.py
+++ b/backend/tests/test_species_catalog_backfill.py
@@ -153,6 +153,17 @@ async def _seed_detections(db, rows):
     await db.commit()
 
 
+async def _seed_detections_more(db, rows):
+    for event, scientific, species_id in rows:
+        await db.execute(
+            "INSERT INTO detections (detection_time, detection_index, score, display_name, category_name,"
+            " frigate_event, camera_name, scientific_name, species_id)"
+            " VALUES (?, 0, 0.9, ?, ?, ?, 'feeder', ?, ?)",
+            (datetime(2026, 1, 1, 12, 0, 0), scientific, scientific, event, scientific, species_id),
+        )
+    await db.commit()
+
+
 async def _species_ids(db):
     cursor = await db.execute("SELECT frigate_event, species_id, scientific_name FROM detections ORDER BY id")
     return {row[0]: (row[1], row[2]) for row in await cursor.fetchall()}
@@ -187,14 +198,36 @@ async def test_exact_and_synonym_names_gain_identity_and_the_rest_stay_untouched
 
 
 @pytest.mark.asyncio
-async def test_the_backfill_is_idempotent_and_never_overwrites(catalog):
+async def test_an_identity_that_agrees_with_its_name_is_never_rewritten(catalog):
+    resolver = SpeciesCatalogResolver(catalog)
+    async with aiosqlite.connect(":memory:") as db:
+        await _seed_detections(db, [("evt-tit", "Cyanistes caeruleus", None)])
+        await backfill_catalog_identity(db, resolver=resolver)
+        tit_id = (await _species_ids(db))["evt-tit"][0]
+        assert tit_id is not None
+
+        await _seed_detections_more(db, [("evt-already", "Cyanistes caeruleus", tit_id)])
+        first = await backfill_catalog_identity(db, resolver=resolver)
+        second = await backfill_catalog_identity(db, resolver=resolver)
+
+        results = await _species_ids(db)
+        assert results["evt-already"][0] == tit_id
+        assert first["rows_identified"] == 0 and first["rows_repaired"] == 0
+        assert second["rows_identified"] == 0 and second["rows_repaired"] == 0
+
+
+@pytest.mark.asyncio
+async def test_an_identity_that_names_a_different_bird_is_repaired_from_the_rows_own_name(catalog):
+    """The #386 shape: a Dunnock retagged by hand before corrections carried
+    identity kept the Tree Sparrow's `species_id` under the Dunnock name, and the
+    leaderboard listed Dunnock twice. The name is what the owner asserted."""
     resolver = SpeciesCatalogResolver(catalog)
     async with aiosqlite.connect(":memory:") as db:
         await _seed_detections(
             db,
             [
                 ("evt-tit", "Cyanistes caeruleus", None),
-                ("evt-already", "Cyanistes caeruleus", 9999),
+                ("evt-stale", "Cyanistes caeruleus", 9999),
             ],
         )
 
@@ -202,9 +235,34 @@ async def test_the_backfill_is_idempotent_and_never_overwrites(catalog):
         second = await backfill_catalog_identity(db, resolver=resolver)
 
         results = await _species_ids(db)
-        assert results["evt-already"][0] == 9999, "an existing identity is never rewritten"
+        assert results["evt-stale"][0] == results["evt-tit"][0], "the stale id is re-derived from the name"
         assert first["rows_identified"] == 1
-        assert second["rows_identified"] == 0
+        assert first["rows_repaired"] == 1 and first["names_repaired"] == 1
+        assert second["rows_repaired"] == 0, "re-running repairs nothing twice"
+
+
+@pytest.mark.asyncio
+async def test_a_disputed_identity_under_an_ambiguous_name_is_left_alone(catalog):
+    """Repair uses the same rule as the fill: exactly one match, or nothing."""
+    connection = sqlite3.connect(catalog)
+    try:
+        connection.execute("INSERT INTO species (species_id, rank, status) VALUES (99, 'species', 'accepted')")
+        connection.execute(
+            "INSERT INTO species_concepts (species_id, provider, provider_taxon_id, source_release, scientific_name)"
+            " VALUES (99, 'catalogue-of-life', 'HOMONYM', 'COL26.7-test', 'Cyanistes caeruleus')"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    resolver = SpeciesCatalogResolver(catalog)
+
+    async with aiosqlite.connect(":memory:") as db:
+        await _seed_detections(db, [("evt-stale", "Cyanistes caeruleus", 9999)])
+
+        summary = await backfill_catalog_identity(db, resolver=resolver)
+
+        assert (await _species_ids(db))["evt-stale"][0] == 9999
+        assert summary["rows_repaired"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes [#386](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/386).

## What the reporter saw

The leaderboard listing the same species several times, in every window and both feeds.

## What it actually is

A data fault, not a display one, and one the code stopped producing on 1 September. Before `apply_manual_species_tag` carried catalogue identity (#360), retagging a detection wrote the new names and **never touched `species_id`**. Proven from `git show bd7099fb~1`: the SET clause wrote `display_name, category_name, scientific_name, common_name, taxa_id, audio_*` and nothing else. So a Tree Sparrow you corrected to a Dunnock became a Dunnock carrying the Tree Sparrow's identity. The leaderboard groups on identity, so it listed Dunnock twice.

Reproduced on quark: three Dunnock rows in week and month, counts 98 + 1 + 1. The two strays carried `species_id` 9774 (*Passer montanus*) and 8554 (*Argya striata*, Jungle Babbler), both `manual_tagged = 1`, both dated before #360 shipped. Patrick reset his database on 31 August and has been correcting since, which is exactly how you accumulate these.

I chased two wrong theories first, a model-swap race in video refinement and a stale scientific name in the router, and ruled both out against the data before landing on this one.

## The fix

The startup identity backfill already fills a missing `species_id` when the row's scientific name resolves to exactly one catalogue identity. It now also **repairs** a present `species_id` that names a different bird than the row's own scientific name, under that same rule. The name is what the owner asserted; the stale id is not.

- Only `species_id` is written, only where it disagrees.
- An identity that agrees with its name is never rewritten, and an ambiguous name repairs nothing. Both pinned by tests.
- Idempotent: a second run repairs zero.
- The leaderboard is left keyed on identity. Folding disagreeing rows there would hide the corruption instead of fixing it.

## Verification against real data

Ran the repair against a `VACUUM INTO` snapshot of quark's live database and catalogue:

```
BEFORE  Dunnock species_id distribution: [(10081, 238), (9774, 1), (8554, 1), (None, 1)]
BEFORE  rows whose id contradicts their name: 2
RUN 1   repaired: 2  names: 1  status: complete
AFTER   Dunnock species_id distribution: [(10081, 241)]
AFTER   rows whose id contradicts their name: 0
RUN 2   repaired: 0 (idempotent)
```

The `None` row was filled by the existing missing-identity pass in the same run, so all 241 Dunnock rows now share one identity and the leaderboard is back to one line.

- `pytest` 2670 passed, 49 skipped. Seven tests cover this: the retag path writes the corrected identity, the repair, the agreeing case, the ambiguous case, and idempotency.
- The test that asserted "an existing identity is never rewritten" now asserts what is true: an identity that **agrees with its name** is never rewritten. That invariant was deliberately relaxed for exactly one case, and the module docstring says so.
- `ruff check .` / `ruff format --check .` clean from the repository root.