### PR TITLE
Let the Home Assistant sidebar survive a reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The Home Assistant sidebar survives a settings change.** Every change to the integration's
+  options reloads it, and the reload left the sidebar pointing at the old YA-WAMF address with the
+  old credentials: the panel could not be removed because the removal was awaited when Home
+  Assistant expects a plain call, the proxy view could not be replaced because views cannot be
+  unregistered, and the stale proxy kept using a login token that nothing was refreshing any more,
+  so the sidebar worked for a while and then answered with sign-in errors until Home Assistant was
+  restarted. The view is now registered once per run and reads the live connection on every
+  request, the panel is replaced rather than re-added, the proxy refreshes its login before
+  forwarding, and the seven unauthenticated root paths the integration used to claim on the Home
+  Assistant origin are gone. In the same pass: a rejected credential now opens Home Assistant's
+  reconfigure prompt instead of failing silently every poll; the Last Bird sensor goes unavailable
+  when YA-WAMF cannot be reached instead of holding its last value; the snapshot camera keeps one
+  frame per detection instead of downloading and scaling the same image on every dashboard refresh;
+  every request the integration makes carries a timeout; and the manifest declares the frontend and
+  http dependencies it always relied on. The integration version is 1.1.0.
+
 - **Counting the media cache no longer stalls every other request
   ([#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300)).** The cache
   statistics behind Settings, and behind the owner system checks that run once a minute on every

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -501,6 +501,47 @@ Ollama is unavailable.
 CSV export (eBird format) is shipped. Add a first-class, safe full-database backup and restore
 flow so users can snapshot and recover their detection history and config.
 
+#### Home Assistant integration: survive a reload 🔁
+**Priority:** P1 | **Effort:** S | **Status:** ✅ Shipped in `dev`; move to Delivered at the next release
+
+A review of `custom_components/yawamf` on 2026-09-07 (verified against Home Assistant core `dev`)
+found that the sidebar proxy does not survive an integration reload, which is what every options
+change triggers:
+
+- `async_unregister_ingress_panel` awaits `frontend.async_remove_panel`, but that is a synchronous
+  `@callback` returning `None`. The `await` raises `TypeError`, the bare `except` swallows it at
+  debug level, and the panel is never removed. The next setup then logs "Overwriting panel yawamf"
+  as an exception and the panel keeps the **old** ingress token URL.
+- `async_register_ingress` calls `hass.http.register_view` on every setup. Views cannot be
+  unregistered and aiohttp answers with the first-registered route, so after a reload the old
+  `YAWAMFIngressView` (old token, old URL, old credentials) keeps serving until Home Assistant
+  restarts. Changing the URL or credentials in the options flow silently does nothing for the
+  sidebar. Worse, the old view holds the unloaded coordinator, which has stopped polling and so
+  stops refreshing its login token; the sidebar keeps working only until that token expires, then
+  answers with 401s until Home Assistant restarts.
+- `YAWAMFIngressAssetView` registers unauthenticated views at Home Assistant's root
+  (`/favicon.ico`, `/manifest.json`, …). The files are public on YA-WAMF anyway, so nothing secret
+  leaks; the cost is that the integration squats root paths on the Home Assistant origin, and
+  `/manifest.json` is already owned by HA's frontend so that one is dead. The SPA resolves assets
+  through `window.__YAWAMF_APP_BASE_PATH`, so they are not needed.
+
+Smaller gaps found in the same pass: the Last Bird sensor skips the state write when the event id
+is unchanged, so it never becomes `unavailable` when the coordinator fails; the camera entity
+re-downloads and re-scales the full snapshot on every image request with no per-event cache and no
+timeout; the config flow validates with no request timeout; a 401/403 raises `UpdateFailed` instead
+of `ConfigEntryAuthFailed` (no reauth flow); `manifest.json` lacks `dependencies: ["http",
+"frontend"]` and an `integration_type`; and `docs/integrations/home-assistant.md` still describes
+the count sensor as "since midnight" when it is a rolling 24-hour window.
+
+**Acceptance (met):** the ingress view is registered once per HA run and reads the live coordinator
+and token from `hass.data`; the panel is removed with a plain call and re-registered with
+`update=True`; an options change to URL or credentials takes effect in the sidebar without
+restarting HA and logs no exception; the root asset views are gone; the proxy refreshes the login
+before forwarding; the sensor writes state on availability changes; the camera caches per
+`frigate_event` and times out; the config flow times out; auth failures start reauth; the manifest
+declares its dependencies; the doc matches the sensor; and
+`backend/tests/test_home_assistant_sensor.py` covers the reload path, reauth, and the camera cache.
+
 #### Home Assistant OS add-on 🏠
 **Priority:** P3 | **Effort:** M | **Status:** ☐ Proposed ([#49](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/49))
 

--- a/backend/tests/test_home_assistant_sensor.py
+++ b/backend/tests/test_home_assistant_sensor.py
@@ -25,15 +25,25 @@ def _install_common_test_modules():
         "custom_components.yawamf.const",
         "custom_components.yawamf.coordinator",
         "custom_components.yawamf.sensor",
+        "custom_components.yawamf.camera",
+        "custom_components.yawamf.ingress",
+        "custom_components.yawamf.config_flow",
         "homeassistant",
         "homeassistant.components",
         "homeassistant.components.sensor",
+        "homeassistant.components.camera",
+        "homeassistant.components.http",
+        "homeassistant.components.frontend",
         "homeassistant.config_entries",
         "homeassistant.core",
+        "homeassistant.data_entry_flow",
+        "homeassistant.exceptions",
         "homeassistant.helpers",
+        "homeassistant.helpers.aiohttp_client",
         "homeassistant.helpers.device_registry",
         "homeassistant.helpers.entity_platform",
         "homeassistant.helpers.update_coordinator",
+        "voluptuous",
     ]:
         sys.modules.pop(name, None)
 
@@ -92,6 +102,18 @@ def _install_common_test_modules():
     core_mod.callback = lambda func: func
     sys.modules["homeassistant.core"] = core_mod
 
+    exceptions_mod = types.ModuleType("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        pass
+
+    class ConfigEntryAuthFailed(HomeAssistantError):
+        pass
+
+    exceptions_mod.HomeAssistantError = HomeAssistantError
+    exceptions_mod.ConfigEntryAuthFailed = ConfigEntryAuthFailed
+    sys.modules["homeassistant.exceptions"] = exceptions_mod
+
     device_registry_mod = types.ModuleType("homeassistant.helpers.device_registry")
 
     class DeviceInfo(dict):
@@ -113,6 +135,10 @@ def _install_common_test_modules():
 
         def __init__(self, coordinator):
             self.coordinator = coordinator
+
+        @property
+        def available(self):
+            return getattr(self.coordinator, "last_update_success", True)
 
     class DataUpdateCoordinator:
         def __class_getitem__(cls, _item):
@@ -202,7 +228,12 @@ def _load_coordinator_and_sensor_modules():
             )
             if data is not None and "Content-Type" not in req.headers:
                 req.add_header("Content-Type", "application/json")
-            response = request.urlopen(req, timeout=5)
+            from urllib.error import HTTPError
+
+            try:
+                response = request.urlopen(req, timeout=5)
+            except HTTPError as http_error:
+                response = http_error
             body = response.read()
             payload = json.loads(body.decode("utf-8")) if body else None
             response.close()
@@ -261,8 +292,15 @@ def _load_ingress_module():
     aiohttp_web_mod = types.ModuleType("aiohttp.web")
     aiohttp_web_mod.StreamResponse = object
     aiohttp_web_mod.Request = object
-    aiohttp_web_mod.HTTPBadGateway = RuntimeError
-    aiohttp_web_mod.HTTPUnauthorized = RuntimeError
+
+    class _HTTPException(Exception):
+        def __init__(self, *args, text=None, **kwargs):
+            super().__init__(text or self.__class__.__name__)
+            self.text = text
+
+    aiohttp_web_mod.HTTPBadGateway = type("HTTPBadGateway", (_HTTPException,), {})
+    aiohttp_web_mod.HTTPUnauthorized = type("HTTPUnauthorized", (_HTTPException,), {})
+    aiohttp_web_mod.HTTPNotFound = type("HTTPNotFound", (_HTTPException,), {})
     sys.modules["aiohttp.web"] = aiohttp_web_mod
     sys.modules["aiohttp"].web = aiohttp_web_mod
 
@@ -289,11 +327,147 @@ def _load_ingress_module():
     return module
 
 
+def _load_camera_module():
+    _install_common_test_modules()
+
+    camera_mod = types.ModuleType("homeassistant.components.camera")
+
+    class Camera:
+        def __init__(self):
+            pass
+
+    camera_mod.Camera = Camera
+    sys.modules["homeassistant.components.camera"] = camera_mod
+
+    coordinator_mod = types.ModuleType("custom_components.yawamf.coordinator")
+    coordinator_mod.YAWAMFDataUpdateCoordinator = object
+    sys.modules["custom_components.yawamf.coordinator"] = coordinator_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.yawamf.camera",
+        PACKAGE_DIR / "camera.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["custom_components.yawamf.camera"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_config_flow_module(session):
+    """Load config_flow.py against stubs; ``session`` is what async_get_clientsession returns."""
+    _install_common_test_modules()
+
+    vol = types.ModuleType("voluptuous")
+    vol.Schema = lambda schema: schema
+    vol.Required = lambda key, default=None: key
+    vol.Optional = lambda key, default=None: key
+    vol.All = lambda *validators: validators
+    vol.Coerce = lambda kind: kind
+    vol.Range = lambda min=None, max=None: (min, max)
+    sys.modules["voluptuous"] = vol
+
+    config_entries_mod = sys.modules["homeassistant.config_entries"]
+
+    class ConfigFlow:
+        def __init_subclass__(cls, **kwargs):
+            pass
+
+        def __init__(self):
+            self.context = {}
+            self.forms = []
+            self.aborts = []
+
+        def async_show_form(self, *, step_id, data_schema, errors=None):
+            self.forms.append({"step_id": step_id, "errors": errors or {}})
+            return {"type": "form", "step_id": step_id, "errors": errors or {}}
+
+        def async_abort(self, *, reason):
+            self.aborts.append(reason)
+            return {"type": "abort", "reason": reason}
+
+    class OptionsFlow:
+        pass
+
+    config_entries_mod.ConfigFlow = ConfigFlow
+    config_entries_mod.OptionsFlow = OptionsFlow
+
+    data_entry_flow_mod = types.ModuleType("homeassistant.data_entry_flow")
+    data_entry_flow_mod.FlowResult = dict
+    sys.modules["homeassistant.data_entry_flow"] = data_entry_flow_mod
+
+    aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    aiohttp_client_mod.async_get_clientsession = lambda hass: session
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.yawamf.config_flow",
+        PACKAGE_DIR / "config_flow.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["custom_components.yawamf.config_flow"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _RecordingSession:
+    """A fake aiohttp session that answers from a table and records every request."""
+
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = []
+
+    def _request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        status, payload = self._responses.get((method, url.split("?")[0].rsplit("/", 1)[-1]), (404, None))
+        response = types.SimpleNamespace(
+            status=status,
+            raise_for_status=lambda: None if status < 400 else (_ for _ in ()).throw(RuntimeError(status)),
+        )
+
+        async def _json():
+            return payload
+
+        async def _read():
+            return payload if isinstance(payload, bytes) else b""
+
+        response.json = _json
+        response.read = _read
+
+        class _Context:
+            async def __aenter__(self_inner):
+                return response
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return False
+
+        return _Context()
+
+    def get(self, url, **kwargs):
+        return self._request("GET", url, **kwargs)
+
+    def post(self, url, **kwargs):
+        return self._request("POST", url, **kwargs)
+
+    def request(self, method, url, **kwargs):
+        return self._request(method, url, **kwargs)
+
+
 class _JsonHandler(BaseHTTPRequestHandler):
     routes = {}
 
     def do_GET(self):
-        handler = self.routes.get(("GET", self.path))
+        self._answer("GET")
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+        self._answer("POST")
+
+    def _answer(self, method):
+        handler = self.routes.get((method, self.path))
         if handler is None:
             self.send_response(404)
             self.end_headers()
@@ -553,69 +727,6 @@ def test_sensors_handle_string_total_count():
     assert value is None or isinstance(value, int)
 
 
-@pytest.mark.asyncio
-async def test_ingress_registers_sidebar_panel_with_home_assistant_panel_api():
-    ingress_module = _load_ingress_module()
-    ingress_module.secrets.token_urlsafe = lambda _length: "test-token"
-    registered_panels: list[dict] = []
-
-    frontend_mod = types.ModuleType("homeassistant.components.frontend")
-
-    def async_register_built_in_panel(
-        hass,
-        *,
-        component_name,
-        frontend_url_path,
-        sidebar_title,
-        sidebar_icon,
-        config,
-        require_admin,
-    ):
-        registered_panels.append(
-            {
-                "component_name": component_name,
-                "frontend_url_path": frontend_url_path,
-                "sidebar_title": sidebar_title,
-                "sidebar_icon": sidebar_icon,
-                "config": config,
-                "require_admin": require_admin,
-            }
-        )
-
-    frontend_mod.async_register_built_in_panel = async_register_built_in_panel
-    sys.modules["homeassistant.components.frontend"] = frontend_mod
-    sys.modules["homeassistant.components"].frontend = frontend_mod
-
-    registered_views = []
-    hass = types.SimpleNamespace(
-        http=types.SimpleNamespace(register_view=registered_views.append),
-    )
-    coordinator = types.SimpleNamespace(url="http://yawamf.local", headers={}, session=None)
-
-    await ingress_module.async_register_ingress(hass, coordinator)
-
-    assert [view.url for view in registered_views] == [
-        "/api/yawamf/ingress/{path:.*}",
-        "/favicon.ico",
-        "/favicon.png",
-        "/apple-touch-icon.png",
-        "/manifest.json",
-        "/pwa-192x192.png",
-        "/pwa-512x512.png",
-        "/frigate-logo.png",
-    ]
-    assert registered_panels == [
-        {
-            "component_name": "iframe",
-            "frontend_url_path": "yawamf",
-            "sidebar_title": "YA-WAMF",
-            "sidebar_icon": "mdi:bird",
-            "config": {"url": "/api/yawamf/ingress/?auth=test-token"},
-            "require_admin": False,
-        }
-    ]
-
-
 def test_ingress_rewrites_runtime_icon_assets_and_manifest_paths():
     ingress_module = _load_ingress_module()
 
@@ -648,3 +759,504 @@ def test_ingress_rewrite_does_not_duplicate_app_base_marker():
     rewritten = ingress_module._rewrite_root_paths(body)
 
     assert rewritten.count("__YAWAMF_APP_BASE_PATH") == 1
+
+
+# ---------------------------------------------------------------------------
+# Sidebar proxy survives a reload
+# ---------------------------------------------------------------------------
+
+
+def _frontend_stub():
+    """A frontend module whose panel calls record what they were given.
+
+    ``async_remove_panel`` is a plain function here, as it is in core, so a
+    caller that awaits it gets a TypeError just as it would in Home Assistant.
+    """
+    frontend_mod = types.ModuleType("homeassistant.components.frontend")
+    frontend_mod.registered = []
+    frontend_mod.removed = []
+
+    def async_register_built_in_panel(hass, **kwargs):
+        if kwargs["frontend_url_path"] in {p["frontend_url_path"] for p in frontend_mod.registered} and not kwargs.get(
+            "update"
+        ):
+            raise ValueError(f"Overwriting panel {kwargs['frontend_url_path']}")
+        frontend_mod.registered.append(kwargs)
+
+    def async_remove_panel(hass, frontend_url_path, *, warn_if_unknown=True):
+        frontend_mod.removed.append(frontend_url_path)
+
+    frontend_mod.async_register_built_in_panel = async_register_built_in_panel
+    frontend_mod.async_remove_panel = async_remove_panel
+    sys.modules["homeassistant.components.frontend"] = frontend_mod
+    sys.modules["homeassistant.components"].frontend = frontend_mod
+    return frontend_mod
+
+
+def _hass_stub():
+    views = []
+    return types.SimpleNamespace(http=types.SimpleNamespace(register_view=views.append), data={}), views
+
+
+@pytest.mark.asyncio
+async def test_ingress_registers_the_view_once_and_follows_the_live_coordinator_across_a_reload():
+    ingress_module = _load_ingress_module()
+    ingress_module.secrets.token_urlsafe = lambda _length: "test-token"
+    frontend = _frontend_stub()
+    hass, views = _hass_stub()
+
+    first = types.SimpleNamespace(url="http://old.local", headers={}, session=None)
+    second = types.SimpleNamespace(url="http://new.local", headers={}, session=None)
+
+    await ingress_module.async_register_ingress(hass, first)
+    await ingress_module.async_register_ingress(hass, second)
+
+    assert [view.url for view in views] == ["/api/yawamf/ingress/{path:.*}"], "the view must be registered once per run"
+    assert views[0].runtime.coordinator is second, "the proxy must read the coordinator from the latest setup"
+    assert [panel["config"] for panel in frontend.registered] == [
+        {"url": "/api/yawamf/ingress/?auth=test-token"},
+        {"url": "/api/yawamf/ingress/?auth=test-token"},
+    ]
+    assert all(panel["update"] is True for panel in frontend.registered)
+    assert all(panel["require_admin"] is False for panel in frontend.registered)
+
+
+@pytest.mark.asyncio
+async def test_ingress_unregister_removes_the_panel_with_a_plain_call_and_the_proxy_refuses_afterwards():
+    ingress_module = _load_ingress_module()
+    frontend = _frontend_stub()
+    hass, views = _hass_stub()
+    coordinator = types.SimpleNamespace(url="http://yawamf.local", headers={}, session=None)
+
+    await ingress_module.async_register_ingress(hass, coordinator)
+    ingress_module.async_unregister_ingress(hass)
+
+    assert frontend.removed == ["yawamf"]
+    assert views[0].runtime.coordinator is None
+    request = types.SimpleNamespace(query={"auth": views[0].runtime.token}, cookies={}, headers={}, method="GET")
+    with pytest.raises(ingress_module.web.HTTPNotFound):
+        await views[0]._proxy(request, "")
+
+
+@pytest.mark.asyncio
+async def test_ingress_keeps_its_token_across_a_reload_so_an_open_browser_keeps_working():
+    ingress_module = _load_ingress_module()
+    _frontend_stub()
+    hass, views = _hass_stub()
+
+    await ingress_module.async_register_ingress(hass, types.SimpleNamespace(url="http://a", headers={}, session=None))
+    token_before = views[0].runtime.token
+    ingress_module.async_unregister_ingress(hass)
+    await ingress_module.async_register_ingress(hass, types.SimpleNamespace(url="http://b", headers={}, session=None))
+
+    assert views[0].runtime.token == token_before
+
+
+@pytest.mark.asyncio
+async def test_ingress_unregister_is_harmless_when_nothing_was_registered():
+    ingress_module = _load_ingress_module()
+    frontend = _frontend_stub()
+    hass, _views = _hass_stub()
+
+    ingress_module.async_unregister_ingress(hass)
+
+    assert frontend.removed == []
+
+
+@pytest.mark.asyncio
+async def test_ingress_proxy_refreshes_the_login_before_forwarding():
+    ingress_module = _load_ingress_module()
+    _frontend_stub()
+    hass, views = _hass_stub()
+    order = []
+
+    class _Coordinator:
+        url = "http://yawamf.local"
+        headers = {"Authorization": "Bearer fresh"}
+
+        async def async_ensure_logged_in(self):
+            order.append("login")
+
+        class session:
+            @staticmethod
+            def request(method, url, **kwargs):
+                order.append(("forward", url, kwargs["headers"].get("Authorization")))
+                raise RuntimeError("stop here; the response path needs a real aiohttp")
+
+    await ingress_module.async_register_ingress(hass, _Coordinator())
+    request = types.SimpleNamespace(
+        query={"auth": views[0].runtime.token}, cookies={}, headers={"Host": "ha.local"}, method="GET"
+    )
+
+    with pytest.raises(ingress_module.web.HTTPBadGateway):
+        await views[0]._proxy(request, "api/version")
+
+    assert order == ["login", ("forward", "http://yawamf.local/api/version", "Bearer fresh")]
+
+
+@pytest.mark.asyncio
+async def test_ingress_proxy_answers_502_without_a_stack_trace_when_the_login_is_rejected():
+    ingress_module = _load_ingress_module()
+    _frontend_stub()
+    hass, views = _hass_stub()
+    auth_failed = sys.modules["homeassistant.exceptions"].ConfigEntryAuthFailed
+
+    class _Coordinator:
+        url = "http://yawamf.local"
+        headers = {}
+        session = None
+
+        async def async_ensure_logged_in(self):
+            raise auth_failed("nope")
+
+    await ingress_module.async_register_ingress(hass, _Coordinator())
+    request = types.SimpleNamespace(query={"auth": views[0].runtime.token}, cookies={}, headers={}, method="GET")
+
+    with pytest.raises(ingress_module.web.HTTPBadGateway) as raised:
+        await views[0]._proxy(request, "")
+
+    assert "reconfigure the integration" in raised.value.text
+
+
+@pytest.mark.asyncio
+async def test_ingress_proxy_rejects_a_request_without_the_token():
+    ingress_module = _load_ingress_module()
+    _frontend_stub()
+    hass, views = _hass_stub()
+    await ingress_module.async_register_ingress(
+        hass, types.SimpleNamespace(url="http://yawamf.local", headers={}, session=None)
+    )
+    request = types.SimpleNamespace(query={}, cookies={"yawamf_ingress_token": "stale"}, headers={}, method="GET")
+
+    with pytest.raises(ingress_module.web.HTTPUnauthorized):
+        await views[0]._proxy(request, "")
+
+
+@pytest.mark.asyncio
+async def test_unloading_one_of_two_sidebar_entries_points_the_proxy_at_the_survivor():
+    _install_common_test_modules()
+    ingress_module = _load_ingress_module()
+    frontend = _frontend_stub()
+    hass, views = _hass_stub()
+    hass.config_entries = types.SimpleNamespace(async_unload_platforms=_async_true)
+
+    init_spec = importlib.util.spec_from_file_location("custom_components.yawamf", PACKAGE_DIR / "__init__.py")
+    sys.modules["homeassistant.const"] = types.SimpleNamespace(
+        Platform=types.SimpleNamespace(SENSOR="sensor", CAMERA="camera")
+    )
+    sys.modules["homeassistant.helpers.aiohttp_client"] = types.SimpleNamespace(
+        async_get_clientsession=lambda hass: None
+    )
+    init_module = importlib.util.module_from_spec(init_spec)
+    assert init_spec.loader is not None
+    init_spec.loader.exec_module(init_module)
+
+    first = types.SimpleNamespace(url="http://first", headers={}, session=None)
+    second = types.SimpleNamespace(url="http://second", headers={}, session=None)
+    hass.data[ingress_module.DOMAIN] = {"a": first, "b": second, "_ingress_entries": {"a", "b"}}
+    await ingress_module.async_register_ingress(hass, first)
+    await ingress_module.async_register_ingress(hass, second)
+
+    assert await init_module.async_unload_entry(hass, types.SimpleNamespace(entry_id="b")) is True
+
+    assert views[0].runtime.coordinator is first, "the proxy must follow the entry that still wants the sidebar"
+    assert frontend.removed == [], "the panel stays while another entry still wants it"
+
+    assert await init_module.async_unload_entry(hass, types.SimpleNamespace(entry_id="a")) is True
+
+    assert views[0].runtime.coordinator is None
+    assert frontend.removed == ["yawamf"]
+
+
+async def _async_true(*_args, **_kwargs):
+    return True
+
+
+def test_ingress_no_longer_squats_root_asset_paths():
+    ingress_module = _load_ingress_module()
+
+    assert not hasattr(ingress_module, "YAWAMFIngressAssetView")
+    assert not hasattr(ingress_module, "_PUBLIC_ASSET_PATHS")
+
+
+# ---------------------------------------------------------------------------
+# Sensor availability
+# ---------------------------------------------------------------------------
+
+
+def test_last_bird_sensor_writes_state_when_the_coordinator_stops_reaching_yawamf():
+    sensor_module = _load_sensor_module()
+    coordinator = _Coordinator(
+        {
+            "display_name": "Northern Cardinal",
+            "frigate_event": "evt-1",
+            "detection_time": "2026-04-01T10:15:00Z",
+            "camera_name": "front",
+        }
+    )
+    coordinator.last_update_success = True
+    sensor = sensor_module.YAWAMFLastBirdSensor(coordinator)
+
+    sensor._handle_coordinator_update()
+    sensor._handle_coordinator_update()
+    coordinator.last_update_success = False
+    sensor._handle_coordinator_update()
+    sensor._handle_coordinator_update()
+    coordinator.last_update_success = True
+    sensor._handle_coordinator_update()
+
+    assert sensor._write_count == 3, "one write per change: first seen, went unavailable, came back"
+
+
+# ---------------------------------------------------------------------------
+# Coordinator authentication failures start reauth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coordinator_raises_auth_failed_when_yawamf_answers_401():
+    coordinator_module, _sensor_module = _load_coordinator_and_sensor_modules()
+    auth_failed = sys.modules["homeassistant.exceptions"].ConfigEntryAuthFailed
+
+    with _JsonServer({("GET", "/api/stats/daily-summary"): lambda: (401, {"detail": "no"})}) as base_url:
+        session = sys.modules["aiohttp"].ClientSession()
+        coordinator = coordinator_module.YAWAMFDataUpdateCoordinator(
+            hass=object(),
+            logger=logging.getLogger("yawamf-test"),
+            config_entry=types.SimpleNamespace(entry_id="entry-1"),
+            session=session,
+            url=base_url,
+            username=None,
+            password=None,
+            api_key="stale-key",
+            update_interval=coordinator_module.timedelta(seconds=30),
+        )
+
+        with pytest.raises(auth_failed):
+            await coordinator.async_config_entry_first_refresh()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_raises_auth_failed_when_the_login_is_rejected():
+    coordinator_module, _sensor_module = _load_coordinator_and_sensor_modules()
+    auth_failed = sys.modules["homeassistant.exceptions"].ConfigEntryAuthFailed
+    routes = {
+        ("POST", "/api/auth/login"): lambda: (401, {"detail": "bad password"}),
+        ("GET", "/api/stats/daily-summary"): lambda: (200, {"total_count": 0}),
+    }
+
+    with _JsonServer(routes) as base_url:
+        session = sys.modules["aiohttp"].ClientSession()
+        coordinator = coordinator_module.YAWAMFDataUpdateCoordinator(
+            hass=object(),
+            logger=logging.getLogger("yawamf-test"),
+            config_entry=types.SimpleNamespace(entry_id="entry-1"),
+            session=session,
+            url=base_url,
+            username="owner",
+            password="wrong",
+            api_key=None,
+            update_interval=coordinator_module.timedelta(seconds=30),
+        )
+
+        with pytest.raises(auth_failed):
+            await coordinator.async_config_entry_first_refresh()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_reports_a_plain_outage_as_update_failed_not_auth():
+    coordinator_module, _sensor_module = _load_coordinator_and_sensor_modules()
+    update_failed = sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed
+
+    with _JsonServer({("GET", "/api/stats/daily-summary"): lambda: (503, {"detail": "down"})}) as base_url:
+        session = sys.modules["aiohttp"].ClientSession()
+        coordinator = coordinator_module.YAWAMFDataUpdateCoordinator(
+            hass=object(),
+            logger=logging.getLogger("yawamf-test"),
+            config_entry=types.SimpleNamespace(entry_id="entry-1"),
+            session=session,
+            url=base_url,
+            username=None,
+            password=None,
+            api_key=None,
+            update_interval=coordinator_module.timedelta(seconds=30),
+        )
+
+        with pytest.raises(update_failed):
+            await coordinator.async_config_entry_first_refresh()
+
+
+# ---------------------------------------------------------------------------
+# Camera caches per detection and times out
+# ---------------------------------------------------------------------------
+
+
+def _camera_coordinator(session, event_id="evt-1"):
+    coordinator = types.SimpleNamespace(
+        entry_id="entry-1",
+        url="http://yawamf.local",
+        headers={},
+        session=session,
+        data={"latest": {"frigate_event": event_id}},
+    )
+
+    async def _login():
+        return None
+
+    coordinator.async_ensure_logged_in = _login
+    return coordinator
+
+
+def _camera_hass():
+    async def run_in_executor(func, *args):
+        return func(*args)
+
+    return types.SimpleNamespace(async_add_executor_job=run_in_executor)
+
+
+@pytest.mark.asyncio
+async def test_camera_serves_the_cached_snapshot_for_the_same_detection_and_refetches_for_a_new_one():
+    camera_module = _load_camera_module()
+    session = _RecordingSession({("GET", "snapshot.jpg"): (200, b"jpeg-bytes")})
+    coordinator = _camera_coordinator(session)
+    camera = camera_module.YAWAMFLatestBirdCamera(coordinator)
+    camera.hass = _camera_hass()
+
+    first = await camera.async_camera_image()
+    again = await camera.async_camera_image()
+    coordinator.data["latest"] = {"frigate_event": "evt-2"}
+    fresh = await camera.async_camera_image()
+
+    assert first == again == fresh == b"jpeg-bytes"
+    assert [call["url"] for call in session.calls] == [
+        "http://yawamf.local/api/frigate/evt-1/snapshot.jpg",
+        "http://yawamf.local/api/frigate/evt-2/snapshot.jpg",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_camera_snapshot_fetch_carries_a_timeout():
+    camera_module = _load_camera_module()
+    session = _RecordingSession({("GET", "snapshot.jpg"): (200, b"jpeg-bytes")})
+    camera = camera_module.YAWAMFLatestBirdCamera(_camera_coordinator(session))
+    camera.hass = _camera_hass()
+
+    await camera.async_camera_image()
+
+    assert session.calls[0]["timeout"].total == 15
+
+
+@pytest.mark.asyncio
+async def test_camera_returns_nothing_for_a_detection_it_cannot_fetch_and_keeps_the_older_frame():
+    camera_module = _load_camera_module()
+    session = _RecordingSession({("GET", "snapshot.jpg"): (200, b"jpeg-bytes")})
+    coordinator = _camera_coordinator(session)
+    camera = camera_module.YAWAMFLatestBirdCamera(coordinator)
+    camera.hass = _camera_hass()
+
+    assert await camera.async_camera_image() == b"jpeg-bytes"
+
+    coordinator.data["latest"] = {"frigate_event": "evt-2"}
+    session._responses[("GET", "snapshot.jpg")] = (503, None)
+    assert await camera.async_camera_image() is None, "a frame from another detection must not stand in"
+
+    coordinator.data["latest"] = {"frigate_event": "evt-1"}
+    assert await camera.async_camera_image() == b"jpeg-bytes", "the older detection is still cached"
+    assert len(session.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Config flow: timeouts and reauth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_flow_validation_requests_all_carry_a_timeout():
+    session = _RecordingSession(
+        {
+            ("GET", "health"): (200, {}),
+            ("GET", "status"): (200, {"auth_required": True, "public_access_enabled": False}),
+            ("POST", "login"): (200, {"access_token": "jwt"}),
+        }
+    )
+    config_flow = _load_config_flow_module(session)
+
+    await config_flow.validate_input(
+        object(), {"url": "http://yawamf.local", "username": "owner", "password": "pw", "api_key": ""}
+    )
+
+    assert len(session.calls) == 3
+    assert all(call["timeout"].total == 10 for call in session.calls)
+
+
+@pytest.mark.asyncio
+async def test_reauth_replaces_credentials_in_data_and_clears_them_from_options():
+    session = _RecordingSession(
+        {
+            ("GET", "health"): (200, {}),
+            ("GET", "status"): (200, {"auth_required": True, "public_access_enabled": False}),
+            ("POST", "login"): (200, {"access_token": "jwt"}),
+        }
+    )
+    config_flow = _load_config_flow_module(session)
+    entry = types.SimpleNamespace(
+        entry_id="entry-1",
+        data={"url": "http://yawamf.local", "username": "old", "password": "old-pw"},
+        options={"url": "http://yawamf.local", "username": "stale", "password": "stale-pw", "polling_interval": 45},
+    )
+    updates = []
+    reloads = []
+
+    async def reload(entry_id):
+        reloads.append(entry_id)
+
+    flow = config_flow.ConfigFlow()
+    flow.context = {"entry_id": "entry-1"}
+    flow.hass = types.SimpleNamespace(
+        config_entries=types.SimpleNamespace(
+            async_get_entry=lambda entry_id: entry,
+            async_update_entry=lambda entry, **changes: updates.append(changes),
+            async_reload=reload,
+        )
+    )
+
+    shown = await flow.async_step_reauth({"url": "http://yawamf.local"})
+    result = await flow.async_step_reauth_confirm({"username": "owner", "password": "new-pw"})
+
+    assert shown["step_id"] == "reauth_confirm"
+    assert result == {"type": "abort", "reason": "reauth_successful"}
+    assert updates == [
+        {
+            "data": {"url": "http://yawamf.local", "username": "owner", "password": "new-pw", "api_key": None},
+            "options": {"url": "http://yawamf.local", "polling_interval": 45},
+        }
+    ]
+    assert reloads == ["entry-1"]
+    assert session.calls[-1]["json"] == {"username": "owner", "password": "new-pw"}
+
+
+@pytest.mark.asyncio
+async def test_reauth_shows_the_form_again_when_the_new_credentials_are_rejected():
+    session = _RecordingSession(
+        {
+            ("GET", "health"): (200, {}),
+            ("GET", "status"): (200, {"auth_required": True, "public_access_enabled": False}),
+            ("POST", "login"): (401, {"detail": "no"}),
+        }
+    )
+    config_flow = _load_config_flow_module(session)
+    entry = types.SimpleNamespace(entry_id="entry-1", data={"url": "http://yawamf.local"}, options={})
+    flow = config_flow.ConfigFlow()
+    flow.context = {"entry_id": "entry-1"}
+    flow.hass = types.SimpleNamespace(
+        config_entries=types.SimpleNamespace(
+            async_get_entry=lambda entry_id: entry,
+            async_update_entry=lambda *a, **k: pytest.fail("must not persist rejected credentials"),
+            async_reload=None,
+        )
+    )
+
+    result = await flow.async_step_reauth_confirm({"username": "owner", "password": "wrong"})
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_auth"}

--- a/custom_components/yawamf/__init__.py
+++ b/custom_components/yawamf/__init__.py
@@ -22,11 +22,12 @@ from .const import (
     DEFAULT_ENABLE_INGRESS,
 )
 from .coordinator import YAWAMFDataUpdateCoordinator
-from .ingress import async_register_ingress, async_unregister_ingress_panel
+from .ingress import async_register_ingress, async_unregister_ingress
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.CAMERA]
+_INGRESS_ENTRIES_KEY = "_ingress_entries"
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -57,12 +58,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-    hass.data[DOMAIN].setdefault("_ingress_entries", set())
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    domain_data[entry.entry_id] = coordinator
+    ingress_entries: set[str] = domain_data.setdefault(_INGRESS_ENTRIES_KEY, set())
 
     if enable_ingress:
         await async_register_ingress(hass, coordinator)
-        hass.data[DOMAIN]["_ingress_entries"].add(entry.entry_id)
+        ingress_entries.add(entry.entry_id)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -74,12 +76,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        ingress_entries = hass.data.get(DOMAIN, {}).get("_ingress_entries", set())
+        domain_data = hass.data.get(DOMAIN, {})
+        ingress_entries: set[str] = domain_data.get(_INGRESS_ENTRIES_KEY, set())
+        domain_data.pop(entry.entry_id, None)
         if entry.entry_id in ingress_entries:
             ingress_entries.discard(entry.entry_id)
-            if not ingress_entries:
-                await async_unregister_ingress_panel(hass)
-        hass.data[DOMAIN].pop(entry.entry_id)
+            survivor = next((domain_data[other] for other in ingress_entries if other in domain_data), None)
+            if survivor is not None:
+                # Another entry still wants the sidebar; point the proxy at it.
+                await async_register_ingress(hass, survivor)
+            else:
+                async_unregister_ingress(hass)
 
     return unload_ok
 

--- a/custom_components/yawamf/camera.py
+++ b/custom_components/yawamf/camera.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import logging
 
+import aiohttp
 from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -21,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 # scaled dashboard thumbnail, but the more-info / live camera view loops the
 # full image and fails to render when it's this large, so downscale it.
 _MAX_EDGE = 1280
+_SNAPSHOT_TIMEOUT = aiohttp.ClientTimeout(total=15)
 
 
 def _downscale_jpeg(data: bytes) -> bytes:
@@ -65,6 +67,10 @@ class YAWAMFLatestBirdCamera(CoordinatorEntity[YAWAMFDataUpdateCoordinator], Cam
         super().__init__(coordinator)
         Camera.__init__(self)
         self._attr_unique_id = f"{coordinator.entry_id}_latest_snapshot"
+        # The dashboard asks for the image on every refresh, but the snapshot
+        # only changes when the detection does, so remember the last one.
+        self._cached_event_id: str | None = None
+        self._cached_image: bytes | None = None
 
     @property
     def is_on(self) -> bool:
@@ -82,19 +88,30 @@ class YAWAMFLatestBirdCamera(CoordinatorEntity[YAWAMFDataUpdateCoordinator], Cam
 
     async def async_camera_image(self, width: int | None = None, height: int | None = None) -> bytes | None:
         """Return a still image response from the camera."""
-        latest = self.coordinator.data.get("latest")
-        if not latest:
+        latest = (self.coordinator.data or {}).get("latest")
+        if not isinstance(latest, dict):
             return None
 
         event_id = latest.get("frigate_event")
-        url = f"{self.coordinator.url}/api/frigate/{event_id}/snapshot.jpg"
+        if not isinstance(event_id, str) or not event_id:
+            return None
+        if event_id == self._cached_event_id and self._cached_image is not None:
+            return self._cached_image
 
+        url = f"{self.coordinator.url}/api/frigate/{event_id}/snapshot.jpg"
         try:
-            async with self.coordinator.session.get(url, headers=self.coordinator.headers) as resp:
+            await self.coordinator.async_ensure_logged_in()
+            async with self.coordinator.session.get(
+                url, headers=self.coordinator.headers, timeout=_SNAPSHOT_TIMEOUT
+            ) as resp:
                 if resp.status != 200:
                     return None
                 data = await resp.read()
-        except Exception:
+        except Exception:  # noqa: BLE001 - the card shows nothing rather than a frame from another detection
+            _LOGGER.debug("YA-WAMF snapshot fetch failed", exc_info=True)
             return None
 
-        return await self.hass.async_add_executor_job(_downscale_jpeg, data)
+        image = await self.hass.async_add_executor_job(_downscale_jpeg, data)
+        self._cached_event_id = event_id
+        self._cached_image = image
+        return image

--- a/custom_components/yawamf/config_flow.py
+++ b/custom_components/yawamf/config_flow.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
+import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -26,6 +28,17 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10)
+CREDENTIAL_KEYS = (CONF_USERNAME, CONF_PASSWORD, CONF_API_KEY)
+
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_USERNAME): str,
+        vol.Optional(CONF_PASSWORD): str,
+        vol.Optional(CONF_API_KEY): str,
+    }
+)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -50,12 +63,12 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     try:
         session = async_get_clientsession(hass)
-        async with session.get(f"{url}/health") as response:
+        async with session.get(f"{url}/health", timeout=REQUEST_TIMEOUT) as response:
             if response.status != 200:
                 raise CannotConnect
 
         # If auth is enabled and public access is disabled, we need credentials.
-        async with session.get(f"{url}/api/auth/status") as status_resp:
+        async with session.get(f"{url}/api/auth/status", timeout=REQUEST_TIMEOUT) as status_resp:
             status_resp.raise_for_status()
             status = await status_resp.json()
 
@@ -68,6 +81,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
                 async with session.post(
                     f"{url}/api/auth/login",
                     json={"username": username, "password": password},
+                    timeout=REQUEST_TIMEOUT,
                 ) as login_resp:
                     if login_resp.status in (401, 403):
                         raise InvalidAuth
@@ -79,6 +93,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
                 async with session.get(
                     f"{url}/api/stats/daily-summary",
                     headers={"X-API-Key": api_key},
+                    timeout=REQUEST_TIMEOUT,
                 ) as protected_resp:
                     if protected_resp.status in (401, 403):
                         raise InvalidAuth
@@ -123,6 +138,43 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors)
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """YA-WAMF rejected the stored credentials; ask for new ones."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Validate replacement credentials against the configured URL and apply them."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None:
+            return self.async_abort(reason="reauth_failed")
+
+        if user_input is None:
+            return self.async_show_form(step_id="reauth_confirm", data_schema=STEP_REAUTH_DATA_SCHEMA)
+
+        url = entry.options.get(CONF_URL, entry.data[CONF_URL])
+        errors: dict[str, str] = {}
+        try:
+            await validate_input(self.hass, {CONF_URL: url, **user_input})
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception during reauth")
+            errors["base"] = "unknown"
+        else:
+            # Options override data at setup, so stale credentials must leave both.
+            credentials = {key: user_input.get(key) for key in CREDENTIAL_KEYS}
+            self.hass.config_entries.async_update_entry(
+                entry,
+                data={**entry.data, **credentials},
+                options={key: value for key, value in entry.options.items() if key not in CREDENTIAL_KEYS},
+            )
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(step_id="reauth_confirm", data_schema=STEP_REAUTH_DATA_SCHEMA, errors=errors)
 
     @staticmethod
     @callback

--- a/custom_components/yawamf/coordinator.py
+++ b/custom_components/yawamf/coordinator.py
@@ -10,7 +10,10 @@ from typing import Any
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 
 class YAWAMFDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -63,8 +66,13 @@ class YAWAMFDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return True
         return datetime.now(timezone.utc) < (self._access_token_expires_at - timedelta(minutes=5))
 
-    async def _ensure_logged_in(self) -> None:
-        """Best-effort login if username/password provided."""
+    async def async_ensure_logged_in(self) -> None:
+        """Log in with the stored username and password when the token is missing or near expiry.
+
+        The sidebar proxy calls this before each upstream request, so a token
+        that expires between polls is refreshed on demand rather than waiting
+        for the next poll.
+        """
         if not self.username or not self.password:
             return
         if self._token_valid():
@@ -78,10 +86,10 @@ class YAWAMFDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 async with self.session.post(
                     f"{self.url}/api/auth/login",
                     json={"username": self.username, "password": self.password},
-                    timeout=aiohttp.ClientTimeout(total=10),
+                    timeout=REQUEST_TIMEOUT,
                 ) as resp:
                     if resp.status in (401, 403):
-                        raise UpdateFailed("Invalid YA-WAMF credentials")
+                        raise ConfigEntryAuthFailed("YA-WAMF rejected the stored username and password")
                     resp.raise_for_status()
                     data = await resp.json()
 
@@ -95,7 +103,7 @@ class YAWAMFDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self._access_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)
                 else:
                     self._access_token_expires_at = None
-            except UpdateFailed:
+            except (UpdateFailed, ConfigEntryAuthFailed):
                 raise
             except Exception as err:
                 raise UpdateFailed(f"Error logging in to YA-WAMF: {err}") from err
@@ -103,20 +111,20 @@ class YAWAMFDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API."""
         try:
-            await self._ensure_logged_in()
+            await self.async_ensure_logged_in()
             headers = self._headers()
 
             async with self.session.get(
                 f"{self.url}/api/stats/daily-summary",
                 headers=headers,
-                timeout=aiohttp.ClientTimeout(total=10),
+                timeout=REQUEST_TIMEOUT,
             ) as resp:
                 if resp.status in (401, 403):
-                    # Clear cached token so we can re-login next cycle.
+                    # Forget the token so a reauth with new credentials starts clean.
                     self._access_token = None
                     self._access_token_expires_at = None
-                    raise UpdateFailed(
-                        "Authentication required for YA-WAMF API (check HA integration credentials/public access)"
+                    raise ConfigEntryAuthFailed(
+                        "YA-WAMF requires authentication: provide credentials or enable public access"
                     )
                 resp.raise_for_status()
                 summary_data = await resp.json()
@@ -134,5 +142,7 @@ class YAWAMFDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "count_24h": count_24h if isinstance(count_24h, int) else 0,
                 "top_species": top_species if isinstance(top_species, list) else [],
             }
+        except ConfigEntryAuthFailed:
+            raise
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err

--- a/custom_components/yawamf/ingress.py
+++ b/custom_components/yawamf/ingress.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import logging
 import secrets
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlencode
 
 from aiohttp import ClientTimeout, web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import INGRESS_URL, PANEL_URL_PATH
+from .const import DOMAIN, INGRESS_URL, PANEL_URL_PATH
 from .coordinator import YAWAMFDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,15 +35,34 @@ _INGRESS_BLOCKED_RESPONSE_HEADERS = {
 
 _INGRESS_TOKEN_PARAM = "auth"
 _INGRESS_TOKEN_COOKIE = "yawamf_ingress_token"
-_PUBLIC_ASSET_PATHS = (
-    "favicon.ico",
-    "favicon.png",
-    "apple-touch-icon.png",
-    "manifest.json",
-    "pwa-192x192.png",
-    "pwa-512x512.png",
-    "frigate-logo.png",
-)
+_RUNTIME_KEY = "_ingress_runtime"
+
+
+@dataclass
+class IngressRuntime:
+    """What the proxy needs at request time, held in ``hass.data`` for the life of the run.
+
+    Home Assistant views cannot be unregistered, so the view is registered once
+    and looks here on every request. A reload replaces the coordinator (new URL,
+    new credentials) without touching the view; an unload with no entries left
+    sets the coordinator to ``None`` and the view answers 404 until the next
+    setup. The token lives for the whole run so a browser that already holds
+    the cookie survives a reload.
+    """
+
+    token: str
+    coordinator: YAWAMFDataUpdateCoordinator | None = None
+    views_registered: bool = False
+    panel_registered: bool = False
+
+
+def _runtime(hass: HomeAssistant) -> IngressRuntime:
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    runtime = domain_data.get(_RUNTIME_KEY)
+    if runtime is None:
+        runtime = IngressRuntime(token=secrets.token_urlsafe(32))
+        domain_data[_RUNTIME_KEY] = runtime
+    return runtime
 
 
 class YAWAMFIngressView(HomeAssistantView):
@@ -51,9 +72,12 @@ class YAWAMFIngressView(HomeAssistantView):
     name = "api:yawamf:ingress"
     requires_auth = False
 
-    def __init__(self, coordinator: YAWAMFDataUpdateCoordinator, ingress_token: str) -> None:
-        self.coordinator = coordinator
-        self.ingress_token = ingress_token
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
+    @property
+    def runtime(self) -> IngressRuntime:
+        return _runtime(self.hass)
 
     async def get(self, request: web.Request, path: str = "") -> web.StreamResponse:
         return await self._proxy(request, path)
@@ -74,16 +98,30 @@ class YAWAMFIngressView(HomeAssistantView):
         return await self._proxy(request, path)
 
     async def _proxy(self, request: web.Request, path: str) -> web.StreamResponse:
-        if not _is_authorized_ingress_request(request, self.ingress_token):
+        runtime = self.runtime
+        coordinator = runtime.coordinator
+        if coordinator is None:
+            raise web.HTTPNotFound(text="YA-WAMF sidebar is not enabled.")
+        if not _is_authorized_ingress_request(request, runtime.token):
             raise web.HTTPUnauthorized()
 
-        target_url = _build_target_url(self.coordinator.url, path, _upstream_query_string(request))
-        headers = _build_forward_headers(request.headers, self.coordinator.headers)
+        try:
+            await coordinator.async_ensure_logged_in()
+        except ConfigEntryAuthFailed as err:
+            raise web.HTTPBadGateway(
+                text="YA-WAMF rejected the stored credentials; reconfigure the integration."
+            ) from err
+        except Exception as err:  # noqa: BLE001 - an unreachable YA-WAMF is a gateway failure, not a crash
+            _LOGGER.debug("YA-WAMF ingress login refresh failed", exc_info=True)
+            raise web.HTTPBadGateway(text="YA-WAMF ingress could not sign in; see Home Assistant logs.") from err
+
+        target_url = _build_target_url(coordinator.url, path, _upstream_query_string(request))
+        headers = _build_forward_headers(request.headers, coordinator.headers)
         body = None if request.method in {"GET", "HEAD"} else await request.read()
-        should_set_cookie = request.query.get(_INGRESS_TOKEN_PARAM) == self.ingress_token
+        should_set_cookie = request.query.get(_INGRESS_TOKEN_PARAM) == runtime.token
 
         try:
-            async with self.coordinator.session.request(
+            async with coordinator.session.request(
                 request.method,
                 target_url,
                 headers=headers,
@@ -96,7 +134,7 @@ class YAWAMFIngressView(HomeAssistantView):
                     reason=upstream.reason,
                     headers=_response_headers(upstream.headers),
                 )
-                _set_ingress_cookie(response, self.ingress_token, should_set_cookie)
+                _set_ingress_cookie(response, runtime.token, should_set_cookie)
 
                 if request.method != "HEAD" and _should_rewrite_response(upstream.headers):
                     body = await upstream.text()
@@ -111,7 +149,7 @@ class YAWAMFIngressView(HomeAssistantView):
                         content_type=upstream.content_type,
                         charset=upstream.charset,
                     )
-                    _set_ingress_cookie(text_response, self.ingress_token, should_set_cookie)
+                    _set_ingress_cookie(text_response, runtime.token, should_set_cookie)
                     return text_response
 
                 # Preserve exact byte-length framing for unencoded bodies (e.g. media
@@ -142,64 +180,6 @@ class YAWAMFIngressView(HomeAssistantView):
         except Exception as err:  # noqa: BLE001 - HA should return a proxy failure, not crash the view
             _LOGGER.exception("YA-WAMF ingress proxy request failed")
             raise web.HTTPBadGateway(text="YA-WAMF ingress proxy failed; see Home Assistant logs.") from err
-
-
-class YAWAMFIngressAssetView(HomeAssistantView):
-    """Serve known YA-WAMF public assets at HA root for iframe compatibility."""
-
-    requires_auth = False
-
-    def __init__(self, coordinator: YAWAMFDataUpdateCoordinator, asset_path: str) -> None:
-        self.coordinator = coordinator
-        self.asset_path = asset_path
-        self.url = f"/{asset_path}"
-        self.name = f"api:yawamf:asset:{asset_path}"
-
-    async def get(self, request: web.Request) -> web.StreamResponse:
-        target_url = _build_target_url(self.coordinator.url, self.asset_path, _upstream_query_string(request))
-
-        try:
-            async with self.coordinator.session.request(
-                "GET",
-                target_url,
-                headers=_build_forward_headers(request.headers, self.coordinator.headers),
-                allow_redirects=False,
-                timeout=ClientTimeout(total=None),
-            ) as upstream:
-                if _should_rewrite_response(upstream.headers):
-                    body = await upstream.text()
-                    response_headers = _response_headers(upstream.headers)
-                    response_headers.pop("Content-Type", None)
-                    return web.Response(
-                        status=upstream.status,
-                        reason=upstream.reason,
-                        headers=response_headers,
-                        text=_rewrite_root_paths(body),
-                        content_type=upstream.content_type,
-                        charset=upstream.charset,
-                    )
-
-                response = web.StreamResponse(
-                    status=upstream.status,
-                    reason=upstream.reason,
-                    headers=_response_headers(upstream.headers),
-                )
-                _preserve_content_length(response, upstream.headers)
-                await response.prepare(request)
-                try:
-                    async for chunk in upstream.content.iter_chunked(64 * 1024):
-                        await response.write(chunk)
-                except ConnectionResetError:
-                    _LOGGER.debug("YA-WAMF ingress asset client disconnected mid-stream", exc_info=True)
-                    return response
-                await response.write_eof()
-                return response
-        except ConnectionResetError:
-            _LOGGER.debug("YA-WAMF ingress asset client disconnected", exc_info=True)
-            raise
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.exception("YA-WAMF ingress asset request failed")
-            raise web.HTTPBadGateway(text="YA-WAMF ingress asset request failed; see Home Assistant logs.") from err
 
 
 def _build_target_url(base_url: str, path: str, query_string: str) -> str:
@@ -341,11 +321,19 @@ def _rewrite_root_paths(body: str) -> str:
 
 
 async def async_register_ingress(hass: HomeAssistant, coordinator: YAWAMFDataUpdateCoordinator) -> None:
-    """Register the HA proxy view and sidebar panel."""
-    ingress_token = secrets.token_urlsafe(32)
-    hass.http.register_view(YAWAMFIngressView(coordinator, ingress_token))
-    for asset_path in _PUBLIC_ASSET_PATHS:
-        hass.http.register_view(YAWAMFIngressAssetView(coordinator, asset_path))
+    """Point the sidebar proxy at ``coordinator`` and show the panel.
+
+    Safe to call on every setup, including the reload that follows an options
+    change: the view is registered once per run, the panel is re-registered
+    with ``update=True`` so a second registration replaces rather than raises,
+    and the proxy reads the coordinator from ``hass.data`` on each request.
+    """
+    runtime = _runtime(hass)
+    runtime.coordinator = coordinator
+
+    if not runtime.views_registered:
+        hass.http.register_view(YAWAMFIngressView(hass))
+        runtime.views_registered = True
 
     try:
         from homeassistant.components import frontend
@@ -356,20 +344,30 @@ async def async_register_ingress(hass: HomeAssistant, coordinator: YAWAMFDataUpd
             sidebar_title="YA-WAMF",
             sidebar_icon="mdi:bird",
             frontend_url_path=PANEL_URL_PATH,
-            config={"url": f"{INGRESS_URL}/?{_INGRESS_TOKEN_PARAM}={ingress_token}"},
+            config={"url": f"{INGRESS_URL}/?{_INGRESS_TOKEN_PARAM}={runtime.token}"},
             require_admin=False,
+            update=True,
         )
+        runtime.panel_registered = True
     except Exception:  # noqa: BLE001 - proxy remains usable even if panel registration API differs
         _LOGGER.exception("Failed to register YA-WAMF Home Assistant sidebar panel")
 
 
-async def async_unregister_ingress_panel(hass: HomeAssistant) -> None:
-    """Best-effort removal of the sidebar panel on unload/reload."""
+def async_unregister_ingress(hass: HomeAssistant) -> None:
+    """Hide the panel and make the proxy answer 404 until the next setup.
+
+    ``frontend.async_remove_panel`` is a plain callback, not a coroutine; it
+    must be called, not awaited.
+    """
+    runtime = _runtime(hass)
+    runtime.coordinator = None
+    if not runtime.panel_registered:
+        return
+
     try:
         from homeassistant.components import frontend
 
-        remove_panel = getattr(frontend, "async_remove_panel", None)
-        if remove_panel is not None:
-            await remove_panel(hass, PANEL_URL_PATH)
+        frontend.async_remove_panel(hass, PANEL_URL_PATH)
+        runtime.panel_registered = False
     except Exception:  # noqa: BLE001
-        _LOGGER.debug("Failed to unregister YA-WAMF sidebar panel", exc_info=True)
+        _LOGGER.warning("Failed to remove the YA-WAMF sidebar panel", exc_info=True)

--- a/custom_components/yawamf/manifest.json
+++ b/custom_components/yawamf/manifest.json
@@ -1,11 +1,18 @@
 {
   "domain": "yawamf",
   "name": "Yet Another WhosAtMyFeeder",
-  "documentation": "https://github.com/Jellman86/YetAnother-WhosAtMyFeeder",
-  "requirements": [],
-  "codeowners": ["@Jellman86"],
+  "codeowners": [
+    "@Jellman86"
+  ],
   "config_flow": true,
+  "dependencies": [
+    "frontend",
+    "http"
+  ],
+  "documentation": "https://github.com/Jellman86/YetAnother-WhosAtMyFeeder",
+  "integration_type": "service",
   "iot_class": "local_polling",
-  "version": "1.0.1",
+  "requirements": [],
+  "version": "1.1.0",
   "icon": "mdi:bird"
 }

--- a/custom_components/yawamf/sensor.py
+++ b/custom_components/yawamf/sensor.py
@@ -89,6 +89,7 @@ class YAWAMFLastBirdSensor(CoordinatorEntity[YAWAMFDataUpdateCoordinator], Senso
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.entry_id}_last_bird"
         self._last_event_id: str | None = None
+        self._last_available: bool | None = None
 
     @property
     def native_value(self) -> str | None:
@@ -118,11 +119,18 @@ class YAWAMFLastBirdSensor(CoordinatorEntity[YAWAMFDataUpdateCoordinator], Senso
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Only emit HA state updates when a new detection arrives."""
+        """Emit a state update when a new detection arrives or availability changes.
+
+        Suppressing writes for a repeated event keeps automations from firing
+        twice for one visit; it must not also hide the sensor going
+        unavailable when the coordinator stops reaching YA-WAMF.
+        """
         event_id = _latest_event_id(self.coordinator)
-        if event_id == self._last_event_id:
+        available = self.available
+        if event_id == self._last_event_id and available == self._last_available:
             return
         self._last_event_id = event_id
+        self._last_available = available
         self.async_write_ha_state()
 
     @property

--- a/custom_components/yawamf/strings.json
+++ b/custom_components/yawamf/strings.json
@@ -12,12 +12,26 @@
           "api_key": "Legacy API key (optional)",
           "enable_ingress": "Show YA-WAMF in the Home Assistant sidebar"
         }
+      },
+      "reauth_confirm": {
+        "title": "Reconnect to YA-WAMF",
+        "description": "YA-WAMF rejected the stored credentials. Enter a username and password, or a legacy API key, or leave all three empty if you have enabled Public Access in YA-WAMF.",
+        "data": {
+          "username": "Username (optional)",
+          "password": "Password (optional)",
+          "api_key": "Legacy API key (optional)"
+        }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect to YA-WAMF.",
       "invalid_auth": "Authentication failed. Provide credentials or enable Public Access in YA-WAMF.",
       "unknown": "Unexpected error."
+    },
+    "abort": {
+      "reauth_successful": "Credentials updated.",
+      "reauth_failed": "The YA-WAMF entry no longer exists.",
+      "already_configured": "This YA-WAMF instance is already configured."
     }
   },
   "options": {

--- a/custom_components/yawamf/translations/en.json
+++ b/custom_components/yawamf/translations/en.json
@@ -12,12 +12,26 @@
           "api_key": "Legacy API key (optional)",
           "enable_ingress": "Show YA-WAMF in the Home Assistant sidebar"
         }
+      },
+      "reauth_confirm": {
+        "title": "Reconnect to YA-WAMF",
+        "description": "YA-WAMF rejected the stored credentials. Enter a username and password, or a legacy API key, or leave all three empty if you have enabled Public Access in YA-WAMF.",
+        "data": {
+          "username": "Username (optional)",
+          "password": "Password (optional)",
+          "api_key": "Legacy API key (optional)"
+        }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect to YA-WAMF.",
       "invalid_auth": "Authentication failed. Provide credentials or enable Public Access in YA-WAMF.",
       "unknown": "Unexpected error."
+    },
+    "abort": {
+      "reauth_successful": "Credentials updated.",
+      "reauth_failed": "The YA-WAMF entry no longer exists.",
+      "already_configured": "This YA-WAMF instance is already configured."
     }
   },
   "options": {

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -41,6 +41,11 @@ The same YA-WAMF frontend bundle works for both standalone access and the Home
 Assistant sidebar. The app detects the Home Assistant ingress path at runtime,
 and the integration rewrites root asset links while proxying the page.
 
+Changing the URL or credentials in the integration options takes effect in the
+sidebar straight away; no Home Assistant restart is needed. If YA-WAMF starts
+rejecting the stored credentials, Home Assistant shows a **Reconfigure** prompt
+on the integration asking for new ones.
+
 ### Reverse Proxy Notes
 - Use the **public hostname** you configured on the proxy (not the internal container IP).
 - Ensure the proxy forwards the `/health` and `/api/stats/daily-summary` endpoints.
@@ -53,7 +58,7 @@ and the integration rewrites root asset links while proxying the page.
 | **Last Bird Detected** | The name of the most recent visitor. This sensor now only emits a Home Assistant state update when a new detection event arrives, so repeated visits from the same species can still drive automations reliably. Attributes include camera, confidence, temperature, and weather. |
 | **Last Detection Event** | The raw YA-WAMF/Frigate event ID for the most recent detection. Use this as the safest trigger when you want an automation to fire for every new detection, regardless of species. |
 | **Last Detection Time** | A proper Home Assistant timestamp entity for the most recent detection time. |
-| **Daily Count** | A counter for how many birds have visited since midnight. |
+| **Bird Count (24h)** | How many detections there were in the last 24 hours. It is a rolling window, not a count since midnight, so it can go down as old visits age out. |
 | **Latest Snapshot** | (Optional) A camera entity showing the last detected bird. |
 
 ## Automation Example


### PR DESCRIPTION
## Outcome

Changing the URL or credentials in the Home Assistant integration's options now takes effect in the sidebar immediately, with no restart and no exception in the log. Before, the sidebar silently kept the old address and credentials, then broke once its stale login token expired. A rejected credential now opens Home Assistant's reconfigure prompt instead of failing silently on every poll.

## Scope

- **Included:**
  - Ingress: one view per run reading the live coordinator and token from `hass.data`; panel registered with `update=True` and removed with a plain call; proxy refreshes the login before forwarding and answers 502 with a plain message when credentials are rejected; the seven unauthenticated root asset views are removed; two entries with the sidebar on hand over cleanly when one unloads.
  - Coordinator: 401/403 raises `ConfigEntryAuthFailed`; a plain outage stays `UpdateFailed`.
  - Config flow: reauth step that replaces credentials in `data` and clears them from `options` (options override data at setup); timeouts on every validation request.
  - Sensor: Last Bird writes state on availability changes, not only on a new event.
  - Camera: one cached frame per `frigate_event`; 15 s timeout; nothing shown for a detection it cannot fetch.
  - Manifest: `dependencies: ["frontend", "http"]`, `integration_type: service`, version 1.1.0. Strings and translations for the reauth step. Docs describe the rolling 24-hour count and the reauth prompt.
  - Roadmap entry updated with the token-expiry consequence and the asset-path wording, marked shipped.
- **Explicitly excluded:** any change to the YA-WAMF backend or SPA. Tests run against stubs because Home Assistant is not a test dependency of this repository; the panel API signatures were verified against core `dev` by reading the source.
- **Issue or roadmap outcome:** ROADMAP "Home Assistant integration: survive a reload".

## Verification

```text
backend$ pytest tests/test_home_assistant_sensor.py
30 passed

backend$ pytest
2722 passed, 49 skipped in 61.18s

$ ruff check . && ruff format --check .
All checks passed!
519 files already formatted

$ python backend/scripts/docs_consistency_check.py
Documentation consistency check passed.
```

Not verified: a live Home Assistant install. The reload, reauth, and camera paths are covered by tests against stubs whose behaviour mirrors core (a synchronous `async_remove_panel`, a registration that raises on overwrite without `update=True`).

## Data integrity and risk

- Detection-history or configuration risk: none in YA-WAMF. In Home Assistant, reauth rewrites the entry's credential keys and drops the same keys from options; URL and polling interval are untouched.
- Migration/recovery path, if data changes: not applicable. Existing entries load unchanged.
- Security or secret-handling risk: reduced. The integration no longer serves unauthenticated proxies at the Home Assistant root. The ingress token still gates the proxy.
- Deployment verification, if deployed: not deployed; the integration ships as files users copy into Home Assistant.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.
