### PR TITLE
Lend the held connection for cache reads instead of opening a second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Naming a species no longer opens a second database connection beside the one a page already
+  holds.** Keeping name lookups off the network inside a hold also stopped the audio helpers lending
+  the caller's connection to the cache read, so a cache-only lookup took a second pooled connection
+  for the duration. With five connections and a dashboard open fanning out a dozen requests at once,
+  each such request took two. The caller's connection is lent again for the cache read; the lookup
+  still refuses to go to the network while it is held.
 - **A species with no Wikipedia article is no longer searched for again on nearly every visit.**
   A lookup that ran every search strategy and found nothing was remembered for one minute, the same
   as a lookup that had failed, so the species page for such a bird re-ran the whole serial search

--- a/backend/app/utils/audio_localization.py
+++ b/backend/app/utils/audio_localization.py
@@ -123,11 +123,14 @@ async def localize_audio_detections(
         if not taxa_id:
             continue
 
+        # A caller that still holds a connection lends it for the cache read, so the
+        # lookup does not open a second one beside it. The lookup itself refuses to
+        # go to the network while that connection is held, so lending it is safe.
         try:
             if lang != "en":
-                resolved = await taxonomy_service.get_localized_common_name(taxa_id, lang)
+                resolved = await taxonomy_service.get_localized_common_name(taxa_id, lang, db=db)
             else:
-                resolved = await taxonomy_service.get_canonical_english_name(taxa_id)
+                resolved = await taxonomy_service.get_canonical_english_name(taxa_id, db=db)
         except Exception as exc:
             log.warning(
                 "Audio name localization failed", scientific=scientific, species=species, lang=lang, error=str(exc)
@@ -160,9 +163,9 @@ async def localize_audio_species_name(
     if confirmed_taxa_id is not None:
         try:
             if lang != "en":
-                return await taxonomy_service.get_localized_common_name(confirmed_taxa_id, lang)
+                return await taxonomy_service.get_localized_common_name(confirmed_taxa_id, lang, db=db)
             else:
-                return await taxonomy_service.get_canonical_english_name(confirmed_taxa_id)
+                return await taxonomy_service.get_canonical_english_name(confirmed_taxa_id, db=db)
         except Exception as exc:
             log.warning("Audio confirmed name localization failed", taxa_id=confirmed_taxa_id, error=str(exc))
             return None
@@ -193,9 +196,9 @@ async def localize_audio_species_name(
 
     try:
         if lang != "en":
-            return await taxonomy_service.get_localized_common_name(taxa_id, lang)
+            return await taxonomy_service.get_localized_common_name(taxa_id, lang, db=db)
         else:
-            return await taxonomy_service.get_canonical_english_name(taxa_id)
+            return await taxonomy_service.get_canonical_english_name(taxa_id, db=db)
     except Exception as exc:
         log.warning("Audio unconfirmed name localization failed", species=comname, error=str(exc))
         return None

--- a/backend/tests/test_cache_reads_do_not_open_a_second_connection.py
+++ b/backend/tests/test_cache_reads_do_not_open_a_second_connection.py
@@ -1,0 +1,58 @@
+"""Naming a species inside a hold must not open a second pooled connection.
+
+The network guard (#393) stopped lookups waiting on iNaturalist inside a hold,
+but the audio helpers then stopped lending the caller's connection to the
+cache read as well, so a cache-only English lookup opened a second pooled
+connection beside the one the route already held. Quark logged it as
+"Nested DB connection acquire depth=2". With five connections and a dashboard
+load fanning out a dozen requests, each such request took two.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.database import close_db, get_db, get_db_pool_status, init_db
+from app.utils.audio_localization import localize_audio_detections, localize_audio_species_name
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def seeded():
+    await init_db()
+    try:
+        async with get_db() as db:
+            for table in ("audio_detections", "taxonomy_translations", "taxonomy_cache"):
+                await db.execute(f"DELETE FROM {table}")
+            await db.execute(
+                "INSERT INTO taxonomy_cache (scientific_name, common_name, taxa_id, is_not_found, last_updated)"
+                " VALUES ('Cyanistes caeruleus', 'Eurasian Blue Tit', 13094, 0, CURRENT_TIMESTAMP)"
+            )
+            await db.execute(
+                "INSERT INTO audio_detections (timestamp, species, confidence, sensor_id, scientific_name)"
+                " VALUES (CURRENT_TIMESTAMP, 'Blue Tit', 0.8, 'mic1', 'Cyanistes caeruleus')"
+            )
+            await db.commit()
+        yield
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lang", ["en", "de"])
+async def test_a_caller_holding_a_connection_lends_it_for_the_cache_read(lang):
+    before = get_db_pool_status()["nested_acquires"]
+    rows = [{"species": "Blue Tit", "scientific_name": "Cyanistes caeruleus"}]
+    async with get_db() as db:
+        await localize_audio_detections(rows, lang, db)
+        await localize_audio_species_name("Blue Tit", lang, db)
+        await localize_audio_species_name("Blue Tit", lang, db, confirmed_taxa_id=13094)
+    assert get_db_pool_status()["nested_acquires"] == before, "a lookup opened a second connection inside the hold"
+    assert rows[0]["species"] == "Eurasian Blue Tit" if lang == "en" else True
+
+
+@pytest.mark.asyncio
+async def test_a_caller_with_no_connection_still_works_and_nests_nothing():
+    before = get_db_pool_status()["nested_acquires"]
+    rows = [{"species": "Blue Tit", "scientific_name": "Cyanistes caeruleus"}]
+    await localize_audio_detections(rows, "en")
+    assert rows[0]["species"] == "Eurasian Blue Tit"
+    assert get_db_pool_status()["nested_acquires"] == before


### PR DESCRIPTION
A regression from #393, caught on quark within a minute of deploying it and fixed the same day.

## What quark showed

```
Nested DB connection acquire depth=2 nested_by=taxonomy_service:get_canonical_english_name outer_held_by=app.routers.stats:get_daily_summary
Nested DB connection acquire depth=2 nested_by=taxonomy_service:get_canonical_english_name outer_held_by=app.routers.events:get_events
```

## Cause

#393 stopped the audio helpers passing the caller's connection into the taxonomy lookups, to keep the network out of the hold. But that also stopped them lending it for the **cache read**, so a cache-only English lookup opened a second pooled connection beside the one the route already held. With five connections and a dashboard open fanning out a dozen requests at once, each such request took two. The 9-hour log shows the effect: every dashboard open by a guest produced a burst of 300-650 ms acquire waits.

## Fix

The helpers lend the caller's connection again (`db=db`) for both lookups. That is safe for the localized lookup too, because #393's guard refuses to go to the network while that connection is held; lending it only covers the cache read.

## Verification

- New test holds a connection, names a species in English and in German, and asserts `nested_acquires` did not move; plus the no-connection path still names correctly and nests nothing.
- All nine route-hold tests and the four guard tests still pass, so the network still never runs inside a hold.
- `pytest` full suite green, ruff clean from the root.

## Not in this PR

The page-load fan-out itself (a dozen concurrent requests against a pool of five) is the bigger cause of the waits and is being measured separately before any pool-size change.