### PR TITLE
Give a worker's first load the warm-up window and report what it loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A model that takes longer than twenty seconds to load can now start in subprocess mode.** A
+  worker says it is ready only after it has loaded and compiled its model, and the supervisor gave
+  that handshake twenty seconds. The three-minute first-load window added for
+  [#300](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/300) only covered heartbeats
+  after the handshake, so a large model compiling for the NPU was killed at the twenty-second mark,
+  respawned, killed again, and the pool never started; the reference install dropped detections as
+  "worker unavailable" with no worker process left in the container. The handshake now gets the same
+  first-load window.
+- **Detections are classified in-process when the workers cannot start, not only when they keep
+  dying.** The in-process fallback engaged when the worker circuit opened, but a pool that never
+  became ready, or one with no worker left, dropped the detection instead. Both now fall back the
+  same way and the Detection tab says why. A worker dying mid-request while others remain still does
+  not fall back, because the supervisor is already replacing it.
+- **The Detection tab names the runtime the workers actually loaded.** In subprocess mode the API
+  process never loads a model, so its provider and backend stayed at the literal default "tflite",
+  the band printed that as the runtime, marked it "not yet verified here" because no host check can
+  verify a runtime that does not exist, and inference health was keyed on it too. A worker now
+  reports what it loaded in its ready message, the supervisor records it per pool, and status and
+  health use it. A report for a model that is no longer active is ignored, so the band does not name
+  the previous model's runtime after a switch.
+
 - **The Home Assistant sidebar survives a settings change.** Every change to the integration's
   options reloads it, and the reload left the sidebar pointing at the old YA-WAMF address with the
   old credentials: the panel could not be removed because the removal was awaited when Home

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -3491,11 +3491,14 @@ class ClassifierService:
         self.register_gpu_unhealthy_signal("live_lease_expiry", runtime_key=runtime_key)
 
     def _active_inference_runtime_key(self) -> RuntimeKey:
-        return RuntimeKey.from_values(
-            self._inference_backend,
-            self._active_inference_provider,
-            self._resolve_active_model_id(),
-        )
+        backend, provider = self._inference_backend, self._active_inference_provider
+        if self._image_execution_mode == "subprocess" and not self._worker_process_mode:
+            # The parent records health for work its workers did; key it on
+            # what they loaded, not on this process's never-used defaults.
+            backend, provider = self._effective_subprocess_runtime_fields(
+                None, self._latest_worker_reported_runtime(self._get_supervisor_metrics())
+            )
+        return RuntimeKey.from_values(backend, provider, self._resolve_active_model_id())
 
     def _gpu_unhealthy_signal_outcome(self, source: str) -> Outcome:
         normalized_source = str(source or "")
@@ -4348,12 +4351,59 @@ class ClassifierService:
         self._publish_runtime_recovery(latest)
         return latest
 
+    def runtime_identity(self) -> dict[str, Any]:
+        """What this process is classifying with: backend, provider, model.
+
+        A worker sends this in its ready message, because in subprocess mode
+        the parent never loads a model and would otherwise report its idle
+        defaults as if they were the truth.
+        """
+        try:
+            model_id = self._resolve_active_model_id()
+        except Exception:  # noqa: BLE001 - identity is diagnostic; never fail a worker over it
+            model_id = None
+        return {
+            "inference_backend": self._inference_backend,
+            "active_provider": self._active_inference_provider,
+            "model_id": model_id,
+        }
+
+    def _latest_worker_reported_runtime(self, supervisor_metrics: dict[str, Any] | None) -> dict[str, Any] | None:
+        """The runtime a worker said it loaded, if it loaded the model that is active now.
+
+        Live workers answer first because they are the ones the dashboard is
+        waiting on. A report for a different model is ignored: after a switch
+        the old workers' report would otherwise outlive the model it names.
+        """
+        if not isinstance(supervisor_metrics, dict):
+            return None
+        try:
+            active_model_id = self._resolve_active_model_id()
+        except Exception:  # noqa: BLE001
+            active_model_id = None
+        for pool_name in ("live", "background", "video"):
+            pool = supervisor_metrics.get(pool_name)
+            if not isinstance(pool, dict):
+                continue
+            runtime = pool.get("runtime")
+            if not isinstance(runtime, dict):
+                continue
+            reported_model = runtime.get("model_id")
+            if active_model_id and reported_model and str(reported_model) != str(active_model_id):
+                continue
+            return dict(runtime)
+        return None
+
     def _effective_subprocess_runtime_fields(
         self,
         runtime_recovery: dict[str, Any] | None,
+        worker_runtime: dict[str, Any] | None = None,
     ) -> tuple[str, str]:
         backend = self._inference_backend
         provider = self._active_inference_provider
+        if isinstance(worker_runtime, dict):
+            backend = str(worker_runtime.get("inference_backend") or "").strip() or backend
+            provider = str(worker_runtime.get("active_provider") or "").strip() or provider
         if not isinstance(runtime_recovery, dict):
             return backend, provider
 
@@ -4613,7 +4663,10 @@ class ClassifierService:
             else None
         ) or self._inference_health.most_recent_recovery()
         effective_backend, effective_provider = (
-            self._effective_subprocess_runtime_fields(effective_runtime_recovery)
+            self._effective_subprocess_runtime_fields(
+                effective_runtime_recovery,
+                self._latest_worker_reported_runtime(supervisor_metrics),
+            )
             if self._image_execution_mode == "subprocess"
             else (self._inference_backend, self._active_inference_provider)
         )
