### PR TITLE
Bound page-load fan-out at the API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Opening a page no longer fires a request per row all at once.** The dashboard probed every
+  visit on screen for a clip in the same second, and species pages asked for every row's photo and
+  summary at once: on a live install one dashboard open was twenty-nine clip probes in one second,
+  then twenty species lookups the next, against a server pool of five database connections, and
+  every one of those became a 300 to 650 ms queue. Both kinds of request are now bounded to three in
+  flight at the API client, so the rest wait their turn and every page that asks, now or later,
+  gets the same restraint.
 - **Naming a species no longer opens a second database connection beside the one a page already
   holds.** Keeping name lookups off the network inside a hold also stopped the audio helpers lending
   the caller's connection to the cache read, so a cache-only lookup took a second pooled connection

--- a/apps/ui/src/lib/api/fanout-is-bounded.test.ts
+++ b/apps/ui/src/lib/api/fanout-is-bounded.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A page that renders many rows must not fan out one request per row at once.
+ * The bound lives in the API client so every caller, present and future, gets it.
+ */
+vi.mock('./core', async () => {
+    const actual = await vi.importActual<typeof import('./core')>('./core');
+    return { ...actual, apiFetch: vi.fn(), handleResponse: vi.fn(async () => ({})) };
+});
+
+function neverResolving() {
+    let release!: () => void;
+    const promise = new Promise<Response>((resolve) => {
+        release = () => resolve(new Response(null, { status: 200, headers: {} }));
+    });
+    return { promise, release };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('page-load fan-out is bounded at the API client', () => {
+    it('species info: at most three requests in flight, the rest queued', async () => {
+        const core = await import('./core');
+        const holds = Array.from({ length: 8 }, () => neverResolving());
+        let n = 0;
+        vi.mocked(core.apiFetch).mockImplementation(() => holds[n++].promise);
+        const { fetchSpeciesInfo } = await import('./species');
+
+        const calls = Array.from({ length: 8 }, (_, i) => fetchSpeciesInfo(`Species ${i}`));
+        await Promise.resolve(); await Promise.resolve();
+        expect(vi.mocked(core.apiFetch)).toHaveBeenCalledTimes(3);
+
+        holds.forEach((h) => h.release());
+        await Promise.all(calls);
+        expect(vi.mocked(core.apiFetch)).toHaveBeenCalledTimes(8);
+    });
+
+    it('clip probes: at most three in flight, the rest queued', async () => {
+        const core = await import('./core');
+        const holds = Array.from({ length: 8 }, () => neverResolving());
+        let n = 0;
+        vi.mocked(core.apiFetch).mockImplementation(() => holds[n++].promise);
+        const { checkRecordingClipAvailable } = await import('./media');
+
+        const calls = Array.from({ length: 8 }, (_, i) => checkRecordingClipAvailable(`evt-${i}`));
+        await Promise.resolve(); await Promise.resolve();
+        expect(vi.mocked(core.apiFetch)).toHaveBeenCalledTimes(3);
+
+        holds.forEach((h) => h.release());
+        await Promise.all(calls);
+        expect(vi.mocked(core.apiFetch)).toHaveBeenCalledTimes(8);
+    });
+});

--- a/apps/ui/src/lib/api/media.ts
+++ b/apps/ui/src/lib/api/media.ts
@@ -1,3 +1,4 @@
+import { createSlotGate } from '../utils/concurrency';
 import { API_BASE, apiFetch, getHeaders, handleResponse, withAuthParams } from './core';
 import type { paths } from './generated/openapi';
 
@@ -153,26 +154,33 @@ export async function checkClipAvailable(frigateEvent: string): Promise<boolean>
     }
 }
 
