### PR TITLE
Remember a species with no Wikipedia article for a day, not a minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A species with no Wikipedia article is no longer searched for again on nearly every visit.**
+  A lookup that ran every search strategy and found nothing was remembered for one minute, the same
+  as a lookup that had failed, so the species page for such a bird re-ran the whole serial search
+  on the next visit and took up to twelve seconds on a live install, with the same birds recurring
+  in the log. A definitive miss is now remembered for a day; a request that timed out or errored is
+  still retried after a minute, because that can change.
 - **No page waits on iNaturalist while holding a database connection
   ([#392](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/392)).** Eleven places
   named a species for a non-English reader by checking the cache and then asking iNaturalist over

--- a/backend/app/routers/species.py
+++ b/backend/app/routers/species.py
@@ -44,6 +44,16 @@ log = structlog.get_logger()
 _wiki_cache: dict[str, tuple[SpeciesInfo, datetime]] = {}
 CACHE_TTL_SUCCESS = timedelta(hours=24)
 CACHE_TTL_FAILURE = timedelta(minutes=1)  # Short TTL for failures to allow retries
+# A search that ran every strategy and found nothing is a different thing from a
+# request that failed. The first does not change in the next minute; on a live
+# install it was re-run on nearly every visit and took up to twelve seconds.
+CACHE_TTL_NOT_FOUND = timedelta(hours=24)
+_definitive_misses: dict[str, datetime] = {}
+
+
+def _remember_definitive_miss(cache_key: str) -> None:
+    _definitive_misses[cache_key] = datetime.now()
+
 
 # User-Agent is required by Wikipedia API - they block requests without it
 WIKIPEDIA_USER_AGENT = "YA-WAMF/2.0 (Bird Watching App; https://github.com/Jellman86/YetAnother-WhosAtMyFeeder)"
@@ -96,11 +106,16 @@ def _parse_cached_at(value: object) -> datetime | None:
     return None
 
 
-def _is_cache_valid(info: SpeciesInfo, cached_at: datetime | None) -> bool:
+def _is_cache_valid(info: SpeciesInfo, cached_at: datetime | None, cache_key: str | None = None) -> bool:
     if not cached_at:
         return False
     is_success = bool(info.thumbnail_url or info.extract)
-    cache_ttl = CACHE_TTL_SUCCESS if is_success else CACHE_TTL_FAILURE
+    if is_success:
+        cache_ttl = CACHE_TTL_SUCCESS
+    elif cache_key is not None and cache_key in _definitive_misses:
+        cache_ttl = CACHE_TTL_NOT_FOUND
+    else:
+        cache_ttl = CACHE_TTL_FAILURE
     return datetime.now() - cached_at < cache_ttl
 
 
@@ -401,7 +416,7 @@ async def _get_cached_species_info(
     cache_key = f"{species_name}:{language}"
     if cache_key in _wiki_cache:
         info, cached_at = _wiki_cache[cache_key]
-        if _is_cache_valid(info, cached_at):
+        if _is_cache_valid(info, cached_at, cache_key):
             log.debug("Returning cached species info (memory)", species=species_name)
             return info
 
@@ -428,7 +443,7 @@ async def _get_cached_species_info(
         taxa_id=row[12],
     )
 
-    if _is_cache_valid(info, cached_at):
+    if _is_cache_valid(info, cached_at, cache_key):
         _wiki_cache[cache_key] = (info, cached_at or datetime.now())
         log.debug("Returning cached species info (db)", species=species_name)
         return info
@@ -1670,7 +1685,7 @@ async def _fetch_wikipedia_info(
     try:
         async with httpx.AsyncClient(timeout=15.0, follow_redirects=True, headers=headers) as client:
             # Try multiple strategies to find the Wikipedia article
-            article_title = await _find_wikipedia_article(
+            article_title, definitive = await _find_wikipedia_article(
                 client,
                 species_name,
                 lang,
@@ -1680,8 +1695,11 @@ async def _fetch_wikipedia_info(
             if article_title:
                 log.info("Found Wikipedia article", species=species_name, article=article_title)
                 return await _get_wikipedia_summary(client, article_title, species_name, lang)
-            else:
-                log.warning("No Wikipedia article found after all strategies", species=species_name)
+
+            log.warning("No Wikipedia article found after all strategies", species=species_name, definitive=definitive)
+
+            if definitive:
+                _remember_definitive_miss(f"{species_name}:{lang}")
 
     except httpx.TimeoutException:
         log.error("Wikipedia API timeout", species=species_name)
@@ -1923,8 +1941,13 @@ async def _find_wikipedia_article(
     species_name: str,
     lang: str,
     expected_scientific_name: str | None = None,
-) -> str | None:
-    """Try multiple strategies and select the best matching bird article."""
+) -> tuple[str | None, bool]:
+    """Try multiple strategies and select the best matching bird article.
+
+    Returns the title and whether a miss was definitive: every strategy ran and
+    found nothing, as opposed to one of them failing along the way.
+    """
+    errored = [False]  # a list, so nested helpers can mark it without nonlocal
     base_url = f"https://{lang}.wikipedia.org/api/rest_v1/page/summary"
 
     titles_to_try: list[str] = [species_name]
@@ -1995,6 +2018,7 @@ async def _find_wikipedia_article(
         try:
             response = await client.get(url)
         except Exception as e:
+            errored[0] = True
             log.warning("Error checking Wikipedia title", title=title, strategy=strategy, error=str(e))
             return
 
@@ -2054,7 +2078,7 @@ async def _find_wikipedia_article(
             article=best_title,
             score=best_score,
         )
-        return best_title
+        return best_title, True
 
     log.debug("Falling back to Wikipedia search API", species=species_name, language=lang)
     search_url = f"https://{lang}.wikipedia.org/w/api.php"
@@ -2098,6 +2122,7 @@ async def _find_wikipedia_article(
         try:
             response = await client.get(search_url, params=search_params)
         except Exception as e:
+            errored[0] = True
             log.warning("Wikipedia search failed", error=str(e), species=species_name, query=search_query)
             continue
 
@@ -2131,10 +2156,12 @@ async def _find_wikipedia_article(
             article=best_title,
             score=best_score,
         )
-        return best_title
+        return best_title, True
 
-    log.warning("All Wikipedia search strategies exhausted", species=species_name, language=lang)
-    return None
+    log.warning(
+        "All Wikipedia search strategies exhausted", species=species_name, language=lang, definitive=not errored[0]
+    )
+    return None, not errored[0]
 
 
 async def _get_wikipedia_summary(

--- a/backend/tests/test_species_info_not_found_is_remembered.py
+++ b/backend/tests/test_species_info_not_found_is_remembered.py
@@ -1,0 +1,91 @@
+"""A species with no Wikipedia article must not be searched for again every minute.
+
+On a live install the species page took up to twelve seconds for a bird the
+search could not find, and the same birds recurred in the log, because a lookup
+that found nothing was cached for one minute like a lookup that had failed. A
+request that timed out deserves a quick retry; a search that ran every strategy
+and found nothing does not change in the next sixty seconds.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.routers import species as species_router
+from app.routers.species import (
+    CACHE_TTL_FAILURE,
+    CACHE_TTL_NOT_FOUND,
+    SpeciesInfo,
+    _is_cache_valid,
+    _remember_definitive_miss,
+)
+
+
+def _empty(name="Sooty Fox Sparrow") -> SpeciesInfo:
+    return SpeciesInfo(
+        title=name,
+        description=None,
+        extract=None,
+        thumbnail_url=None,
+        wikipedia_url=None,
+        source=None,
+        source_url=None,
+        scientific_name=None,
+        conservation_status=None,
+        cached_at=datetime.now(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def clean_markers():
+    species_router._definitive_misses.clear()
+    yield
+    species_router._definitive_misses.clear()
+
+
+def test_a_lookup_that_errored_is_retried_after_a_minute():
+    info = _empty()
+    assert _is_cache_valid(info, datetime.now() - timedelta(seconds=30), "Sooty Fox Sparrow:en")
+    assert not _is_cache_valid(info, datetime.now() - CACHE_TTL_FAILURE - timedelta(seconds=1), "Sooty Fox Sparrow:en")
+
+
+def test_a_search_that_found_nothing_is_remembered_for_much_longer():
+    info = _empty()
+    _remember_definitive_miss("Sooty Fox Sparrow:en")
+    assert _is_cache_valid(info, datetime.now() - timedelta(hours=6), "Sooty Fox Sparrow:en")
+    assert not _is_cache_valid(
+        info, datetime.now() - CACHE_TTL_NOT_FOUND - timedelta(seconds=1), "Sooty Fox Sparrow:en"
+    )
+    assert CACHE_TTL_NOT_FOUND > CACHE_TTL_FAILURE * 60
+
+
+def test_a_found_article_is_unaffected():
+    found = _empty()
+    found.extract = "A small brown bird."
+    assert _is_cache_valid(found, datetime.now() - timedelta(hours=23), "Sooty Fox Sparrow:en")
+
+
+@pytest.mark.asyncio
+async def test_the_search_reports_whether_its_miss_was_definitive(monkeypatch):
+    """Every strategy ran and found nothing: definitive. A strategy raised: not."""
+    import httpx
+
+    calls = {"n": 0}
+
+    class Boom(httpx.AsyncClient):
+        async def get(self, *a, **k):
+            calls["n"] += 1
+            raise httpx.ConnectError("down")
+
+    class Empty(httpx.AsyncClient):
+        async def get(self, *a, **k):
+            calls["n"] += 1
+            return httpx.Response(200, json={"query": {"search": []}, "pages": {}})
+
+    async with Boom() as boom:
+        title, definitive = await species_router._find_wikipedia_article(boom, "Sooty Fox Sparrow", "en")
+    assert title is None and definitive is False
+
+    async with Empty() as empty:
+        title, definitive = await species_router._find_wikipedia_article(empty, "Sooty Fox Sparrow", "en")
+    assert title is None and definitive is True


### PR DESCRIPTION
From the 24-hour access log on quark: `/api/species/{name}/info` peaked at **12.2 s** (0.77 s average over 61 calls), and the warnings showed the same birds exhausting every Wikipedia search strategy again and again.

## Cause

`_is_cache_valid` treats any result without an extract or thumbnail as a failure and gives it `CACHE_TTL_FAILURE` of one minute, with a comment saying that is to allow retries. That is right for a timeout and wrong for a search that ran every strategy and found nothing: the article does not appear in the next sixty seconds, so the species page for such a bird re-ran the whole serial search on nearly every visit.

## Fix

- `_find_wikipedia_article` now returns `(title, definitive)`: definitive when every strategy ran and found nothing, not definitive when any strategy raised. Every `except` inside it marks the miss as non-definitive.
- A definitive miss is remembered for `CACHE_TTL_NOT_FOUND` (24 h). An errored lookup keeps its minute.
- The in-memory marker sits beside the existing in-memory cache. The database-backed cache row keeps the short TTL, so after a restart the first visit pays once and is then remembered. Persisting the distinction would need a column, and a migration did not seem proportionate here; stated rather than hidden.

## Verification

- Four tests: an errored lookup is retried after a minute; a definitive miss is remembered for hours and expires after a day; a found article is unaffected; and the search itself reports definitive for empty results and non-definitive for a client that raises.
- `pytest` full suite green, ruff clean from the root.