@@ -5571,7 +5624,32 @@ class ClassifierService:
                 camera_name=camera_name,
                 model_id=model_id,
                 input_context=normalized_input_context,
+                reason="circuit_open",
             )
+        except ClassifierWorkerStartupTimeoutError:
+            return await self._classify_in_process_as_last_resort(
+                priority=priority,
+                image=image,
+                camera_name=camera_name,
+                model_id=model_id,
+                input_context=normalized_input_context,
+                reason="worker_startup_timeout",
+            )
+        except ClassifierWorkerExitedError:
+            if self._supervisor_pool_is_empty(priority):
+                return await self._classify_in_process_as_last_resort(
+                    priority=priority,
+                    image=image,
+                    camera_name=camera_name,
+                    model_id=model_id,
+                    input_context=normalized_input_context,
+                    reason="workers_unavailable",
+                )
+            # A worker died mid-request but others remain; the supervisor is
+            # already replacing it and the next request gets a live worker.
+            if priority == "live":
+                raise LiveImageClassificationOverloadedError("classify_snapshot_worker_unavailable") from None
+            raise BackgroundImageClassificationUnavailableError("background_image_worker_unavailable") from None
         except (ClassifierWorkerHeartbeatTimeoutError, ClassifierWorkerDeadlineExceededError):
             if priority == "live":
                 raise ClassificationLeaseExpiredError(
@@ -5580,14 +5658,19 @@ class ClassifierService:
                     float(getattr(settings.classification, "worker_hard_deadline_seconds", 35.0) or 35.0),
                 ) from None
             raise BackgroundImageClassificationUnavailableError("background_image_worker_timed_out") from None
-        except ClassifierWorkerStartupTimeoutError:
-            if priority == "live":
-                raise LiveImageClassificationOverloadedError("classify_snapshot_worker_unavailable") from None
-            raise BackgroundImageClassificationUnavailableError("background_image_worker_startup_timeout") from None
-        except ClassifierWorkerExitedError:
-            if priority == "live":
-                raise LiveImageClassificationOverloadedError("classify_snapshot_worker_unavailable") from None
-            raise BackgroundImageClassificationUnavailableError("background_image_worker_unavailable") from None
+
+    def _supervisor_pool_is_empty(self, priority: str) -> bool:
+        metrics = self._get_supervisor_metrics() or {}
+        pool = metrics.get(priority) if isinstance(metrics, dict) else None
+        if not isinstance(pool, dict):
+            return False
+        return int(pool.get("workers") or 0) == 0
+
+    _FALLBACK_UNAVAILABLE_ERRORS = {
+        "circuit_open": ("classify_snapshot_circuit_open", "background_image_circuit_open"),
+        "worker_startup_timeout": ("classify_snapshot_worker_unavailable", "background_image_worker_startup_timeout"),
+        "workers_unavailable": ("classify_snapshot_worker_unavailable", "background_image_worker_unavailable"),
+    }
 
     async def _classify_in_process_as_last_resort(
         self,
@@ -5597,34 +5680,39 @@ class ClassifierService:
         camera_name: Optional[str],
         model_id: Optional[str],
         input_context: Any | None,
+        reason: str = "circuit_open",
     ) -> list[dict]:
-        """Classify in this process when the worker circuit is open.
+        """Classify in this process when the isolated workers cannot.
 