+// The dashboard and the explorer probe every visit on the page for a clip. Bounded here so
+// thirty cards do not become thirty probes in one second; each probe takes a pooled
+// database connection on the server for its access check.
+const clipProbeGate = createSlotGate(3);
+
 export async function checkRecordingClipAvailable(frigateEvent: string): Promise<RecordingClipAvailabilityResponse> {
-    try {
-        const response = await apiFetch(`${API_BASE}/frigate/${encodeURIComponent(frigateEvent)}/recording-clip.mp4`, {
-            method: 'HEAD',
-            timeoutMs: 10_000
-        });
-        const rawState = response.headers.get(RECORDING_CLIP_STATE_HEADER)?.toLowerCase();
-        const state: RecordingClipState | null = rawState === 'complete' || rawState === 'partial' ? rawState : null;
-        const rawDuration = Number.parseFloat(response.headers.get(RECORDING_CLIP_DURATION_HEADER) ?? '');
-        return {
-            available: response.ok,
-            fetched: state === 'complete' || (
-                state === null && response.headers.get(RECORDING_CLIP_READY_HEADER)?.toLowerCase() === 'cached'
-            ),
-            state,
-            durationSeconds: Number.isFinite(rawDuration) && rawDuration > 0 ? rawDuration : null
-        };
-    } catch {
-        return { available: false, fetched: false, state: null, durationSeconds: null };
-    }
+    return clipProbeGate.run(async () => {
+        try {
+            const response = await apiFetch(`${API_BASE}/frigate/${encodeURIComponent(frigateEvent)}/recording-clip.mp4`, {
+                method: 'HEAD',
+                timeoutMs: 10_000
+            });
+            const rawState = response.headers.get(RECORDING_CLIP_STATE_HEADER)?.toLowerCase();
+            const state: RecordingClipState | null = rawState === 'complete' || rawState === 'partial' ? rawState : null;
+            const rawDuration = Number.parseFloat(response.headers.get(RECORDING_CLIP_DURATION_HEADER) ?? '');
+            return {
+                available: response.ok,
+                fetched: state === 'complete' || (
+                    state === null && response.headers.get(RECORDING_CLIP_READY_HEADER)?.toLowerCase() === 'cached'
+                ),
+                state,
+                durationSeconds: Number.isFinite(rawDuration) && rawDuration > 0 ? rawDuration : null
+            };
+        } catch {
+            return { available: false, fetched: false, state: null, durationSeconds: null };
+        }
+    });
 }
 
 export async function fetchRecordingClip(frigateEvent: string): Promise<RecordingClipFetchResponse> {

--- a/apps/ui/src/lib/api/species.ts
+++ b/apps/ui/src/lib/api/species.ts
@@ -1,5 +1,6 @@
 import { toLocalYMD } from '../utils/date-only';
 import { API_BASE, apiFetch, handleResponse } from './core';
+import { createSlotGate } from '../utils/concurrency';
 import type { Detection, SpeciesCount } from './types';
 import type { paths } from './generated/openapi';
 
@@ -56,12 +57,19 @@ export async function fetchSpeciesStats(speciesName: string): Promise<SpeciesSta
     return handleResponse<SpeciesStats>(response);
 }
 
