### PR TITLE
Name leaderboard species after giving the connection back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The leaderboard no longer holds a database connection while it names each species
+  ([#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)).** For a reader whose
+  language is not English, naming a species checks a cache and then asks iNaturalist over the
+  network, with a ten second timeout, and the leaderboard did that for every species while holding
+  one of the five pooled connections. One uncached species could stall everything else needing the
+  database for ten seconds; an owner's diagnostics showed the route holding a connection for five.
+  The rows are read first and the connection given back before any name is looked up, and the same
+  test that guards the events list now guards the leaderboard.
 - **The leaderboard no longer lists one species twice while its older detections wait for an
   identity ([#386](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/386)).** A
   detection carrying a catalogue identity grouped as one line and a detection still waiting for the

--- a/backend/app/routers/species.py
+++ b/backend/app/routers/species.py
@@ -902,11 +902,11 @@ async def get_species_list(request: Request):
                 common_name = catalogue_name
             elif taxa_id:
                 if lang != "en":
-                    localized = await taxonomy_service.get_localized_common_name(taxa_id, lang, db=db)
+                    localized = await taxonomy_service.get_localized_common_name(taxa_id, lang)
                     if localized:
                         common_name = localized
                 else:
-                    canonical = await taxonomy_service.get_canonical_english_name(taxa_id, db=db)
+                    canonical = await taxonomy_service.get_canonical_english_name(taxa_id)
                     if canonical:
                         common_name = canonical
 
@@ -1002,6 +1002,10 @@ async def get_leaderboard_species(
 
     unknown_labels = settings.classification.unknown_bird_labels
 
+    # Read everything the database has to say first and give the connection back.
+    # Naming each species below can ask iNaturalist over the network with a ten
+    # second timeout, and doing that while holding one of five pooled connections
+    # is what an owner's diagnostics showed as this route holding one for 5.1 s.
     async with get_db() as db:
         repo = DetectionRepository(db)
         rows = await repo.get_species_leaderboard_window(
@@ -1010,53 +1014,6 @@ async def get_leaderboard_species(
             prev_start=prev_start,
             prev_end=prev_end,
         )
-
-        # Filter to species present in the selected window only.
-        filtered = []
-        for r in rows:
-            if r["species"] in unknown_labels or should_hide_species_label(r["species"]):
-                continue
-            if r["window_count"] <= 0:
-                continue
-
-            common_name = r.get("common_name")
-            taxa_id = r.get("taxa_id")
-            if taxa_id:
-                if lang != "en":
-                    localized = await taxonomy_service.get_localized_common_name(taxa_id, lang, db=db)
-                    if localized:
-                        common_name = localized
-                else:
-                    canonical = await taxonomy_service.get_canonical_english_name(taxa_id, db=db)
-                    if canonical:
-                        common_name = canonical
-
-            delta = r["window_count"] - r["prev_count"]
-            pct = 0.0
-            if r["prev_count"] > 0:
-                pct = (delta / r["prev_count"]) * 100.0
-
-            filtered.append(
-                {
-                    "species": _canonical_species_response_name(
-                        r["species"],
-                        common_name,
-                        r.get("scientific_name"),
-                    ),
-                    "scientific_name": r.get("scientific_name"),
-                    "common_name": common_name,
-                    "taxa_id": taxa_id,
-                    "window_count": r["window_count"],
-                    "window_prev_count": r["prev_count"],
-                    "window_delta": delta,
-                    "window_percent": pct,
-                    "window_first_seen": serialize_api_datetime(r.get("window_first_seen")),
-                    "window_last_seen": serialize_api_datetime(r.get("window_last_seen")),
-                    "window_avg_confidence": r.get("window_avg_confidence", 0.0),
-                    "window_camera_count": r.get("window_camera_count", 0),
-                }
-            )
-
         unknown = await repo.get_species_leaderboard_window_for_name(
             species_name="Unknown Bird",
             window_start=window_start,
@@ -1064,37 +1021,84 @@ async def get_leaderboard_species(
             prev_start=prev_start,
             prev_end=prev_end,
         )
-        if unknown and unknown.get("window_count", 0) > 0:
-            delta = unknown["window_count"] - unknown["prev_count"]
-            pct = 0.0
-            if unknown["prev_count"] > 0:
-                pct = (delta / unknown["prev_count"]) * 100.0
-            filtered.append(
-                {
-                    "species": "Unknown Bird",
-                    "scientific_name": None,
-                    "common_name": None,
-                    "taxa_id": None,
-                    "window_count": unknown["window_count"],
-                    "window_prev_count": unknown["prev_count"],
-                    "window_delta": delta,
-                    "window_percent": pct,
-                    "window_first_seen": serialize_api_datetime(unknown.get("window_first_seen")),
-                    "window_last_seen": serialize_api_datetime(unknown.get("window_last_seen")),
-                    "window_avg_confidence": unknown.get("window_avg_confidence", 0.0),
-                    "window_camera_count": unknown.get("window_camera_count", 0),
-                }
-            )
 
-        # Sort by selected window count desc.
-        filtered.sort(key=lambda x: int(x.get("window_count") or 0), reverse=True)
+    # Filter to species present in the selected window only.
+    filtered = []
+    for r in rows:
+        if r["species"] in unknown_labels or should_hide_species_label(r["species"]):
+            continue
+        if r["window_count"] <= 0:
+            continue
 
-        return {
-            "span": span,
-            "window_start": window_start.replace(tzinfo=timezone.utc).isoformat(),
-            "window_end": window_end.replace(tzinfo=timezone.utc).isoformat(),
-            "species": filtered,
-        }
+        common_name = r.get("common_name")
+        taxa_id = r.get("taxa_id")
+        if taxa_id:
+            if lang != "en":
+                localized = await taxonomy_service.get_localized_common_name(taxa_id, lang)
+                if localized:
+                    common_name = localized
+            else:
+                canonical = await taxonomy_service.get_canonical_english_name(taxa_id)
+                if canonical:
+                    common_name = canonical
+
+        delta = r["window_count"] - r["prev_count"]
+        pct = 0.0
+        if r["prev_count"] > 0:
+            pct = (delta / r["prev_count"]) * 100.0
+
+        filtered.append(
+            {
+                "species": _canonical_species_response_name(
+                    r["species"],
+                    common_name,
+                    r.get("scientific_name"),
+                ),
+                "scientific_name": r.get("scientific_name"),
+                "common_name": common_name,
+                "taxa_id": taxa_id,
+                "window_count": r["window_count"],
+                "window_prev_count": r["prev_count"],
+                "window_delta": delta,
+                "window_percent": pct,
+                "window_first_seen": serialize_api_datetime(r.get("window_first_seen")),
+                "window_last_seen": serialize_api_datetime(r.get("window_last_seen")),
+                "window_avg_confidence": r.get("window_avg_confidence", 0.0),
+                "window_camera_count": r.get("window_camera_count", 0),
+            }
+        )
+
+    if unknown and unknown.get("window_count", 0) > 0:
+        delta = unknown["window_count"] - unknown["prev_count"]
+        pct = 0.0
+        if unknown["prev_count"] > 0:
+            pct = (delta / unknown["prev_count"]) * 100.0
+        filtered.append(
+            {
+                "species": "Unknown Bird",
+                "scientific_name": None,
+                "common_name": None,
+                "taxa_id": None,
+                "window_count": unknown["window_count"],
+                "window_prev_count": unknown["prev_count"],
+                "window_delta": delta,
+                "window_percent": pct,
+                "window_first_seen": serialize_api_datetime(unknown.get("window_first_seen")),
+                "window_last_seen": serialize_api_datetime(unknown.get("window_last_seen")),
+                "window_avg_confidence": unknown.get("window_avg_confidence", 0.0),
+                "window_camera_count": unknown.get("window_camera_count", 0),
+            }
+        )
+
+    # Sort by selected window count desc.
+    filtered.sort(key=lambda x: int(x.get("window_count") or 0), reverse=True)
+
+    return {
+        "span": span,
+        "window_start": window_start.replace(tzinfo=timezone.utc).isoformat(),
+        "window_end": window_end.replace(tzinfo=timezone.utc).isoformat(),
+        "species": filtered,
+    }
 
 
 @router.get("/species/{species_name}/stats", response_model=SpeciesStats)

--- a/backend/tests/test_leaderboard_connection_hold.py
+++ b/backend/tests/test_leaderboard_connection_hold.py
@@ -1,0 +1,97 @@
+"""Naming a species must not happen while a pooled connection is held.
+
+The leaderboard resolves each species' display name after reading the rows,
+and for a non-English reader that lookup checks a cache and then asks
+iNaturalist over the network, with a ten second timeout. It did so inside
+`async with get_db()`, so one uncached species could hold one of five pooled
+connections for ten seconds while everything else needing the database
+queued behind it. An owner's diagnostics showed this route holding a
+connection for 5.1 seconds (#386, and the same disease as #300).
+"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import close_db, get_db, init_db
+from app.main import app
+
+LOOKUP_DELAY_SECONDS = 0.4
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def seeded_db():
+    await init_db()
+    try:
+        async with get_db() as db:
+            await db.execute("DELETE FROM detections")
+            for index in range(4):
+                await db.execute(
+                    """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index,
+                       score, display_name, category_name, scientific_name, taxa_id, is_hidden)
+                       VALUES (?, 'cam1', datetime('now', ?), 1, 0.9, ?, ?, ?, ?, 0)""",
+                    (
+                        f"evt_{index}",
+                        f"-{index + 1} hours",
+                        f"Bird {index}",
+                        f"Genus species{index}",
+                        f"Genus species{index}",
+                        1000 + index,
+                    ),
+                )
+            # An unknown-bird row, so the branch that reports it runs outside the hold too.
+            await db.execute(
+                """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index,
+                   score, display_name, category_name, is_hidden)
+                   VALUES ('evt_unknown', 'cam1', datetime('now', '-30 minutes'), 1, 0.3, 'Unknown Bird', 'Unknown Bird', 0)"""
+            )
+            await db.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_name_lookups_do_not_happen_while_a_connection_is_held(monkeypatch):
+    from app.routers import species as species_router
+
+    # Only the network hop is stubbed, so the cache read before it runs for real.
+    # That matters: the route used to hand these lookups the connection it had
+    # already given back, and a stub of the whole lookup hid it.
+    async def slow_inaturalist(taxa_id, lang):
+        await asyncio.sleep(LOOKUP_DELAY_SECONDS)
+        return None
+
+    monkeypatch.setattr(species_router, "get_user_language", lambda request: "de")
+    monkeypatch.setattr(species_router.taxonomy_service, "_lookup_localized_inaturalist", slow_inaturalist)
+
+    from app.database import get_db_pool_status
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/leaderboard/species?span=week")
+        assert res.status_code == 200
+        names = [row["species"] for row in res.json()["species"]]
+        assert len(names) == 5 and "Unknown Bird" in names
+
+    hold_max_ms = get_db_pool_status()["hold_ms_max"]
+    assert hold_max_ms < LOOKUP_DELAY_SECONDS * 1000 * 0.5, (
+        f"a connection was held for {hold_max_ms} ms while a name lookup took "
+        f"{LOOKUP_DELAY_SECONDS * 1000} ms, so the lookup ran inside the hold"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_english_reader_gets_canonical_names_without_a_connection_in_hand(monkeypatch):
+    """The English branch resolves through the taxonomy cache too, and must open
+    its own short-lived connection now the route has released its own."""
+    from app.routers import species as species_router
+
+    monkeypatch.setattr(species_router, "get_user_language", lambda request: "en")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/leaderboard/species?span=week")
+        assert res.status_code == 200
+        names = [row["species"] for row in res.json()["species"]]
+        assert len(names) == 5 and "Unknown Bird" in names


### PR DESCRIPTION
Folds into 2.19.3. Same disease as the events list fix in #300, same cure, on the route Patrick's latest diagnostics showed holding a connection for **5.1 seconds**.

## The problem

`get_leaderboard_species` resolved each species' display name inside `async with get_db()`. For a non-English reader that lookup checks the taxonomy cache and then **asks iNaturalist over the network with a ten second timeout**. One uncached species could hold one of five pooled connections for ten seconds while everything else needing the database queued behind it.

## The fix

Both database reads (the window rows and the unknown-bird row) happen first; the connection is released; then names are resolved. The taxonomy lookups open their own short-lived connection for the cache when handed none, which is what they were written to do. Only the two lines inside this route changed; other routes that pass `db=db` still have a live connection and are untouched.

## A test that masked the bug, and its replacement

My first test stubbed `get_localized_common_name` entirely. It passed while the route was still passing the lookups a connection it had **already closed**, because the stub never touched it. The test now stubs only `_lookup_localized_inaturalist`, the network hop, so the real cache read runs against whatever the route hands it. A second test covers the English branch (`get_canonical_english_name`), which the first never exercised.

Reverting the route with the new test in place:

```
a connection was held for 1607.55 ms while a name lookup took 400.0 ms, so the lookup ran inside the hold
```

With the fix: 7 targeted tests pass, `pytest` 2676 passed, 49 skipped, ruff clean from the root.

## Not included

The audio leaderboard (`get_audio_species_leaderboard`) showed a ~1 s hold on quark earlier and likely has the same shape. Left for its own change rather than widened into this one.