-        An open circuit means the isolated workers keep dying — on slow
-        hardware, typically killed mid-model-load. Dropping every detection
-        until someone notices is the worst outcome for a recorder of
-        history, so the main process loads its own copy and keeps
-        classifying, and the status endpoint says so plainly.
+        That is an open circuit (workers keep dying), a pool whose workers
+        never became ready (killed mid-model-load on slow hardware), or a
+        pool with no worker left. Dropping every detection until someone
+        notices is the worst outcome for a recorder of history, so the main
+        process loads its own copy and keeps classifying, and the status
+        endpoint says so plainly.
         """
         async with self._worker_fallback_lock:
             if not self.model_loaded:
                 try:
                     await asyncio.to_thread(self._init_bird_model)
                 except Exception as exc:
-                    log.error("worker_fallback_model_load_failed", error=str(exc))
+                    log.error("worker_fallback_model_load_failed", reason=reason, error=str(exc))
         if not self.model_loaded:
+            live_error, background_error = self._FALLBACK_UNAVAILABLE_ERRORS.get(
+                reason, self._FALLBACK_UNAVAILABLE_ERRORS["workers_unavailable"]
+            )
             if priority == "live":
-                raise LiveImageClassificationOverloadedError("classify_snapshot_circuit_open") from None
-            raise BackgroundImageClassificationUnavailableError("background_image_circuit_open") from None
+                raise LiveImageClassificationOverloadedError(live_error) from None
+            raise BackgroundImageClassificationUnavailableError(background_error) from None
 
         if not self._worker_fallback_state["active"]:
             self._worker_fallback_state["active"] = True
-            self._worker_fallback_state["reason"] = "circuit_open"
+            self._worker_fallback_state["reason"] = reason
             self._worker_fallback_state["since_monotonic"] = time.monotonic()
             log.warning(
                 "classifier_worker_fallback_engaged",
-                reason="circuit_open",
-                detail="isolated workers keep failing; classifying in-process until they recover",
+                reason=reason,
+                detail="isolated workers are not available; classifying in-process until they recover",
             )
         self._worker_fallback_state["classifications"] += 1
 

--- a/backend/app/services/classifier_supervisor.py
+++ b/backend/app/services/classifier_supervisor.py
@@ -134,6 +134,7 @@ class ClassifierSupervisor:
                 "last_stderr_excerpt": "",
                 "last_stderr_truncated_bytes": 0,
                 "last_runtime_recovery": None,
+                "runtime": None,
                 "circuit_open": False,
                 "circuit_open_until_monotonic": None,
             },
@@ -144,6 +145,7 @@ class ClassifierSupervisor:
                 "last_stderr_excerpt": "",
                 "last_stderr_truncated_bytes": 0,
                 "last_runtime_recovery": None,
+                "runtime": None,
                 "circuit_open": False,
                 "circuit_open_until_monotonic": None,
             },
@@ -154,6 +156,7 @@ class ClassifierSupervisor:
                 "last_stderr_excerpt": "",
                 "last_stderr_truncated_bytes": 0,
                 "last_runtime_recovery": None,
+                "runtime": None,
                 "circuit_open": False,
                 "circuit_open_until_monotonic": None,
             },
@@ -524,14 +527,16 @@ class ClassifierSupervisor:
                 )
 
             # Serialize model loading across all pools to prevent RAM/GPU spikes
+            ready_timeout_seconds = self._ready_timeout_seconds(priority)
             async with self._global_init_lock:
                 await worker.start()
-                await worker.wait_until_ready(timeout_seconds=self._worker_ready_timeout_seconds[priority])
+                await worker.wait_until_ready(timeout_seconds=ready_timeout_seconds)
+            self._record_worker_runtime(priority, worker)
         except TimeoutError as exc:
             await self._close_failed_worker(worker)
             self._record_start_failure(priority, worker, reason="startup_timeout")
             raise ClassifierWorkerStartupTimeoutError(
-                f"worker startup timed out worker={worker_name} generation={generation} timeout={self._worker_ready_timeout_seconds[priority]}"
+                f"worker startup timed out worker={worker_name} generation={generation} timeout={ready_timeout_seconds}"
             ) from exc
         except Exception as exc:
             await self._close_failed_worker(worker)
@@ -560,6 +565,26 @@ class ClassifierSupervisor:
             await worker.wait_closed()
         except Exception:
             pass
+
+    def _ready_timeout_seconds(self, priority: WorkPriority) -> float:
+        """How long a worker may take to say it is ready.
+
+        A worker builds its classifier before it reports ready, so this is the
+        model-load budget. The warm-up window exists precisely because a cold
+        load (native imports, NPU and GPU kernel compiles) can take minutes on
+        slow hardware; a shorter handshake budget killed every such worker at
+        the twenty-second mark and the pool never started.
+        """
+        timeout = self._worker_ready_timeout_seconds[priority]
+        if self._warmup_liveness_timeout_seconds is not None:
+            timeout = max(timeout, self._warmup_liveness_timeout_seconds)
+        return timeout
+
+    def _record_worker_runtime(self, priority: WorkPriority, worker: Any) -> None:
+        status = worker.get_status() if worker is not None and hasattr(worker, "get_status") else {}
+        runtime = status.get("runtime") if isinstance(status, dict) else None
+        if isinstance(runtime, dict) and runtime:
+            self._metrics[priority]["runtime"] = dict(runtime)
 
     def _record_start_failure(self, priority: WorkPriority, worker: Any, *, reason: str) -> None:
         status = worker.get_status() if worker is not None and hasattr(worker, "get_status") else {}

--- a/backend/app/services/classifier_worker_client.py
+++ b/backend/app/services/classifier_worker_client.py
@@ -83,6 +83,7 @@ class ClassifierWorkerClient:
         self._exit_code: int | None = None
         self._stderr_tail = bytearray()
         self._stderr_truncated_bytes = 0
+        self._runtime: dict[str, Any] | None = None
 
     async def start(self) -> None:
         if self._process is not None:
@@ -160,6 +161,7 @@ class ClassifierWorkerClient:
             "exit_code": self._exit_code,
             "recent_stderr_excerpt": self._stderr_excerpt(),
             "stderr_truncated_bytes": self._stderr_truncated_bytes,
+            "runtime": dict(self._runtime) if self._runtime else None,
         }
 
     async def _reader_loop(self) -> None:
@@ -178,6 +180,9 @@ class ClassifierWorkerClient:
                 self._last_activity_monotonic = time.monotonic()
                 message_type = message["type"]
                 if message_type == "ready":
+                    runtime = message.get("runtime")
+                    if isinstance(runtime, dict) and runtime:
+                        self._runtime = dict(runtime)
                     self._ready.set()
                 elif message_type == "heartbeat":
                     self._last_heartbeat_monotonic = time.monotonic()

--- a/backend/app/services/classifier_worker_process.py
+++ b/backend/app/services/classifier_worker_process.py
@@ -50,12 +50,14 @@ class ClassifierWorkerProcess:
         heartbeat_interval_seconds: float = 1.0,
         progress_emit_timeout_seconds: float = 1.0,
         runtime_recovery_getter: Callable[[], dict[str, Any] | None] | None = None,
+        runtime_identity_getter: Callable[[], dict[str, Any] | None] | None = None,
     ) -> None:
         self.reader = reader
         self.writer = writer
         self.classify_fn = classify_fn
         self.classify_video_fn = classify_video_fn
         self.worker_generation = int(worker_generation)
+        self.runtime_identity_getter = runtime_identity_getter
         self.heartbeat_interval_seconds = max(0.01, float(heartbeat_interval_seconds))
         # How long a progress emit may block before the classification thread gives
         # up waiting for it. Progress delivery is best-effort, so a slow parent must
@@ -71,10 +73,21 @@ class ClassifierWorkerProcess:
     def encode_message(message: dict[str, Any]) -> bytes:
         return encode_protocol_message(message)
 
+    def _runtime_identity(self) -> dict[str, Any] | None:
+        if self.runtime_identity_getter is None:
+            return None
+        try:
+            identity = self.runtime_identity_getter()
+        except Exception:  # noqa: BLE001 - a missing identity must not stop the worker reporting ready
+            return None
+        return dict(identity) if isinstance(identity, dict) else None
+
     async def run(self) -> None:
         heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         try:
-            await self._emit(build_ready_event(worker_generation=self.worker_generation))
+            await self._emit(
+                build_ready_event(worker_generation=self.worker_generation, runtime=self._runtime_identity())
+            )
             while not self._closed:
                 raw = await self.reader.readline()
                 if not raw:
@@ -358,6 +371,7 @@ async def run_worker_main(
     heartbeat_interval_seconds: float = 1.0,
     writer: Any | None = None,
     runtime_recovery_getter: Callable[[], dict[str, Any] | None] | None = None,
+    runtime_identity_getter: Callable[[], dict[str, Any] | None] | None = None,
 ) -> None:
     loop = asyncio.get_running_loop()
     reader = asyncio.StreamReader(limit=WORKER_PROTOCOL_STREAM_LIMIT_BYTES)
@@ -374,6 +388,7 @@ async def run_worker_main(
         worker_generation=worker_generation,
         heartbeat_interval_seconds=heartbeat_interval_seconds,
         runtime_recovery_getter=runtime_recovery_getter,
+        runtime_identity_getter=runtime_identity_getter,
     )
     await worker.run()
 
@@ -401,6 +416,7 @@ def _build_default_classify_fn() -> Callable[..., list[dict[str, Any]]]:
         return service.classify(image, camera_name=camera_name, model_id=model_id, input_context=input_context)
 
     _classify_fn._runtime_recovery_getter = service.latest_runtime_recovery  # type: ignore[attr-defined]
+    _classify_fn._runtime_identity_getter = service.runtime_identity  # type: ignore[attr-defined]
     _classify_fn._video_classify_fn = service.classify_video  # type: ignore[attr-defined]
     return _classify_fn
 
@@ -418,6 +434,7 @@ def main() -> None:
             heartbeat_interval_seconds=heartbeat_interval_seconds,
             writer=_StdoutWriter(protocol_stdout),
             runtime_recovery_getter=getattr(classify_fn, "_runtime_recovery_getter", None),
+            runtime_identity_getter=getattr(classify_fn, "_runtime_identity_getter", None),
         )
     )
 

--- a/backend/app/services/classifier_worker_protocol.py
+++ b/backend/app/services/classifier_worker_protocol.py
@@ -63,11 +63,20 @@ def decode_protocol_message(raw: bytes | str) -> dict[str, Any]:
     return payload
 
 
-def build_ready_event(*, worker_generation: int) -> dict[str, Any]:
-    return {
+def build_ready_event(*, worker_generation: int, runtime: dict[str, Any] | None = None) -> dict[str, Any]:
+    """The worker's first message: it has loaded its model and can take work.
+
+    ``runtime`` names what the worker actually loaded (backend, provider,
+    model id). The parent never loads a model in subprocess mode, so this is
+    the only truthful source for what is classifying.
+    """
+    message: dict[str, Any] = {
         "type": "ready",
         "worker_generation": int(worker_generation),
     }
+    if isinstance(runtime, dict) and runtime:
+        message["runtime"] = dict(runtime)
+    return message
 
 
 def build_heartbeat_event(

--- a/backend/tests/test_classifier_service.py
+++ b/backend/tests/test_classifier_service.py
@@ -1169,7 +1169,11 @@ async def test_classifier_service_maps_supervisor_heartbeat_timeout_to_live_leas
 
 
 @pytest.mark.asyncio
-async def test_classifier_service_maps_supervisor_startup_timeout_to_live_overload(mock_tflite, mock_os_path_exists):
+async def test_classifier_service_classifies_in_process_when_live_workers_never_become_ready(
+    mock_tflite, mock_os_path_exists
+):
+    """A pool killed mid-model-load used to drop every live detection as
+    worker-unavailable. It now classifies in this process and says why."""
     original_mode = settings.classification.image_execution_mode
     settings.classification.image_execution_mode = "subprocess"
 
@@ -1177,21 +1181,29 @@ async def test_classifier_service_maps_supervisor_startup_timeout_to_live_overlo
         async def classify(self, **_kwargs):
             raise ClassifierWorkerStartupTimeoutError("worker startup timed out")
 
+    def _load_fallback_model(self):
+        self._models["bird"] = _FallbackReadyModel([{"label": "Robin", "score": 0.9, "index": 0}])
+
     try:
-        with patch.object(ClassifierService, "_init_bird_model", new=_stub_init_bird_model):
+        with patch.object(ClassifierService, "_init_bird_model", new=_load_fallback_model):
             service = ClassifierService(supervisor=_FakeSupervisor())
             img = Image.new("RGB", (16, 16), color="orange")
-            with pytest.raises(LiveImageClassificationOverloadedError, match="classify_snapshot_worker_unavailable"):
-                await service.classify_async_live(img, camera_name="front")
+            results = await service.classify_async_live(img, camera_name="front")
+            assert results and results[0]["label"] == "Robin"
+            fallback = service.get_worker_fallback_status()
+            assert fallback["active"] is True
+            assert fallback["reason"] == "worker_startup_timeout"
             await service.shutdown()
     finally:
         settings.classification.image_execution_mode = original_mode
 
 
 @pytest.mark.asyncio
-async def test_classifier_service_maps_supervisor_startup_timeout_to_empty_background_results(
+async def test_classifier_service_keeps_the_startup_timeout_error_when_no_fallback_model_can_load(
     mock_tflite, mock_os_path_exists
 ):
+    """When the workers never start and this process cannot load a model either,
+    the caller still gets the specific startup-timeout code, not a generic one."""
     original_mode = settings.classification.image_execution_mode
     settings.classification.image_execution_mode = "subprocess"
 
@@ -1199,14 +1211,18 @@ async def test_classifier_service_maps_supervisor_startup_timeout_to_empty_backg
         async def classify(self, **_kwargs):
             raise ClassifierWorkerStartupTimeoutError("worker startup timed out")
 
+    def _cannot_load(self):
+        raise RuntimeError("no model files on this host")
+
     try:
-        with patch.object(ClassifierService, "_init_bird_model", new=_stub_init_bird_model):
+        with patch.object(ClassifierService, "_init_bird_model", new=_cannot_load):
             service = ClassifierService(supervisor=_FakeSupervisor())
             img = Image.new("RGB", (16, 16), color="purple")
             with pytest.raises(
                 BackgroundImageClassificationUnavailableError, match="background_image_worker_startup_timeout"
             ):
                 await service.classify_async_background(img, camera_name="garden")
+            assert service.get_worker_fallback_status()["active"] is False
             await service.shutdown()
     finally:
         settings.classification.image_execution_mode = original_mode

--- a/backend/tests/test_classifier_supervisor.py
+++ b/backend/tests/test_classifier_supervisor.py
@@ -1260,3 +1260,122 @@ async def test_classifier_supervisor_fails_fast_on_zero_workers():
         )
 
     await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_first_load_gets_the_warmup_window_for_the_ready_handshake():
+    """A worker says ready only after it has loaded its model, so the handshake
+    budget is the model-load budget. With a warm-up window configured, a load
+    slower than the bare ready timeout must not be a startup failure."""
+    created: list[_SlowReadyWorker] = []
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        worker = _SlowReadyWorker(worker_name, worker_generation, ready_delay_seconds=0.05)
+        created.append(worker)
+        return worker
+
+    supervisor = ClassifierSupervisor(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.1,
+        hard_deadline_seconds=1.0,
+        worker_factory=_factory,
+        worker_ready_timeout_seconds=0.02,
+        warmup_liveness_timeout_seconds=0.3,
+    )
+
+    task = asyncio.create_task(
+        supervisor.classify(
+            priority="live",
+            work_id="slow-load",
+            lease_token=1,
+            image_b64="payload",
+            camera_name="garden",
+            model_id="default",
+        )
+    )
+    await asyncio.sleep(0.1)
+
+    assert created[0].ready_timeout_seen == pytest.approx(0.3)
+    await created[0].events.put(
+        {
+            "type": "result",
+            "worker_generation": 1,
+            "request_id": created[0].sent_messages[0]["request_id"],
+            "work_id": "slow-load",
+            "lease_token": 1,
+            "results": [{"label": "Robin", "score": 0.8}],
+        }
+    )
+    results = await task
+    assert results[0]["label"] == "Robin"
+    metrics = supervisor.get_metrics()
+    assert metrics["live"]["workers"] == 1
+    assert metrics["live"]["last_exit_reason"] is None
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_without_a_warmup_window_the_ready_timeout_is_unchanged():
+    created: list[_SlowReadyWorker] = []
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        worker = _SlowReadyWorker(worker_name, worker_generation, ready_delay_seconds=0.1)
+        created.append(worker)
+        return worker
+
+    supervisor = ClassifierSupervisor(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.5,
+        hard_deadline_seconds=1.0,
+        worker_factory=_factory,
+        worker_ready_timeout_seconds=0.02,
+    )
+
+    with pytest.raises(ClassifierWorkerStartupTimeoutError):
+        await supervisor.classify(
+            priority="live",
+            work_id="slow-load",
+            lease_token=1,
+            image_b64="payload",
+            camera_name="garden",
+            model_id="default",
+        )
+
+    assert created[0].ready_timeout_seen == pytest.approx(0.02)
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_supervisor_records_the_runtime_a_worker_reports_when_it_becomes_ready():
+    class _ReportingWorker(_FakeWorker):
+        def get_status(self) -> dict:
+            status = super().get_status()
+            status["runtime"] = {
+                "inference_backend": "openvino",
+                "active_provider": "intel_npu",
+                "model_id": "rope_vit_b14_inat21",
+            }
+            return status
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        return _ReportingWorker(worker_name, worker_generation)
+
+    supervisor = ClassifierSupervisor(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.5,
+        hard_deadline_seconds=1.0,
+        worker_factory=_factory,
+    )
+    await supervisor.start("live")
+
+    metrics = supervisor.get_metrics()
+    assert metrics["live"]["runtime"] == {
+        "inference_backend": "openvino",
+        "active_provider": "intel_npu",
+        "model_id": "rope_vit_b14_inat21",
+    }
+    assert metrics["background"]["runtime"] is None, "only a pool that started has a runtime to report"
+    await supervisor.shutdown()

--- a/backend/tests/test_classifier_worker_client.py
+++ b/backend/tests/test_classifier_worker_client.py
@@ -394,3 +394,49 @@ async def test_classifier_worker_client_real_worker_accepts_large_classify_reque
     assert event["results"][0]["label"] == "WorkerTest"
 
     await client.terminate()
+
+
+@pytest.mark.asyncio
+async def test_classifier_worker_client_records_the_runtime_from_the_ready_message():
+    process = _FakeProcess()
+
+    async def _factory(**_kwargs):
+        return process
+
+    client = ClassifierWorkerClient(
+        worker_name="live-0",
+        worker_generation=1,
+        heartbeat_timeout_seconds=5.0,
+        process_factory=_factory,
+    )
+    await client.start()
+    runtime = {"inference_backend": "openvino", "active_provider": "intel_npu", "model_id": "rope_vit_b14_inat21"}
+    process.feed(build_ready_event(worker_generation=1, runtime=runtime))
+
+    await asyncio.wait_for(client.wait_until_ready(), timeout=0.2)
+
+    assert client.get_status()["runtime"] == runtime
+    process.finish()
+    await client.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_classifier_worker_client_reports_no_runtime_for_a_bare_ready_message():
+    process = _FakeProcess()
+
+    async def _factory(**_kwargs):
+        return process
+
+    client = ClassifierWorkerClient(
+        worker_name="live-0",
+        worker_generation=1,
+        heartbeat_timeout_seconds=5.0,
+        process_factory=_factory,
+    )
+    await client.start()
+    process.feed(build_ready_event(worker_generation=1))
+    await asyncio.wait_for(client.wait_until_ready(), timeout=0.2)
+
+    assert client.get_status()["runtime"] is None
+    process.finish()
+    await client.wait_closed()

--- a/backend/tests/test_classifier_worker_process.py
+++ b/backend/tests/test_classifier_worker_process.py
@@ -467,3 +467,59 @@ async def test_classifier_worker_process_does_not_fail_video_classification_when
     assert any(message["type"] == "progress" for message in writer.messages)
     assert any(message["type"] == "result" and message["results"][0]["label"] == "Robin" for message in writer.messages)
     assert not any(message["type"] == "error" for message in writer.messages)
+
+
+@pytest.mark.asyncio
+async def test_classifier_worker_process_reports_what_it_loaded_in_the_ready_event():
+    reader = asyncio.StreamReader()
+    writer = _MemoryWriter()
+    process = ClassifierWorkerProcess(
+        reader=reader,
+        writer=writer,
+        classify_fn=lambda **_: [],
+        worker_generation=4,
+        heartbeat_interval_seconds=0.01,
+        runtime_identity_getter=lambda: {
+            "inference_backend": "openvino",
+            "active_provider": "intel_npu",
+            "model_id": "rope_vit_b14_inat21",
+        },
+    )
+
+    task = asyncio.create_task(process.run())
+    await asyncio.sleep(0.02)
+    reader.feed_eof()
+    await task
+
+    assert writer.messages[0]["type"] == "ready"
+    assert writer.messages[0]["runtime"] == {
+        "inference_backend": "openvino",
+        "active_provider": "intel_npu",
+        "model_id": "rope_vit_b14_inat21",
+    }
+
+
+@pytest.mark.asyncio
+async def test_classifier_worker_process_still_reports_ready_when_the_identity_getter_fails():
+    reader = asyncio.StreamReader()
+    writer = _MemoryWriter()
+
+    def _broken() -> dict:
+        raise RuntimeError("no model manager here")
+
+    process = ClassifierWorkerProcess(
+        reader=reader,
+        writer=writer,
+        classify_fn=lambda **_: [],
+        worker_generation=1,
+        heartbeat_interval_seconds=0.01,
+        runtime_identity_getter=_broken,
+    )
+
+    task = asyncio.create_task(process.run())
+    await asyncio.sleep(0.02)
+    reader.feed_eof()
+    await task
+
+    assert writer.messages[0]["type"] == "ready"
+    assert "runtime" not in writer.messages[0]

--- a/backend/tests/test_classifier_worker_protocol.py
+++ b/backend/tests/test_classifier_worker_protocol.py
@@ -207,3 +207,18 @@ def test_oversized_request_fails_cleanly_instead_of_poisoning_the_pipe():
     huge = {"type": "classify", "image_b64": "x" * (WORKER_PROTOCOL_STREAM_LIMIT_BYTES + 1)}
     with pytest.raises(ValueError, match="exceeds the protocol stream limit"):
         encode_protocol_message(huge)
+
+
+def test_ready_event_carries_the_runtime_the_worker_loaded():
+    from app.services.classifier_worker_protocol import decode_protocol_message, encode_protocol_message
+
+    runtime = {"inference_backend": "openvino", "active_provider": "intel_npu", "model_id": "rope_vit_b14_inat21"}
+    decoded = decode_protocol_message(encode_protocol_message(build_ready_event(worker_generation=3, runtime=runtime)))
+
+    assert decoded["type"] == "ready"
+    assert decoded["runtime"] == runtime
+
+
+def test_ready_event_without_a_runtime_stays_as_it_was():
+    assert "runtime" not in build_ready_event(worker_generation=1)
+    assert "runtime" not in build_ready_event(worker_generation=1, runtime={})

--- a/backend/tests/test_worker_liveness_and_fallback.py
+++ b/backend/tests/test_worker_liveness_and_fallback.py
@@ -265,3 +265,173 @@ def test_openvino_cache_prefers_the_persistent_models_volume(monkeypatch):
 
     monkeypatch.setenv("OPENVINO_CACHE_DIR", "/custom/cache")
     assert openvino_cache.resolve_openvino_cache_dir() == "/custom/cache"
+
+
+def _service_with_fake_model(supervisor, *, pool_workers: dict[str, int] | None = None):
+    from app.services.classifier_service import ClassifierService
+
+    service = ClassifierService()
+    loads: list[str] = []
+
+    class _LoadedModel:
+        loaded = True
+
+    def _fake_init() -> None:
+        loads.append("load")
+        service._models["bird"] = _LoadedModel()
+
+    sentinel = [{"display_name": "Robin", "score": 0.9}]
+    service._classifier_supervisor = supervisor
+    service._init_bird_model = _fake_init
+    service.classify = lambda image, camera_name=None, model_id=None, input_context=None: sentinel
+    if pool_workers is not None:
+        service._get_supervisor_metrics = lambda: {
+            pool: {"workers": count, "last_exit_reason": None} for pool, count in pool_workers.items()
+        }
+    return service, sentinel, loads
+
+
+@pytest.mark.asyncio
+async def test_workers_that_never_become_ready_fall_back_to_in_process_and_say_so():
+    """Killed mid-model-load on slow hardware, the pool never starts. That used to
+    drop every detection as worker-unavailable; it must classify here instead."""
+    from app.services.classifier_supervisor import ClassifierWorkerStartupTimeoutError
+
+    class _NeverReadySupervisor:
+        async def classify(self, **_kwargs):
+            raise ClassifierWorkerStartupTimeoutError("worker startup timed out")
+
+    service, sentinel, loads = _service_with_fake_model(_NeverReadySupervisor())
+
+    results = await service._run_supervised_inference("live", Image.new("RGB", (8, 8)), "front", None)
+
+    assert results == sentinel
+    fallback = service.get_worker_fallback_status()
+    assert fallback["active"] is True
+    assert fallback["reason"] == "worker_startup_timeout"
+    assert loads == ["load"]
+
+
+@pytest.mark.asyncio
+async def test_a_pool_with_no_workers_left_falls_back_to_in_process():
+    from app.services.classifier_supervisor import ClassifierWorkerExitedError
+
+    class _EmptyPoolSupervisor:
+        async def classify(self, **_kwargs):
+            raise ClassifierWorkerExitedError("No active workers available for live")
+
+    service, sentinel, _loads = _service_with_fake_model(_EmptyPoolSupervisor(), pool_workers={"live": 0})
+
+    results = await service._run_supervised_inference("live", Image.new("RGB", (8, 8)), "front", None)
+
+    assert results == sentinel
+    assert service.get_worker_fallback_status()["reason"] == "workers_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_a_worker_dying_mid_request_does_not_fall_back_while_others_remain():
+    """The supervisor replaces a dead worker; loading a second model copy in the
+    parent for one lost request would double memory for nothing."""
+    from app.services.classifier_service import LiveImageClassificationOverloadedError
+    from app.services.classifier_supervisor import ClassifierWorkerExitedError
+
+    class _OneDiedSupervisor:
+        async def classify(self, **_kwargs):
+            raise ClassifierWorkerExitedError("worker live-1 exited")
+
+    service, _sentinel, loads = _service_with_fake_model(_OneDiedSupervisor(), pool_workers={"live": 1})
+
+    with pytest.raises(LiveImageClassificationOverloadedError):
+        await service._run_supervised_inference("live", Image.new("RGB", (8, 8)), "front", None)
+
+    assert loads == []
+    assert service.get_worker_fallback_status()["active"] is False
+
+
+@pytest.mark.asyncio
+async def test_fallback_that_cannot_load_a_model_keeps_the_original_error_code():
+    from app.services.classifier_service import LiveImageClassificationOverloadedError
+    from app.services.classifier_supervisor import ClassifierWorkerStartupTimeoutError
+
+    class _NeverReadySupervisor:
+        async def classify(self, **_kwargs):
+            raise ClassifierWorkerStartupTimeoutError("worker startup timed out")
+
+    service, _sentinel, _loads = _service_with_fake_model(_NeverReadySupervisor())
+
+    def _cannot_load() -> None:
+        raise RuntimeError("no model files")
+
+    service._init_bird_model = _cannot_load
+
+    with pytest.raises(LiveImageClassificationOverloadedError) as raised:
+        await service._run_supervised_inference("live", Image.new("RGB", (8, 8)), "front", None)
+
+    assert "classify_snapshot_worker_unavailable" in str(raised.value)
+    assert service.get_worker_fallback_status()["active"] is False
+
+
+def test_status_reports_the_runtime_the_workers_loaded_not_the_parents_idle_default():
+    from app.services.classifier_service import ClassifierService
+
+    service = ClassifierService()
+    service._image_execution_mode = "subprocess"
+    service._resolve_active_model_id = lambda: "rope_vit_b14_inat21"
+    metrics = {
+        "live": {
+            "workers": 1,
+            "runtime": {
+                "inference_backend": "openvino",
+                "active_provider": "intel_npu",
+                "model_id": "rope_vit_b14_inat21",
+            },
+        },
+        "background": {"workers": 0, "runtime": None},
+        "video": {"workers": 0, "runtime": None},
+    }
+
+    assert (service._inference_backend, service._active_inference_provider) == ("tflite", "tflite")
+    backend, provider = service._effective_subprocess_runtime_fields(
+        None, service._latest_worker_reported_runtime(metrics)
+    )
+    assert (backend, provider) == ("openvino", "intel_npu")
+
+    service._get_supervisor_metrics = lambda: metrics
+    key = service._active_inference_runtime_key()
+    assert (key.backend, key.provider, key.model_id) == ("openvino", "intel_npu", "rope_vit_b14_inat21")
+
+
+def test_a_worker_report_for_a_different_model_is_ignored_after_a_switch():
+    from app.services.classifier_service import ClassifierService
+
+    service = ClassifierService()
+    service._image_execution_mode = "subprocess"
+    service._resolve_active_model_id = lambda: "rope_vit_b14_inat21"
+    metrics = {
+        "live": {
+            "workers": 0,
+            "runtime": {
+                "inference_backend": "openvino",
+                "active_provider": "intel_npu",
+                "model_id": "eva02_large_inat21",
+            },
+        },
+        "background": {"workers": 0, "runtime": None},
+        "video": {"workers": 0, "runtime": None},
+    }
+
+    assert service._latest_worker_reported_runtime(metrics) is None
+    assert service._effective_subprocess_runtime_fields(None, None) == ("tflite", "tflite")
+
+
+def test_a_recovery_after_load_still_overrides_the_ready_report():
+    """A worker that fell back from NPU to CPU after loading reports a recovery;
+    that is newer than its ready message and must win."""
+    from app.services.classifier_service import ClassifierService
+
+    service = ClassifierService()
+    service._image_execution_mode = "subprocess"
+    worker_runtime = {"inference_backend": "openvino", "active_provider": "intel_npu", "model_id": "m"}
+    recovery = {"recovered_backend": "openvino", "recovered_provider": "intel_cpu"}
+
+    assert service._effective_subprocess_runtime_fields(recovery, worker_runtime) == ("openvino", "intel_cpu")


### PR DESCRIPTION
## Outcome

A model that takes longer than twenty seconds to load can start in subprocess mode. When the workers cannot start at all, detections are classified in-process instead of dropped. The Detection tab names the runtime the workers actually loaded instead of the parent process's idle default.

Found on the reference install today: a switch to eva02_large had every live worker killed at the twenty-second mark while compiling for the NPU, the pool never started, the event at 22:14 was dropped twice as worker-unavailable, and for the rest of the evening there was no classifier worker process in the container. The same status showed "Runtime: tflite, not yet verified here" for a model running on OpenVINO.

## Scope

- **Included:**
  - Supervisor: the ready handshake gets the warm-up window when one is configured, because a worker reports ready only after loading its model. Per-pool `runtime` metric recorded from the worker's ready message.
  - Protocol, worker, client: the ready message carries `{inference_backend, active_provider, model_id}`; the worker's identity getter can fail without stopping the ready message; the client exposes it in `get_status`.
  - Service: `runtime_identity()`; status and the inference-health key prefer the worker-reported runtime in subprocess mode, ignoring a report for a model that is no longer active, and a post-load recovery still overrides the ready report. In-process fallback now engages on startup timeout and on an empty pool, with the reason stated; a worker dying mid-request while others remain does not fall back. When the fallback cannot load a model, the original error codes are kept.
  - Tests at every layer: 15 new, 2 rewritten to the new contract.
- **Explicitly excluded:** the UI. Once `active_provider` is truthful the band and its verified mark work as written. No change to the ready timeout setting itself.
- **Issue or roadmap outcome:** follow-up to #300 and #312.

## Verification

```text
backend$ pytest tests/test_classifier_worker_protocol.py tests/test_classifier_worker_process.py \
    tests/test_classifier_worker_client.py tests/test_classifier_supervisor.py \
    tests/test_worker_liveness_and_fallback.py tests/test_classifier_status_api.py
81 passed

backend$ pytest tests/test_classifier_service.py
182 passed

backend$ pytest
2738 passed, 49 skipped in 58.99s

$ ruff check . && ruff format --check .
All checks passed!
519 files already formatted
```

Not yet verified on the reference install; that needs the `dev-intel` image built from this merge and a deploy through Dockhand.

## Data integrity and risk

- Detection-history or configuration risk: none. Fewer detections are dropped.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none. The ready message adds three diagnostic strings.
- Deployment verification, if deployed: not deployed.
- Trade-off to know: a model that can never load within the warm-up window now costs up to three attempts of that window before the breaker trips and the fallback takes over, where it was three twenty-second attempts. That is the price of not killing a model that needs two minutes; the breaker and the in-process fallback bound it.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.