+// A page of species rows each asks for its info. Bounded here so a leaderboard of
+// twenty does not fire twenty requests in one second at a five-connection pool;
+// on a live install that burst alone produced a dozen 300 to 650 ms waits.
+const speciesInfoGate = createSlotGate(3);
+
 export async function fetchSpeciesInfo(speciesName: string, signal?: AbortSignal): Promise<SpeciesInfo> {
-    const response = await apiFetch(`${API_BASE}/species/${encodeURIComponent(speciesName)}/info`, {
-        signal,
-        timeoutMs: 15_000
+    return speciesInfoGate.run(async () => {
+        const response = await apiFetch(`${API_BASE}/species/${encodeURIComponent(speciesName)}/info`, {
+            signal,
+            timeoutMs: 15_000
+        });
+        return handleResponse<SpeciesInfo>(response);
     });
-    return handleResponse<SpeciesInfo>(response);
 }
 
 export type CommonNameOverride = paths['/api/species/common-name-override']['get']['response'];

--- a/apps/ui/src/lib/utils/concurrency.test.ts
+++ b/apps/ui/src/lib/utils/concurrency.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { createSlotGate } from './concurrency';
+
+function deferred<T = void>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+describe('createSlotGate', () => {
+    it('never runs more than the limit at once and admits the rest in order', async () => {
+        const gate = createSlotGate(3);
+        const holds = Array.from({ length: 6 }, () => deferred());
+        const started: number[] = [];
+        const runs = holds.map((h, i) => gate.run(async () => { started.push(i); await h.promise; return i; }));
+        await Promise.resolve();
+        expect(started).toEqual([0, 1, 2]);
+        expect(gate.active).toBe(3);
+
+        holds[1].resolve();
+        await runs[1];
+        await Promise.resolve();
+        expect(started).toEqual([0, 1, 2, 3]);
+        expect(gate.active).toBe(3);
+
+        for (const h of holds) h.resolve();
+        expect(await Promise.all(runs)).toEqual([0, 1, 2, 3, 4, 5]);
+        expect(gate.active).toBe(0);
+    });
+
+    it('releases the slot when the work throws, so a failure cannot wedge the gate', async () => {
+        const gate = createSlotGate(1);
+        await expect(gate.run(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+        expect(gate.active).toBe(0);
+        expect(await gate.run(async () => 'after')).toBe('after');
+    });
+
+    it('refuses a limit that would admit nothing', () => {
+        expect(() => createSlotGate(0)).toThrow(RangeError);
+    });
+});

--- a/apps/ui/src/lib/utils/concurrency.ts
+++ b/apps/ui/src/lib/utils/concurrency.ts
@@ -1,0 +1,52 @@
+/**
+ * A gate that lets at most `limit` pieces of work run at once; the rest wait
+ * their turn in order.
+ *
+ * A page that renders thirty cards should not fire thirty requests in the same
+ * second. The backend serves them from a pool of five database connections, and
+ * a burst like that turns every one of them into a queue: on a live install one
+ * dashboard open produced fifteen waits of 300 to 650 ms. Bounding the fan-out at
+ * the API client keeps every caller honest, including ones not written yet.
+ */
+export interface SlotGate {
+    run<T>(work: () => Promise<T>): Promise<T>;
+    /** How many pieces of work are running right now. For tests and diagnostics. */
+    readonly active: number;
+}
+
+export function createSlotGate(limit: number): SlotGate {
+    if (!Number.isInteger(limit) || limit < 1) throw new RangeError(`limit must be a positive integer, got ${limit}`);
+    let active = 0;
+    const waiting: Array<() => void> = [];
+
+    function release(): void {
+        const next = waiting.shift();
+        if (next) {
+            next();
+        } else {
+            active -= 1;
+        }
+    }
+
+    function acquire(): Promise<void> {
+        if (active < limit) {
+            active += 1;
+            return Promise.resolve();
+        }
+        return new Promise((resolve) => waiting.push(resolve));
+    }
+
+    return {
+        async run<T>(work: () => Promise<T>): Promise<T> {
+            await acquire();
+            try {
+                return await work();
+            } finally {
+                release();
+            }
+        },
+        get active() {
+            return active;
+        }
+    };
+}


### PR DESCRIPTION
The cause of the acquire-waits on quark, found from its own logs rather than assumed.

## What the 9-hour log showed

Every burst of pool waits was one browser opening a page:

| Second | Requests fired at once |
|---|---|
| 16:14:10 | **29** recording-clip probes |
| 16:14:16 | **20** `species/{name}/info` + 15 thumbnails + list calls |
| 08:52:28 | 15 thumbnails + 5 clips + list calls |

Against a pool of five, each burst produced roughly fifteen waits of 300 to 650 ms. The queries involved take 1 to 2 ms on real data; the "slow holds" of 1.3 s are connections sitting checked out while the loop services forty other requests. Not ingest, not the dawn rush.

## Sources

- `Dashboard.svelte` runs `fullVisitStore.ensureAvailability` for every visit on screen in one `$effect`; each is a HEAD probe of the clip, and each takes a pooled connection server-side for its access check.
- Species rows each call `fetchSpeciesInfo`; `Species.svelte` already had its own three-slot gate, other callers did not.

## Fix, at the right altitude

A small `createSlotGate(limit)` helper, and the two API functions wrapped with it at three in flight each. Every caller, present and future, is bounded without knowing about it; the per-page gate in `Species.svelte` becomes redundant but harmless. Work queues in order, and the slot is released when the work throws.

## Verification

- Gate: never exceeds the limit, admits in order, survives a throw, refuses a limit of zero.
- Each API function: eight concurrent calls start exactly three `apiFetch`es until one completes, then all eight finish.
- `npm test` 1004 passed across 183 files, `npm run check` 0/0, build clean.
- On quark the proof is passive: count "Slow DB pool acquire" per hour after deploy against the 31 in the previous nine hours. I cannot open the dashboard there myself.