### PR TITLE
Walk the media cache off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   filesystem with tens of thousands of cached files it is seconds to tens of seconds, once a minute,
   during which the API answered nothing at all: not the dashboard, not Settings, not even the fixed
   version string. It also explains why clearing the cache made the interface fast again and why it
-  slowed down as the cache refilled. The walk now runs on a worker thread, and one that takes more
-  than a second is logged with its duration, file count, and location so the next diagnostics
-  bundle carries the evidence.
+  slowed down as the cache refilled. The walk now runs on a worker thread, every request that
+  arrives while one is in progress shares it rather than starting another against the same disk,
+  and a walk that takes more than a second is logged with its duration, file count, and location so
+  the next diagnostics bundle carries the evidence.
 
 ## [2.19.3] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **Counting the media cache no longer stalls every other request
+  ([#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)).** The cache
+  statistics behind Settings, and behind the owner system checks that run once a minute on every
+  owner page, were gathered by reading the size and date of every cached file on the same thread
+  that answers requests. On a local disk that is milliseconds. On a slow or network-backed
+  filesystem with tens of thousands of cached files it is seconds to tens of seconds, once a minute,
+  during which the API answered nothing at all: not the dashboard, not Settings, not even the fixed
+  version string. It also explains why clearing the cache made the interface fast again and why it
+  slowed down as the cache refilled. The walk now runs on a worker thread, and one that takes more
+  than a second is logged with its duration, file count, and location so the next diagnostics
+  bundle carries the evidence.
+
 ## [2.19.3] - 2026-09-04
 
 ### Added

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -2796,7 +2796,7 @@ async def get_analysis_status(response: Response, auth: AuthContext = Depends(re
 @router.get("/cache/stats", response_model=CacheStatsResponse)
 async def get_cache_stats(auth: AuthContext = Depends(require_owner)):
     """Get media cache statistics. Owner only."""
-    stats = media_cache.get_cache_stats()
+    stats = await media_cache.get_cache_stats_off_loop()
 
     # Add retention info
     retention = settings.media_cache.retention_days

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -2796,7 +2796,7 @@ async def get_analysis_status(response: Response, auth: AuthContext = Depends(re
 @router.get("/cache/stats", response_model=CacheStatsResponse)
 async def get_cache_stats(auth: AuthContext = Depends(require_owner)):
     """Get media cache statistics. Owner only."""
-    stats = await media_cache.get_cache_stats_off_loop()
+    stats = await media_cache.get_cache_stats()
 
     # Add retention info
     retention = settings.media_cache.retention_days

--- a/backend/app/services/media_cache.py
+++ b/backend/app/services/media_cache.py
@@ -26,7 +26,7 @@ PREVIEWS_DIR = CACHE_BASE_DIR / "previews"
 
 # A cache walk that takes longer than this is worth a log line, because on a
 # slow filesystem it is the difference between a stat per file and a stall.
-SLOW_CACHE_WALK_WARN_MS = float(os.getenv("MEDIA_CACHE_SLOW_WALK_WARN_MS", "1000"))
+SLOW_CACHE_WALK_WARN_MS = 1000.0
 
 # Frigate returns a ~78-byte stub body for clips whose recordings were not
 # retained (expired or never saved).  Any cached file smaller than this
@@ -81,6 +81,7 @@ class MediaCacheService:
         self._init_error: Optional[str] = None
         self._recording_clip_duration_cache: dict[str, tuple[int, int, Optional[float]]] = {}
         self._recording_clip_listeners: list[RecordingClipListener] = []
+        self._cache_stats_walk: Optional[tuple[asyncio.AbstractEventLoop, asyncio.Task[dict]]] = None
         self._recording_clip_commit_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
@@ -1140,7 +1141,7 @@ class MediaCacheService:
         log.info("Cleared all media cache", **stats)
         return stats
 
-    def get_cache_stats(self) -> dict:
+    def _get_cache_stats_sync(self) -> dict:
         """Get cache statistics.
 
         Returns:
@@ -1212,16 +1213,30 @@ class MediaCacheService:
             "newest_file": newest_file.isoformat() if newest_file else None,
         }
 
-    async def get_cache_stats_off_loop(self) -> dict:
-        """Walk the cache on a worker thread so the event loop keeps serving.
+    async def get_cache_stats(self) -> dict:
+        """Walk the cache on a worker thread, one walk at a time.
 
         The walk stats every cached file. On a local disk that is milliseconds;
         on a FUSE or network mount with tens of thousands of files it can be
-        tens of seconds, and it runs once a minute from the owner system checks.
-        Run inline, that stalled every other request for the duration.
+        tens of seconds, and the owner system checks ask for it once a minute
+        from every open owner page. Run inline it stalled every other request
+        for the duration. Run per request it would start one walk per tab and
+        per client retry against the same slow disk, so concurrent callers
+        share the walk already in flight, and a caller that gives up does not
+        cancel it for the others.
         """
+        loop = asyncio.get_running_loop()
+        in_flight = self._cache_stats_walk
+        if in_flight is None or in_flight[0] is not loop or in_flight[1].done():
+            walk = loop.create_task(self._walk_cache_stats_off_loop())
+            self._cache_stats_walk = (loop, walk)
+        else:
+            walk = in_flight[1]
+        return await asyncio.shield(walk)
+
+    async def _walk_cache_stats_off_loop(self) -> dict:
         started = time.perf_counter()
-        stats = await asyncio.to_thread(self.get_cache_stats)
+        stats = await asyncio.to_thread(self._get_cache_stats_sync)
         duration_ms = (time.perf_counter() - started) * 1000.0
         if duration_ms >= SLOW_CACHE_WALK_WARN_MS:
             log.warning(

--- a/backend/app/services/media_cache.py
+++ b/backend/app/services/media_cache.py
@@ -24,6 +24,10 @@ SNAPSHOTS_DIR = CACHE_BASE_DIR / "snapshots"
 CLIPS_DIR = CACHE_BASE_DIR / "clips"
 PREVIEWS_DIR = CACHE_BASE_DIR / "previews"
 
+# A cache walk that takes longer than this is worth a log line, because on a
+# slow filesystem it is the difference between a stat per file and a stall.
+SLOW_CACHE_WALK_WARN_MS = float(os.getenv("MEDIA_CACHE_SLOW_WALK_WARN_MS", "1000"))
+
 # Frigate returns a ~78-byte stub body for clips whose recordings were not
 # retained (expired or never saved).  Any cached file smaller than this
 # threshold is treated as a corrupt placeholder and is rejected at every
@@ -1207,6 +1211,26 @@ class MediaCacheService:
             "oldest_file": oldest_file.isoformat() if oldest_file else None,
             "newest_file": newest_file.isoformat() if newest_file else None,
         }
+
+    async def get_cache_stats_off_loop(self) -> dict:
+        """Walk the cache on a worker thread so the event loop keeps serving.
+
+        The walk stats every cached file. On a local disk that is milliseconds;
+        on a FUSE or network mount with tens of thousands of files it can be
+        tens of seconds, and it runs once a minute from the owner system checks.
+        Run inline, that stalled every other request for the duration.
+        """
+        started = time.perf_counter()
+        stats = await asyncio.to_thread(self.get_cache_stats)
+        duration_ms = (time.perf_counter() - started) * 1000.0
+        if duration_ms >= SLOW_CACHE_WALK_WARN_MS:
+            log.warning(
+                "Slow media cache walk",
+                duration_ms=round(duration_ms, 1),
+                files=stats["snapshot_count"] + stats["clip_count"] + stats["preview_count"],
+                cache_dir=str(CACHE_BASE_DIR),
+            )
+        return stats
 
     def get_status(self) -> dict:
         """Return cache availability and path diagnostics for startup logging."""

--- a/backend/tests/test_cache_stats_off_the_event_loop.py
+++ b/backend/tests/test_cache_stats_off_the_event_loop.py
@@ -1,0 +1,156 @@
+"""The media cache stats walk must never run on the event loop.
+
+`GET /api/cache/stats` stats every cached file. The owner system checks call it
+once a minute from every owner page, so on a slow filesystem an inline walk
+stalled the whole API for as long as the walk took (#300).
+"""
+
+import asyncio
+import threading
+import time
+
+import httpx
+import pytest
+import pytest_asyncio
+import structlog
+
+from app.auth import AuthContext, AuthLevel, require_owner
+from app.main import app
+from app.services import media_cache as media_cache_module
+
+
+def _service_with_cache(tmp_path, monkeypatch, *, snapshots: int = 0, clips: int = 0):
+    cache_base = tmp_path / "media_cache"
+    snapshots_dir = cache_base / "snapshots"
+    clips_dir = cache_base / "clips"
+    previews_dir = cache_base / "previews"
+    for directory in (snapshots_dir, clips_dir, previews_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+    for index in range(snapshots):
+        (snapshots_dir / f"evt_{index}.jpg").write_bytes(b"x" * 10)
+    for index in range(clips):
+        (clips_dir / f"evt_{index}.mp4").write_bytes(b"y" * 100)
+
+    monkeypatch.setattr(media_cache_module, "CACHE_BASE_DIR", cache_base)
+    monkeypatch.setattr(media_cache_module, "SNAPSHOTS_DIR", snapshots_dir)
+    monkeypatch.setattr(media_cache_module, "CLIPS_DIR", clips_dir)
+    monkeypatch.setattr(media_cache_module, "PREVIEWS_DIR", previews_dir)
+    return media_cache_module.MediaCacheService()
+
+
+@pytest.mark.asyncio
+async def test_the_walk_runs_on_a_worker_thread_not_the_loop(tmp_path, monkeypatch):
+    service = _service_with_cache(tmp_path, monkeypatch, snapshots=3, clips=1)
+    walk_threads: list[int] = []
+    original_walk = service.get_cache_stats
+
+    def recording_walk():
+        walk_threads.append(threading.get_ident())
+        return original_walk()
+
+    monkeypatch.setattr(service, "get_cache_stats", recording_walk)
+
+    stats = await service.get_cache_stats_off_loop()
+
+    assert walk_threads, "the walk never ran"
+    assert walk_threads[0] != threading.get_ident(), "the walk ran on the event loop thread"
+    assert stats["snapshot_count"] == 3
+    assert stats["clip_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_the_loop_keeps_serving_while_a_slow_filesystem_is_walked(tmp_path, monkeypatch):
+    service = _service_with_cache(tmp_path, monkeypatch)
+
+    def slow_walk():
+        time.sleep(0.3)
+        return service.__class__.get_cache_stats(service)
+
+    monkeypatch.setattr(service, "get_cache_stats", slow_walk)
+
+    ticks = 0
+
+    async def tick_while_walking():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.02)
+
+    ticker = asyncio.create_task(tick_while_walking())
+    try:
+        await service.get_cache_stats_off_loop()
+    finally:
+        ticker.cancel()
+
+    assert ticks >= 5, f"the loop only ran {ticks} times during a 300ms walk; it was blocked"
+
+
+@pytest.mark.asyncio
+async def test_a_slow_walk_is_logged_with_its_size_and_location(tmp_path, monkeypatch):
+    service = _service_with_cache(tmp_path, monkeypatch, snapshots=2, clips=2)
+    monkeypatch.setattr(media_cache_module, "SLOW_CACHE_WALK_WARN_MS", 0.0)
+
+    with structlog.testing.capture_logs() as captured:
+        await service.get_cache_stats_off_loop()
+
+    slow = [entry for entry in captured if entry["event"] == "Slow media cache walk"]
+    assert len(slow) == 1
+    assert slow[0]["files"] == 4
+    assert slow[0]["cache_dir"] == str(tmp_path / "media_cache")
+    assert slow[0]["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_a_fast_walk_is_not_logged(tmp_path, monkeypatch):
+    service = _service_with_cache(tmp_path, monkeypatch, snapshots=1)
+    monkeypatch.setattr(media_cache_module, "SLOW_CACHE_WALK_WARN_MS", 60_000.0)
+
+    with structlog.testing.capture_logs() as captured:
+        await service.get_cache_stats_off_loop()
+
+    assert not [entry for entry in captured if entry["event"] == "Slow media cache walk"]
+
+
+@pytest_asyncio.fixture
+async def owner_client():
+    app.dependency_overrides[require_owner] = lambda: AuthContext(auth_level=AuthLevel.OWNER, username="owner")
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(require_owner, None)
+
+
+@pytest.mark.asyncio
+async def test_the_cache_stats_route_walks_off_the_loop(owner_client, monkeypatch):
+    from app.routers import settings as settings_router
+
+    loop_thread = threading.get_ident()
+    walk_threads: list[int] = []
+
+    def recording_walk():
+        walk_threads.append(threading.get_ident())
+        return {
+            "snapshot_count": 1,
+            "snapshot_size_bytes": 10,
+            "snapshot_size_mb": 0.0,
+            "clip_count": 0,
+            "clip_size_bytes": 0,
+            "clip_size_mb": 0.0,
+            "preview_count": 0,
+            "preview_size_bytes": 0,
+            "preview_size_mb": 0.0,
+            "total_size_bytes": 10,
+            "total_size_mb": 0.0,
+            "oldest_file": None,
+            "newest_file": None,
+        }
+
+    monkeypatch.setattr(settings_router.media_cache, "get_cache_stats", recording_walk)
+
+    response = await owner_client.get("/api/cache/stats")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["snapshot_count"] == 1
+    assert walk_threads and walk_threads[0] != loop_thread, "the route walked the cache on the event loop"

--- a/backend/tests/test_cache_stats_off_the_event_loop.py
+++ b/backend/tests/test_cache_stats_off_the_event_loop.py
@@ -2,7 +2,9 @@
 
 `GET /api/cache/stats` stats every cached file. The owner system checks call it
 once a minute from every owner page, so on a slow filesystem an inline walk
-stalled the whole API for as long as the walk took (#300).
+stalled the whole API for as long as the walk took (#300). Off the loop, the
+walks must not multiply either: every open owner page and every client retry
+would otherwise start its own walk against the same slow disk.
 """
 
 import asyncio
@@ -38,19 +40,26 @@ def _service_with_cache(tmp_path, monkeypatch, *, snapshots: int = 0, clips: int
     return media_cache_module.MediaCacheService()
 
 
+def _slow_walk_counting_calls(service, seconds: float):
+    """Replace the sync walk with one that sleeps first and counts how often it ran."""
+    calls: list[int] = []
+    real_walk = service._get_cache_stats_sync
+
+    def slow_walk():
+        calls.append(threading.get_ident())
+        time.sleep(seconds)
+        return real_walk()
+
+    service._get_cache_stats_sync = slow_walk
+    return calls
+
+
 @pytest.mark.asyncio
 async def test_the_walk_runs_on_a_worker_thread_not_the_loop(tmp_path, monkeypatch):
     service = _service_with_cache(tmp_path, monkeypatch, snapshots=3, clips=1)
-    walk_threads: list[int] = []
-    original_walk = service.get_cache_stats
+    walk_threads = _slow_walk_counting_calls(service, 0.0)
 
-    def recording_walk():
-        walk_threads.append(threading.get_ident())
-        return original_walk()
-
-    monkeypatch.setattr(service, "get_cache_stats", recording_walk)
-
-    stats = await service.get_cache_stats_off_loop()
+    stats = await service.get_cache_stats()
 
     assert walk_threads, "the walk never ran"
     assert walk_threads[0] != threading.get_ident(), "the walk ran on the event loop thread"
@@ -61,12 +70,7 @@ async def test_the_walk_runs_on_a_worker_thread_not_the_loop(tmp_path, monkeypat
 @pytest.mark.asyncio
 async def test_the_loop_keeps_serving_while_a_slow_filesystem_is_walked(tmp_path, monkeypatch):
     service = _service_with_cache(tmp_path, monkeypatch)
-
-    def slow_walk():
-        time.sleep(0.3)
-        return service.__class__.get_cache_stats(service)
-
-    monkeypatch.setattr(service, "get_cache_stats", slow_walk)
+    _slow_walk_counting_calls(service, 0.3)
 
     ticks = 0
 
@@ -78,11 +82,53 @@ async def test_the_loop_keeps_serving_while_a_slow_filesystem_is_walked(tmp_path
 
     ticker = asyncio.create_task(tick_while_walking())
     try:
-        await service.get_cache_stats_off_loop()
+        await service.get_cache_stats()
     finally:
         ticker.cancel()
 
     assert ticks >= 5, f"the loop only ran {ticks} times during a 300ms walk; it was blocked"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_share_one_walk(tmp_path, monkeypatch):
+    service = _service_with_cache(tmp_path, monkeypatch, snapshots=2)
+    calls = _slow_walk_counting_calls(service, 0.2)
+
+    results = await asyncio.gather(*(service.get_cache_stats() for _ in range(6)))
+
+    assert len(calls) == 1, f"six concurrent requests started {len(calls)} walks"
+    assert all(r["snapshot_count"] == 2 for r in results)
+
+
+@pytest.mark.asyncio
+async def test_a_later_caller_gets_a_fresh_walk_once_the_first_has_finished(tmp_path, monkeypatch):
+    service = _service_with_cache(tmp_path, monkeypatch, snapshots=1)
+    calls = _slow_walk_counting_calls(service, 0.0)
+
+    await service.get_cache_stats()
+    (media_cache_module.SNAPSHOTS_DIR / "evt_new.jpg").write_bytes(b"z")
+    later = await service.get_cache_stats()
+
+    assert len(calls) == 2, "a finished walk must not be served as if it were still current"
+    assert later["snapshot_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_a_caller_that_gives_up_does_not_cancel_the_walk_for_others(tmp_path, monkeypatch):
+    service = _service_with_cache(tmp_path, monkeypatch, snapshots=1)
+    calls = _slow_walk_counting_calls(service, 0.3)
+
+    impatient = asyncio.create_task(service.get_cache_stats())
+    patient = asyncio.create_task(service.get_cache_stats())
+    await asyncio.sleep(0.05)
+    impatient.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await impatient
+
+    stats = await patient
+
+    assert stats["snapshot_count"] == 1
+    assert len(calls) == 1, "the patient caller should have finished on the shared walk, not started another"
 
 
 @pytest.mark.asyncio
@@ -91,7 +137,7 @@ async def test_a_slow_walk_is_logged_with_its_size_and_location(tmp_path, monkey
     monkeypatch.setattr(media_cache_module, "SLOW_CACHE_WALK_WARN_MS", 0.0)
 
     with structlog.testing.capture_logs() as captured:
-        await service.get_cache_stats_off_loop()
+        await service.get_cache_stats()
 
     slow = [entry for entry in captured if entry["event"] == "Slow media cache walk"]
     assert len(slow) == 1
@@ -106,7 +152,7 @@ async def test_a_fast_walk_is_not_logged(tmp_path, monkeypatch):
     monkeypatch.setattr(media_cache_module, "SLOW_CACHE_WALK_WARN_MS", 60_000.0)
 
     with structlog.testing.capture_logs() as captured:
-        await service.get_cache_stats_off_loop()
+        await service.get_cache_stats()
 
     assert not [entry for entry in captured if entry["event"] == "Slow media cache walk"]
 
@@ -147,7 +193,7 @@ async def test_the_cache_stats_route_walks_off_the_loop(owner_client, monkeypatc
             "newest_file": None,
         }
 
-    monkeypatch.setattr(settings_router.media_cache, "get_cache_stats", recording_walk)
+    monkeypatch.setattr(settings_router.media_cache, "_get_cache_stats_sync", recording_walk)
 
     response = await owner_client.get("/api/cache/stats")
 


### PR DESCRIPTION
## Outcome

Opening Settings, or leaving any owner page open, no longer stalls the whole API for the length of a media cache directory walk. On a slow or network-backed filesystem with tens of thousands of cached files that walk was seconds to tens of seconds, once a minute, and every request waited behind it.

## Scope

- **Included:** `GET /api/cache/stats` gathers its numbers on a worker thread, following the file's existing `async` / `_sync` pattern used by the cleanup walks. Requests that arrive while a walk is in progress share it instead of starting another against the same disk, and a caller that gives up does not cancel it for the rest. A walk over a second is logged with duration, file count and cache location. Tests prove the walk leaves the loop, the loop keeps serving during a slow walk, six concurrent callers start one walk, a finished walk is not served stale, a cancelled caller does not cancel the shared walk, the route uses the off-loop path, and the slow-walk log fires only when it should.
- **Explicitly excluded:** how often the owner system checks call the route (once a minute), and the undercount of `.meta.json` sidecars in the reported sizes. Both are separate decisions and are recorded in `ISSUES.md` on #402.
- **Issue or roadmap outcome:** #300. The reporter's bundles show 168 client-side timeouts on this exact request, hold labels on handlers that do nothing slow themselves, and a fixed-string route stalling, which is the signature of a blocked loop rather than a starved pool. Clearing the cache made it fast; the cache refilling made it slow again.

## Verification

```text
backend$ pytest tests/test_cache_stats_off_the_event_loop.py tests/test_media_cache.py tests/test_code_quality_architecture.py
40 passed

backend$ pytest
2704 passed, 49 skipped in 58.16s

$ ruff check . && ruff format --check .
All checks passed!
519 files already formatted
```

Reference install (XFS, 14,080 matching files): the same walk measures 70 to 94 ms, so this change is invisible there and matters on the filesystems where the reporter is.

## Data integrity and risk

- Detection-history or configuration risk: none. Read-only directory walk, no database access.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none. The log line carries a path and counts, no media or names.
- Deployment verification, if deployed: not yet deployed. Images are built from `dev` only, so verification on the reference install follows the merge.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.
