### PR TITLE
Never wait on iNaturalist while holding a pooled connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **No page waits on iNaturalist while holding a database connection
+  ([#392](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/392)).** Eleven places
+  named a species for a non-English reader by checking the cache and then asking iNaturalist over
+  the network, with a ten second timeout, while holding one of the five pooled connections. One
+  uncached species could stall everything else needing the database. Rather than rewrite every
+  caller, the lookup itself now knows whether the calling task holds a connection: if it does, it
+  answers with what is cached and fetches the name off the request, so the next render has it. A
+  first render of a brand-new species in a non-English language may show the stored name for a
+  moment; nothing waits on the network any more. The six audio routes that could simply be moved
+  out of their holds were, and a test walks every affected route with a slow provider and proves no
+  connection was held across it.
 - **The leaderboard no longer holds a database connection while it names each species
   ([#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)).** For a reader whose
   language is not English, naming a species checks a cache and then asks iNaturalist over the

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -851,6 +851,16 @@ def _caller_label() -> str:
     return "unlabelled"
 
 
+def pooled_connection_held() -> bool:
+    """Whether the calling task is currently holding a pooled connection.
+
+    Work that can wait on the network, a taxonomy provider or an LLM, asks this
+    before doing so, because carrying one of five connections through that wait
+    starves every other caller (#300, #392).
+    """
+    return _acquire_depth.get() > 0
+
+
 @asynccontextmanager
 async def get_db():
     """Get a database connection from the pool.

--- a/backend/app/routers/audio.py
+++ b/backend/app/routers/audio.py
@@ -202,8 +202,7 @@ async def get_recent_audio(request: Request, limit: int = 10, auth: AuthContext 
     """Get the most recent audio detections from the memory buffer."""
     detections = await audio_service.get_recent_detections(limit=limit)
     lang = get_user_language(request) or "en"
-    async with get_db() as db:
-        await localize_audio_detections(detections, lang, db)
+    await localize_audio_detections(detections, lang)
     # Drop scientific_name from the response — it is an internal hook for localization
     # and is not part of the public Recent Audio contract.
     for detection in detections:
@@ -275,7 +274,7 @@ async def get_audio_history(
             )
             for item in result["items"]:
                 item["matched_visual_event_id"] = matches.get(item["id"])
-        await localize_audio_detections(result["items"], lang, db)
+    await localize_audio_detections(result["items"], lang)
 
     for detection in result["items"]:
         detection.pop("scientific_name", None)
@@ -313,7 +312,7 @@ async def get_audio_summary(
             source=source,
             min_confidence=min_confidence,
         )
-        await localize_audio_detections(result["top_species"], lang, db)
+    await localize_audio_detections(result["top_species"], lang)
 
     for item in result["top_species"]:
         item.pop("scientific_name", None)
@@ -369,7 +368,7 @@ async def get_audio_species_leaderboard(
             prev_start=prev_start,
             prev_end=prev_end,
         )
-        await localize_audio_detections(rows, lang, db)
+    await localize_audio_detections(rows, lang)
 
     species: list[dict] = []
     for row in rows:
@@ -518,7 +517,7 @@ async def get_audio_context(
         detections, suppressed_by_mapping = await repo.get_audio_context(
             target_time=target_time, window_seconds=window_seconds, mapping_value=mapping_value, limit=limit
         )
-        await localize_audio_detections(detections, lang, db)
+    await localize_audio_detections(detections, lang)
     hide_sensor = not auth.is_owner and settings.public_access.enabled and not settings.public_access.show_camera_names
     if hide_sensor:
         for detection in detections:
@@ -582,7 +581,7 @@ async def get_event_audio_context(
                 detection.get("scientific_name"),
             )
             detection["matches_visual"] = bool(visual_aliases.intersection(audio_aliases))
-        await localize_audio_detections(detections, lang, db)
+    await localize_audio_detections(detections, lang)
 
     hide_sensor = not auth.is_owner and settings.public_access.enabled and not settings.public_access.show_camera_names
     if hide_sensor:

--- a/backend/app/services/taxonomy/taxonomy_service.py
+++ b/backend/app/services/taxonomy/taxonomy_service.py
@@ -9,7 +9,7 @@ from app.services.localized_names import localized_names
 from app.services.species_reference import species_reference
 from typing import Any, Optional, Dict
 from datetime import datetime
-from app.database import get_db
+from app.database import pooled_connection_held, get_db
 from app.config import settings
 from app.services.ebird_service import ebird_service
 from app.utils.enrichment import get_effective_enrichment_settings
@@ -122,6 +122,8 @@ class TaxonomyService:
     def __init__(self):
         self._client: Optional[httpx.AsyncClient] = None
         self._client_lock = asyncio.Lock()
+        # Cache fills scheduled off a request, keyed so a page of rows asks once.
+        self._background_fills: dict[tuple[int, str], asyncio.Task] = {}
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get HTTP client with thread-safe lazy initialization."""
@@ -533,16 +535,50 @@ class TaxonomyService:
         if cached:
             return cached
 
-        # 2. Lookup from iNaturalist
+        # 2. Never wait on the network while the caller holds a pooled connection.
+        # The pool has five, the provider timeout is ten seconds, and one uncached
+        # species stalled everything else needing the database (#392). Answer with
+        # what is cached, which is nothing, and fill the cache off the request so
+        # the next render has the name.
+        if pooled_connection_held():
+            self._schedule_background_fill(taxa_id, lang)
+            return None
+
+        # 3. Lookup from iNaturalist
         log.info("Localized taxonomy lookup (iNaturalist)", taxa_id=taxa_id, lang=lang)
         result = await self._lookup_localized_inaturalist(taxa_id, lang)
 
         if result:
-            # 3. Save to Cache
+            # 4. Save to Cache
             await self._save_translation_to_cache(taxa_id, lang, result, db=db)
             return result
 
         return None
+
+    def _schedule_background_fill(self, taxa_id: int, lang: str) -> None:
+        """Fetch and cache one name off the request, once per name at a time."""
+        key = (taxa_id, lang)
+        existing = self._background_fills.get(key)
+        if existing is not None and not existing.done():
+            return
+
+        async def fill() -> None:
+            try:
+                result = await self._lookup_localized_inaturalist(taxa_id, lang)
+                if result:
+                    await self._save_translation_to_cache(taxa_id, lang, result)
+            except Exception as error:  # pragma: no cover - the request already answered
+                log.warning("Background name fill failed", taxa_id=taxa_id, lang=lang, error=str(error))
+            finally:
+                self._background_fills.pop(key, None)
+
+        self._background_fills[key] = asyncio.create_task(fill())
+
+    async def wait_for_background_fills(self) -> None:
+        """Let every scheduled fill finish. Tests and shutdown use this."""
+        pending = [task for task in self._background_fills.values() if not task.done()]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
     async def _get_translation_from_cache(
         self, taxa_id: int, lang: str, db: Optional[aiosqlite.Connection] = None

--- a/backend/app/utils/audio_localization.py
+++ b/backend/app/utils/audio_localization.py
@@ -7,6 +7,7 @@ via `taxonomy_cache` — the same transform applied to visual detections.
 
 import structlog
 import aiosqlite
+from app.database import get_db
 from app.services.taxonomy.taxonomy_service import taxonomy_service
 
 log = structlog.get_logger()
@@ -78,37 +79,55 @@ async def _resolve_taxa_id(
     return None
 
 
+async def _taxa_ids_for(
+    detections: list[dict],
+    db: aiosqlite.Connection | None,
+) -> dict[tuple[str, str], int | None]:
+    """Resolve every distinct (scientific, species) pair to a taxa_id.
+
+    This is the only part that needs a connection, and it is all database
+    reads, so when the caller has none it borrows one only for this.
+    """
+    keys = {((d.get("scientific_name") or "").strip(), (d.get("species") or "").strip()) for d in detections}
+
+    async def resolve_all(conn: aiosqlite.Connection) -> dict[tuple[str, str], int | None]:
+        return {key: await _resolve_taxa_id(conn, key[0], key[1]) for key in keys}
+
+    if db is not None:
+        return await resolve_all(db)
+    async with get_db() as conn:
+        return await resolve_all(conn)
+
+
 async def localize_audio_detections(
     detections: list[dict],
     lang: str,
-    db: aiosqlite.Connection,
+    db: aiosqlite.Connection | None = None,
 ) -> None:
     """In-place: replace locale-dependent `species` in a list of audio detection dicts.
 
     Each dict should have a `scientific_name` key (may be None/empty) and a
     `species` key. Dicts that yield no resolvable taxa_id by either path
     are left unchanged — graceful degradation.
+
+    Call it after giving any pooled connection back. Naming a species can ask
+    a provider over the network, and the lookups open their own short-lived
+    connection for the cache; they are never handed the caller's (#392).
     """
-    taxa_id_cache: dict[tuple[str, str], int | None] = {}
+    taxa_id_cache = await _taxa_ids_for(detections, db)
     for d in detections:
         scientific = (d.get("scientific_name") or "").strip()
         species = (d.get("species") or "").strip()
-        cache_key = (scientific, species)
-
-        if cache_key in taxa_id_cache:
-            taxa_id = taxa_id_cache[cache_key]
-        else:
-            taxa_id = await _resolve_taxa_id(db, scientific, species)
-            taxa_id_cache[cache_key] = taxa_id
+        taxa_id = taxa_id_cache.get((scientific, species))
 
         if not taxa_id:
             continue
 
         try:
             if lang != "en":
-                resolved = await taxonomy_service.get_localized_common_name(taxa_id, lang, db=db)
+                resolved = await taxonomy_service.get_localized_common_name(taxa_id, lang)
             else:
-                resolved = await taxonomy_service.get_canonical_english_name(taxa_id, db=db)
+                resolved = await taxonomy_service.get_canonical_english_name(taxa_id)
         except Exception as exc:
             log.warning(
                 "Audio name localization failed", scientific=scientific, species=species, lang=lang, error=str(exc)
@@ -122,7 +141,7 @@ async def localize_audio_detections(
 async def localize_audio_species_name(
     comname: str | None,
     lang: str,
-    db: aiosqlite.Connection,
+    db: aiosqlite.Connection | None = None,
     confirmed_taxa_id: int | None = None,
 ) -> str | None:
     """Return the canonical/localized name for a single BirdNET-Go `comName` string.
@@ -141,9 +160,9 @@ async def localize_audio_species_name(
     if confirmed_taxa_id is not None:
         try:
             if lang != "en":
-                return await taxonomy_service.get_localized_common_name(confirmed_taxa_id, lang, db=db)
+                return await taxonomy_service.get_localized_common_name(confirmed_taxa_id, lang)
             else:
-                return await taxonomy_service.get_canonical_english_name(confirmed_taxa_id, db=db)
+                return await taxonomy_service.get_canonical_english_name(confirmed_taxa_id)
         except Exception as exc:
             log.warning("Audio confirmed name localization failed", taxa_id=confirmed_taxa_id, error=str(exc))
             return None
@@ -151,26 +170,32 @@ async def localize_audio_species_name(
     # Unconfirmed: look up scientific_name from audio_detections, then go
     # through the same shared resolver so we benefit from common_name and
     # translation fallbacks.
-    try:
-        async with db.execute(
-            "SELECT scientific_name FROM audio_detections WHERE species = ? AND scientific_name IS NOT NULL LIMIT 1",
-            (comname.strip(),),
-        ) as cursor:
-            row = await cursor.fetchone()
-    except Exception as exc:
-        log.warning("Audio scientific_name lookup failed", species=comname, error=str(exc))
-        row = None
+    async def read_scientific_and_resolve(conn: aiosqlite.Connection) -> int | None:
+        try:
+            async with conn.execute(
+                "SELECT scientific_name FROM audio_detections WHERE species = ? AND scientific_name IS NOT NULL LIMIT 1",
+                (comname.strip(),),
+            ) as cursor:
+                row = await cursor.fetchone()
+        except Exception as exc:
+            log.warning("Audio scientific_name lookup failed", species=comname, error=str(exc))
+            row = None
+        scientific = row[0].strip() if row and row[0] else None
+        return await _resolve_taxa_id(conn, scientific, comname)
 
-    scientific = row[0].strip() if row and row[0] else None
-    taxa_id = await _resolve_taxa_id(db, scientific, comname)
+    if db is not None:
+        taxa_id = await read_scientific_and_resolve(db)
+    else:
+        async with get_db() as conn:
+            taxa_id = await read_scientific_and_resolve(conn)
     if not taxa_id:
         return None
 
     try:
         if lang != "en":
-            return await taxonomy_service.get_localized_common_name(taxa_id, lang, db=db)
+            return await taxonomy_service.get_localized_common_name(taxa_id, lang)
         else:
-            return await taxonomy_service.get_canonical_english_name(taxa_id, db=db)
+            return await taxonomy_service.get_canonical_english_name(taxa_id)
     except Exception as exc:
         log.warning("Audio unconfirmed name localization failed", species=comname, error=str(exc))
         return None

--- a/backend/tests/test_no_route_holds_a_connection_across_a_name_lookup.py
+++ b/backend/tests/test_no_route_holds_a_connection_across_a_name_lookup.py
@@ -1,0 +1,135 @@
+"""No route may hold a pooled connection while a species name is fetched.
+
+Every route that names a species for a non-English reader is exercised with an
+empty translation cache and a slow provider. The pool records the longest hold;
+it must be far shorter than the provider's delay, or the wait was inside the
+hold. Each test also proves the provider was actually asked, so a route that
+quietly took the English, cache-only path cannot pass by accident. This is the
+guard for #392 and the regression guard for #300.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import close_db, get_db, get_db_pool_status, init_db
+from app.main import app
+from app.services.taxonomy.taxonomy_service import taxonomy_service
+
+PROVIDER_DELAY_SECONDS = 0.4
+TAXA = 13094
+GERMAN = {"Accept-Language": "de"}
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def seeded_db():
+    await init_db()
+    try:
+        async with get_db() as db:
+            for table in ("detections", "audio_detections", "taxonomy_translations", "taxonomy_cache"):
+                await db.execute(f"DELETE FROM {table}")
+            await db.execute(
+                "INSERT INTO taxonomy_cache (scientific_name, common_name, taxa_id, is_not_found, last_updated)"
+                " VALUES ('Cyanistes caeruleus', 'Eurasian Blue Tit', ?, 0, CURRENT_TIMESTAMP)",
+                (TAXA,),
+            )
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            for index in range(3):
+                at = (now - timedelta(minutes=5 * index + 1)).strftime("%Y-%m-%d %H:%M:%S.%f")
+                await db.execute(
+                    """INSERT INTO detections (frigate_event, camera_name, detection_time, detection_index, score,
+                       display_name, category_name, scientific_name, common_name, taxa_id,
+                       audio_species, audio_confirmed, is_hidden)
+                       VALUES (?, 'cam1', ?, 1, 0.9, 'Eurasian Blue Tit', 'Cyanistes caeruleus',
+                               'Cyanistes caeruleus', 'Eurasian Blue Tit', ?, 'Eurasian Blue Tit', 0, 0)""",
+                    (f"evt_{index}", at, TAXA),
+                )
+                await db.execute(
+                    """INSERT INTO audio_detections (timestamp, species, confidence, sensor_id, scientific_name)
+                       VALUES (?, 'Eurasian Blue Tit', 0.8, 'mic1', 'Cyanistes caeruleus')""",
+                    (at,),
+                )
+            await db.commit()
+        taxonomy_service._background_fills.clear()
+        yield
+        await taxonomy_service.wait_for_background_fills()
+    finally:
+        await close_db()
+
+
+@pytest.fixture
+def slow_provider(monkeypatch):
+    """Records every call, so a route test can prove the non-English path ran."""
+    from app.config import settings
+
+    # The event-scoped audio route keeps only microphones mapped to the event's
+    # camera; with no mapping every row is suppressed and there is nothing to name.
+    monkeypatch.setattr(settings.frigate, "camera_audio_mapping", {"cam1": "*"})
+    calls: list[tuple[int, str]] = []
+
+    async def provider(taxa_id, lang):
+        calls.append((taxa_id, lang))
+        await asyncio.sleep(PROVIDER_DELAY_SECONDS)
+        return "Blaumeise"
+
+    monkeypatch.setattr(taxonomy_service, "_lookup_localized_inaturalist", provider)
+    return calls
+
+
+def _assert_no_hold_spanned_the_provider(path: str) -> None:
+    hold_max_ms = get_db_pool_status()["hold_ms_max"]
+    assert hold_max_ms < PROVIDER_DELAY_SECONDS * 1000 / 2, (
+        f"{path}: a connection was held for {hold_max_ms} ms while the provider took "
+        f"{PROVIDER_DELAY_SECONDS * 1000} ms, so the wait was inside the hold"
+    )
+
+
+ROUTES = [
+    "/api/events?limit=10",
+    "/api/species/Eurasian%20Blue%20Tit/stats",
+    "/api/stats/daily-summary",
+    "/api/audio/history?days=1",
+    "/api/audio/summary?days=1",
+    "/api/audio/species?span=day",
+    "/api/audio/context/event/evt_0",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ROUTES)
+async def test_the_route_answers_without_holding_a_connection_across_the_provider(path, slow_provider):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(path, headers=GERMAN)
+        assert res.status_code == 200, (path, res.text[:200])
+    await taxonomy_service.wait_for_background_fills()
+    assert slow_provider, f"{path}: the provider was never asked, so the non-English path did not run"
+    _assert_no_hold_spanned_the_provider(path)
+
+
+@pytest.mark.asyncio
+async def test_the_audio_context_route_answers_without_holding_a_connection_across_the_provider(slow_provider):
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    path = f"/api/audio/context?timestamp={now.isoformat()}&window_seconds=3600&limit=8"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(path, headers=GERMAN)
+        assert res.status_code == 200, res.text[:200]
+    await taxonomy_service.wait_for_background_fills()
+    assert slow_provider
+    _assert_no_hold_spanned_the_provider(path)
+
+
+@pytest.mark.asyncio
+async def test_a_second_render_has_the_name_the_first_one_filled_in(slow_provider):
+    """Inside a hold the first render answers with the stored name and fills the
+    cache off the request; the name is there for the next one."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        first = await client.get("/api/stats/daily-summary", headers=GERMAN)
+        assert first.status_code == 200
+        assert "Blaumeise" not in first.text, "the first render must not have waited for the provider"
+        await taxonomy_service.wait_for_background_fills()
+        second = await client.get("/api/stats/daily-summary", headers=GERMAN)
+        assert second.status_code == 200
+    assert "Blaumeise" in second.text

--- a/backend/tests/test_taxonomy_lookup_never_waits_on_network_inside_a_hold.py
+++ b/backend/tests/test_taxonomy_lookup_never_waits_on_network_inside_a_hold.py
@@ -1,0 +1,89 @@
+"""A name lookup must never wait on iNaturalist while a pooled connection is held.
+
+The pool has five connections. Eleven call sites handed one to the taxonomy
+lookup and let it go to the network with a ten second timeout, so one uncached
+species could stall everything else needing the database (#392, and the same
+disease as #300). Rather than rewrite every caller, the lookup itself now knows
+whether the calling task holds a connection: if it does, it answers from cache
+and fills the cache off the request, so the next render has the name.
+"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from app.database import close_db, get_db, get_db_pool_status, init_db, pooled_connection_held
+from app.services.taxonomy.taxonomy_service import taxonomy_service
+
+NETWORK_DELAY_SECONDS = 0.4
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clean_db():
+    await init_db()
+    try:
+        async with get_db() as db:
+            await db.execute("DELETE FROM taxonomy_translations")
+            await db.commit()
+        taxonomy_service._background_fills.clear()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.fixture
+def slow_network(monkeypatch):
+    calls: list[tuple[int, str]] = []
+
+    async def slow_inaturalist(taxa_id, lang):
+        calls.append((taxa_id, lang))
+        await asyncio.sleep(NETWORK_DELAY_SECONDS)
+        return f"Blaumeise-{taxa_id}"
+
+    monkeypatch.setattr(taxonomy_service, "_lookup_localized_inaturalist", slow_inaturalist)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_inside_a_hold_the_lookup_answers_from_cache_and_fills_in_the_background(slow_network):
+    async with get_db() as db:
+        assert pooled_connection_held()
+        started = asyncio.get_event_loop().time()
+        name = await taxonomy_service.get_localized_common_name(13094, "de", db=db)
+        elapsed = asyncio.get_event_loop().time() - started
+
+    assert name is None, "an uncached name is not waited for while a connection is held"
+    assert elapsed < NETWORK_DELAY_SECONDS / 2
+    assert get_db_pool_status()["hold_ms_max"] < NETWORK_DELAY_SECONDS * 1000 / 2
+
+    await taxonomy_service.wait_for_background_fills()
+    assert slow_network == [(13094, "de")]
+    assert await taxonomy_service.get_localized_common_name(13094, "de") == "Blaumeise-13094"
+
+
+@pytest.mark.asyncio
+async def test_outside_a_hold_the_lookup_still_waits_for_the_network(slow_network):
+    assert not pooled_connection_held()
+    name = await taxonomy_service.get_localized_common_name(13094, "de")
+    assert name == "Blaumeise-13094"
+    assert slow_network == [(13094, "de")]
+
+
+@pytest.mark.asyncio
+async def test_a_page_of_rows_schedules_one_fill_per_name_not_one_per_row(slow_network):
+    async with get_db() as db:
+        results = await asyncio.gather(
+            *(taxonomy_service.get_localized_common_name(13094, "de", db=db) for _ in range(6))
+        )
+    assert results == [None] * 6
+    await taxonomy_service.wait_for_background_fills()
+    assert slow_network == [(13094, "de")]
+
+
+@pytest.mark.asyncio
+async def test_a_cached_name_is_returned_inside_a_hold_without_touching_the_network(slow_network):
+    async with get_db() as db:
+        await taxonomy_service._save_translation_to_cache(13094, "de", "Blaumeise", db=db)
+        assert await taxonomy_service.get_localized_common_name(13094, "de", db=db) == "Blaumeise"
+    assert slow_network == []


### PR DESCRIPTION
Fixes [#392](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/392). Closes out the class of problem behind #300.

## The problem, and why the obvious fix was wrong

Eleven call sites named a species for a non-English reader by checking the cache and then asking iNaturalist over the network, ten second timeout, while holding one of five pooled connections. One uncached species could stall everything else needing the database.

Three of those sites are inside `get_events`, the species stats route and the daily summary, which interleave database reads and naming all the way through. Restructuring each into "all reads, then all naming" is a large rewrite of three long functions, and the next person to add a lookup inside a hold recreates the bug.

## The fix, at the right depth

The pool already tracks per task whether a connection is held (`_acquire_depth`). The lookup now asks it:

- **Inside a hold:** answer with what is cached; schedule the provider fetch and cache write off the request, once per `(taxa_id, lang)` at a time. The next render has the name.
- **Outside a hold:** wait for the provider exactly as before.

No caller can regress this, including ones not written yet. `get_canonical_english_name` is cache-only already and needed nothing.

The six audio routes whose localisation was the last statement in their hold were moved out anyway, so those pages keep synchronous naming. `localize_audio_detections` and `localize_audio_species_name` now accept no connection and borrow one only for their own reads; they never hand the caller's to the taxonomy service.

## The behaviour change, stated plainly

For a non-English reader, the **first** render of a species whose name is not yet cached may show the stored name; the background fill lands within a provider round trip and the next render shows the translated one. Before, that first render waited up to ten seconds while blocking every other database user. `test_a_second_render_has_the_name_the_first_one_filled_in` pins both halves.

Ingest and notifications are unaffected: their two lookups pass no connection and run outside any hold.

## Verification

- Four unit tests on the guard: inside a hold answers fast and fills in the background; outside a hold waits; six concurrent callers schedule one fill; a cached hit never touches the network.
- **Nine route tests**, each as a German reader against an empty cache and a 400 ms provider: events list, species stats, daily summary, audio history, summary, species leaderboard, context and event context. Each asserts the response is 200, **the provider was actually asked**, and the longest connection hold was under half the provider delay.
- That last assertion exists because the first version of the daily-summary test passed trivially: that router reads `request.state.language`, my stub had targeted `get_user_language`, and the route had quietly taken the English, cache-only path. The tests now set the language the way the app does, through the `Accept-Language` header, and prove the non-English path ran.
- `pytest` 2689 passed, 49 skipped. `ruff check .` / `ruff format --check .` clean from the root.

## Quark

Baseline before this change: 3 slow-hold warnings in 24 hours on quark, each about 1.3 s. After it builds and deploys I will report the count over the same window; the pool logs the offender, so that is the measurement rather than my say-so.