### PR TITLE
Fold the leaderboard so one bird is never two lines

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -6,6 +6,7 @@ on:
     branches: [dev, main]
     paths:
       - "README.md"
+      - "CHANGELOG.md"
       - "MIGRATION.md"
       - "docs/**"
       - "backend/app/main.py"
@@ -15,6 +16,7 @@ on:
   pull_request:
     paths:
       - "README.md"
+      - "CHANGELOG.md"
       - "MIGRATION.md"
       - "docs/**"
       - "backend/app/main.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
-### Fixed
-
-- **A species corrected by hand no longer appears twice on the leaderboard
-  ([#386](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/386)).** Before
-  corrections carried catalogue identity, retagging a detection wrote the new name but kept the old
-  bird's `species_id`, so a Tree Sparrow you corrected to a Dunnock counted as a Dunnock with a Tree
-  Sparrow's identity and the leaderboard listed Dunnock twice, in every window and both feeds. The
-  code has written the right identity since 2.19.2, but rows corrected before then still carried the
-  wrong one. The startup identity backfill now repairs any row whose identity names a different bird
-  than the row's own scientific name, under the same rule it already trusts: the name must resolve to
-  exactly one catalogue identity, or the row is left alone. Runs once on the upgrade, is idempotent
-  after, and touches only `species_id`.
-
 ### Added
 
 - **One public projection of the settings a viewer needs.** `/api/settings` is owner-only, so the
@@ -54,6 +41,26 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   where work that needs a person belongs. Old jobs links still work and land on the timeline.
 
 ### Fixed
+
+- **The leaderboard no longer lists one species twice while its older detections wait for an
+  identity ([#386](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/386)).** A
+  detection carrying a catalogue identity grouped as one line and a detection still waiting for the
+  startup backfill grouped as another, so the moment new detections began resolving on an install
+  whose history had not yet caught up, every species split in two and the split grew with each
+  detection. The dashboard's count list was folded for exactly this in 2.19.1; the leaderboard
+  never was. Both now fold rows that share a taxon, or a name when no taxon is known, summing the
+  counts, taking the earliest first-seen and latest last-seen, weighting confidence by count, and
+  keeping the larger camera count rather than a sum that could claim more than was measured.
+- **A species corrected by hand no longer appears twice on the leaderboard
+  ([#386](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/386)).** Before
+  corrections carried catalogue identity, retagging a detection wrote the new name but kept the old
+  bird's `species_id`, so a Tree Sparrow you corrected to a Dunnock counted as a Dunnock with a Tree
+  Sparrow's identity and the leaderboard listed Dunnock twice, in every window and both feeds. The
+  code has written the right identity since 2.19.2, but rows corrected before then still carried the
+  wrong one. The startup identity backfill now repairs any row whose identity names a different bird
+  than the row's own scientific name, under the same rule it already trusts: the name must resolve to
+  exactly one catalogue identity, or the row is left alone. Runs once on the upgrade, is idempotent
+  after, and touches only `species_id`.
 
 - **A guest sees the interface the owner configured, not the built-in defaults.** Three settings
   never reached a visitor. Detections needing a person were never flagged, because the review check

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Callable, Any, Optional
 from dataclasses import dataclass
 from datetime import datetime, timedelta, date, timezone
 import aiosqlite
@@ -30,14 +30,14 @@ def clear_species_alias_cache() -> None:
     _SPECIES_ALIAS_CACHE.clear()
 
 
-def merge_species_count_rows(rows: list[dict]) -> list[dict]:
-    """Fold count rows that are the same bird under different identity keys.
+def _fold_same_bird(rows: list[dict], combine: Callable[[dict, dict], None]) -> list[dict]:
+    """Group summary rows that are the same bird under different identity keys.
 
-    The canonical key prefers catalogue identity, but a row written between
-    ingest and the next identity backfill can lack `species_id` while its
-    neighbours carry it - and one Dunnock then arrives as two rows, which the
-    dashboard's keyed list cannot survive. Same taxon, or same name when a
-    taxon is missing, means the same bird here.
+    The canonical key prefers catalogue identity, so a row carrying `species_id`
+    groups as `species:N` while one still waiting for the identity backfill
+    groups as `taxon:N`. Those are different strings, and one bird then arrives
+    as two rows. Same taxon, or same name when a taxon is missing, means the
+    same bird here; `combine(target, row)` folds the second into the first.
     """
     by_taxa: dict[int, dict] = {}
     by_name: dict[str, dict] = {}
@@ -58,19 +58,69 @@ def merge_species_count_rows(rows: list[dict]) -> list[dict]:
             if name:
                 by_name[name] = entry
             continue
-        target["count"] = int(target.get("count") or 0) + int(row.get("count") or 0)
-        row_time = row.get("latest_detection_time")
-        target_time = target.get("latest_detection_time")
-        if row_time is not None and (target_time is None or row_time > target_time):
-            target["latest_detection_time"] = row_time
-            target["latest_event"] = row.get("latest_event")
+        combine(target, row)
         if target.get("taxa_id") is None and taxa_id is not None:
             target["taxa_id"] = taxa_id
             by_taxa[taxa_id] = target
         for field in ("scientific_name", "common_name"):
             if not target.get(field) and row.get(field):
                 target[field] = row.get(field)
+    return merged
+
+
+def merge_species_count_rows(rows: list[dict]) -> list[dict]:
+    """Fold count rows that are the same bird under different identity keys.
+
+    The dashboard's keyed species list cannot survive one Dunnock arriving as
+    two rows (#359). See `_fold_same_bird` for why that happens.
+    """
+
+    def combine(target: dict, row: dict) -> None:
+        target["count"] = int(target.get("count") or 0) + int(row.get("count") or 0)
+        row_time = row.get("latest_detection_time")
+        target_time = target.get("latest_detection_time")
+        if row_time is not None and (target_time is None or row_time > target_time):
+            target["latest_detection_time"] = row_time
+            target["latest_event"] = row.get("latest_event")
+
+    merged = _fold_same_bird(rows, combine)
     merged.sort(key=lambda entry: int(entry.get("count") or 0), reverse=True)
+    return merged
+
+
+def merge_species_leaderboard_rows(rows: list[dict]) -> list[dict]:
+    """Fold leaderboard rows that are the same bird under different identity keys.
+
+    The count path was folded for this in #359; the leaderboard was not, and an
+    owner watched the duplicates multiply as each new detection resolved its
+    identity while the older ones had not yet been backfilled (#386).
+    """
+
+    def combine(target: dict, row: dict) -> None:
+        target_n = int(target.get("window_count") or 0)
+        row_n = int(row.get("window_count") or 0)
+        total = target_n + row_n
+        if total:
+            target["window_avg_confidence"] = (
+                float(target.get("window_avg_confidence") or 0.0) * target_n
+                + float(row.get("window_avg_confidence") or 0.0) * row_n
+            ) / total
+        target["window_count"] = total
+        target["prev_count"] = int(target.get("prev_count") or 0) + int(row.get("prev_count") or 0)
+        for field, pick in (("window_first_seen", min), ("window_last_seen", max)):
+            left, right = target.get(field), row.get(field)
+            if left is None or right is None:
+                target[field] = left if right is None else right
+            else:
+                target[field] = pick(left, right)
+        # Two groups' distinct-camera counts cannot be unioned after the fact. The
+        # larger is the only figure that cannot claim more than was measured.
+        target["window_camera_count"] = max(
+            int(target.get("window_camera_count") or 0), int(row.get("window_camera_count") or 0)
+        )
+
+    merged = _fold_same_bird(rows, combine)
+    merged.sort(key=lambda entry: int(entry.get("window_count") or 0), reverse=True)
     return merged
 
 
@@ -3649,21 +3699,23 @@ class DetectionRepository:
         async with self.db.execute(query, params) as cursor:
             rows = await cursor.fetchall()
 
-        return [
-            {
-                "species": row[3],
-                "scientific_name": row[1],
-                "common_name": row[2],
-                "taxa_id": row[4],
-                "window_count": int(row[5] or 0),
-                "prev_count": int(row[6] or 0),
-                "window_first_seen": _parse_datetime(row[7]) if row[7] else None,
-                "window_last_seen": _parse_datetime(row[8]) if row[8] else None,
-                "window_avg_confidence": float(row[9] or 0.0),
-                "window_camera_count": int(row[10] or 0),
-            }
-            for row in rows
-        ]
+        return merge_species_leaderboard_rows(
+            [
+                {
+                    "species": row[3],
+                    "scientific_name": row[1],
+                    "common_name": row[2],
+                    "taxa_id": row[4],
+                    "window_count": int(row[5] or 0),
+                    "prev_count": int(row[6] or 0),
+                    "window_first_seen": _parse_datetime(row[7]) if row[7] else None,
+                    "window_last_seen": _parse_datetime(row[8]) if row[8] else None,
+                    "window_avg_confidence": float(row[9] or 0.0),
+                    "window_camera_count": int(row[10] or 0),
+                }
+                for row in rows
+            ]
+        )
 
     async def get_species_leaderboard_window_for_labels(
         self,

--- a/backend/tests/test_species_leaderboard_merge.py
+++ b/backend/tests/test_species_leaderboard_merge.py
@@ -1,0 +1,159 @@
+"""The leaderboard must never list one bird twice (#386).
+
+The canonical key prefers catalogue identity, so a detection carrying
+`species_id` groups as `species:N` while one still waiting for the identity
+backfill groups as `taxon:N`. Those are different strings, and a species with
+some rows resolved and some not arrives as two leaderboard lines. The count path
+was folded for exactly this in #359; the leaderboard never was, and a reporter
+watched the duplicates multiply as each new detection resolved while the older
+ones had not.
+"""
+
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+
+from app.database import close_db, get_db, init_db
+from app.repositories.detection_repository import DetectionRepository, merge_species_leaderboard_rows
+
+
+def _row(
+    species,
+    window_count,
+    taxa_id=None,
+    prev=0,
+    first="2026-09-02 10:00:00",
+    last="2026-09-02 12:00:00",
+    confidence=0.9,
+    cameras=1,
+    **extra,
+):
+    return {
+        "species": species,
+        "scientific_name": extra.get("scientific_name"),
+        "common_name": extra.get("common_name"),
+        "taxa_id": taxa_id,
+        "window_count": window_count,
+        "prev_count": prev,
+        "window_first_seen": datetime.fromisoformat(first),
+        "window_last_seen": datetime.fromisoformat(last),
+        "window_avg_confidence": confidence,
+        "window_camera_count": cameras,
+    }
+
+
+def test_the_same_taxon_under_two_identity_keys_becomes_one_line():
+    # 86 resolved rows and 3 not-yet-backfilled rows of the same nuthatch.
+    merged = merge_species_leaderboard_rows(
+        [
+            _row(
+                "White-breasted Nuthatch",
+                86,
+                taxa_id=14805,
+                prev=40,
+                last="2026-09-02 13:03:00",
+                confidence=0.98,
+                cameras=2,
+            ),
+            _row(
+                "White-breasted Nuthatch",
+                3,
+                taxa_id=14805,
+                prev=0,
+                first="2026-09-02 13:20:00",
+                last="2026-09-02 13:30:00",
+                confidence=1.0,
+                cameras=1,
+            ),
+        ]
+    )
+    assert len(merged) == 1
+    (row,) = merged
+    assert row["window_count"] == 89
+    assert row["prev_count"] == 40
+    assert row["window_first_seen"] == datetime.fromisoformat("2026-09-02 10:00:00")
+    assert row["window_last_seen"] == datetime.fromisoformat("2026-09-02 13:30:00")
+    # Weighted by count, not a plain mean of two averages.
+    assert row["window_avg_confidence"] == pytest.approx((0.98 * 86 + 1.0 * 3) / 89)
+    # Two groups' distinct-camera counts cannot be unioned after the fact; the
+    # larger is the only figure that cannot overstate what was measured.
+    assert row["window_camera_count"] == 2
+
+
+def test_the_same_name_without_a_taxon_still_merges_and_adopts_it():
+    merged = merge_species_leaderboard_rows(
+        [
+            _row("Dunnock", 5, taxa_id=None),
+            _row("dunnock", 2, taxa_id=13988, scientific_name="Prunella modularis"),
+        ]
+    )
+    assert len(merged) == 1
+    assert merged[0]["window_count"] == 7
+    assert merged[0]["taxa_id"] == 13988
+    assert merged[0]["scientific_name"] == "Prunella modularis"
+
+
+def test_distinct_species_stay_distinct_and_rank_by_window_count():
+    merged = merge_species_leaderboard_rows(
+        [
+            _row("Tufted Titmouse", 3, taxa_id=1),
+            _row("Black-capped Chickadee", 256, taxa_id=2),
+            _row("Tufted Titmouse", 64, taxa_id=1),
+        ]
+    )
+    assert [(r["species"], r["window_count"]) for r in merged] == [
+        ("Black-capped Chickadee", 256),
+        ("Tufted Titmouse", 67),
+    ]
+
+
+@pytest_asyncio.fixture
+async def seeded():
+    await init_db()
+    try:
+        async with get_db() as db:
+            await db.execute("DELETE FROM detections")
+            rows = []
+            for i in range(6):
+                # The first four resolved; the newest two still awaiting the backfill.
+                rows.append(
+                    (
+                        f"nut_{i}",
+                        "cam1",
+                        f"2026-09-02 1{i}:00:00",
+                        1,
+                        0.95,
+                        "White-breasted Nuthatch",
+                        "Sitta carolinensis",
+                        "Sitta carolinensis",
+                        14805,
+                        777 if i < 4 else None,
+                        0,
+                    )
+                )
+            await db.executemany(
+                """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index, score,
+                   display_name, category_name, scientific_name, taxa_id, species_id, is_hidden)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+                rows,
+            )
+            await db.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_the_leaderboard_query_itself_returns_one_line_per_bird(seeded):
+    async with get_db() as db:
+        repo = DetectionRepository(db)
+        rows = await repo.get_species_leaderboard_window(
+            window_start=datetime(2026, 9, 2, 0, 0, 0),
+            window_end=datetime(2026, 9, 3, 0, 0, 0),
+            prev_start=datetime(2026, 9, 1, 0, 0, 0),
+            prev_end=datetime(2026, 9, 2, 0, 0, 0),
+        )
+    nuthatch = [r for r in rows if r["species"] == "White-breasted Nuthatch"]
+    assert len(nuthatch) == 1, [(r["species"], r["window_count"]) for r in rows]
+    assert nuthatch[0]["window_count"] == 6


### PR DESCRIPTION
Second half of [#386](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/386). #388 repaired the stale identities from old manual corrections; this fixes the live split Patrick then watched multiply.

## What was actually happening

`_canonical_key_sql` prefers catalogue identity: a row carrying `species_id` groups as `species:N`, a row without one groups as `taxon:N`. **Those are different strings.** So a species with some detections resolved and some not arrives as two leaderboard lines, and the moment new detections start resolving on an install whose history has not yet been backfilled, every species splits and the split grows with each detection. Patrick's second screenshot shows exactly that: three species doubled, and in every case the small group is the newest detections.

The dashboard's count list was folded for this in #359, with a docstring that describes this bug word for word. The leaderboard never got the fold.

## The fix

One shared `_fold_same_bird` helper now serves both paths, so the rule cannot drift between them again. Same taxon, or same name when no taxon is known, is the same bird.

The leaderboard combiner: sums `window_count` and `prev_count`, takes the earliest first-seen and latest last-seen, weights `window_avg_confidence` by count rather than averaging two averages, and keeps the **larger** `window_camera_count`. Two groups' distinct-camera counts cannot be unioned after the fact, and max is the only figure that cannot claim more than was measured.

`get_species_leaderboard_base` already keys by name and is unaffected.

## Verification

Against a `VACUUM INTO` snapshot of quark with **four** identity groups for one Dunnock (two stale ids from the #388 case plus three rows deliberately nulled to reproduce Patrick's state):

```
identity groups in the raw data for Dunnock: 4
leaderboard lines for Dunnock after the fold: 1 | window_count: 205
any species listed twice across the whole board: none
```

- `pytest` 2674 passed, 49 skipped. Four new tests: the fold itself with every combined field asserted, name-only merge adopting the taxon, distinct species staying distinct and ranked, and the real leaderboard query returning one line from mixed rows.
- The existing three count-merge tests pass unchanged on the refactored helper.
- `ruff check .` / `ruff format --check .` clean from the repository root.

## Two things riding along, because the gate found them

- The Unreleased section had grown a second `### Fixed` (from #388's squash). The changelog check from #387 correctly refused it. Folded back to one heading, 16 entries preserved.
- That check could never have run on the merge that caused it: `docs-quality.yml` did not trigger on `CHANGELOG.md`. It does now, on push and pull request. Two lines, and without them the gate is decorative.

## What Patrick will see

He tracks dev. Once this builds, his next image has both fixes, and the #388 repair runs on that restart and heals his older rows anyway. Either one alone would have stopped the doubling; together the board is right immediately and the data is right underneath it.