### PR TITLE
Name the planned runtime before the first worker has loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Before the first visit of the day, the Detection tab names the runtime that will load.** Worker
+  pools start on the first classification, so between a restart and the first bird nothing has
+  loaded anywhere and the band fell back to the API process's idle default, "tflite, not yet
+  verified here". The status now resolves the provider the way a worker will, from the active model,
+  the host capabilities and the provider preference, reports it with a source of `planned`, and the
+  band says "loads on first detection" in place of a verified mark it cannot yet earn. Once a worker
+  loads, its own report takes over; if this process has loaded a fallback model, that wins, because
+  it is the one classifying.
+
 - **A model that takes longer than twenty seconds to load can now start in subprocess mode.** A
   worker says it is ready only after it has loaded and compiled its model, and the supervisor gave
   that handshake twenty seconds. The three-minute first-load window added for

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -36,6 +36,14 @@ Last reviewed against the GitHub issue tracker on **September 7, 2026**.
 - **Reported cache sizes undercount.** `get_cache_stats` counts `*.jpg` and `*.mp4` only, so the
   `.meta.json` sidecars beside every snapshot are not in the total. On the reference install that
   is 14,712 uncounted files.
+- **The owner's SSE token reaches nginx's error log.** The live stream authenticates with a query
+  parameter because `EventSource` cannot set headers, and nginx writes the full request line when
+  the upstream refuses a connection, which it does for a few seconds on every container start while
+  uvicorn boots. Three such lines appeared on the reference install on September 7, 2026, each
+  carrying a valid owner token. The access log already uses a redacting format; the error log does
+  not. The durable fix is a short-lived, single-use stream ticket exchanged for the session token so
+  what is logged is worthless a minute later. That touches the stream route and the client and is a
+  small design decision rather than a mechanical one.
 - **API process memory is being watched again.** #314 closed at about 340 MB resident after the
   `MALLOC_ARENA_MAX=2` fix. On the reference install the API process measured 1.49 GB resident
   fourteen hours after a start in subprocess mode, where it holds no model. The RSS sampler is

--- a/apps/ui/src/lib/api/classifier.ts
+++ b/apps/ui/src/lib/api/classifier.ts
@@ -17,6 +17,10 @@ export interface ClassifierStatus {
     openvino_gpu_probe_error?: string | null;
     resolved_live_workers?: number;
     resolved_background_workers?: number;
+    /** Where active_provider and inference_backend come from in subprocess mode:
+     *  a worker's ready message, this process's own fallback model, the plan
+     *  for a pool that has not started yet, or a bare default. */
+    runtime_source?: 'worker' | 'planned' | 'in_process' | 'in_process_fallback' | 'default' | null;
     worker_in_process_fallback?: {
         active: boolean;
         reason: string | null;

--- a/apps/ui/src/lib/components/settings/DetectionStatusBand.svelte
+++ b/apps/ui/src/lib/components/settings/DetectionStatusBand.svelte
@@ -31,6 +31,10 @@
                 )
         )
     );
+    // Pools start on the first visit; until a worker has loaded, the runtime
+    // shown is the one that will load, so "verified" would be a claim about
+    // something that has not happened yet.
+    const runtimePlanned = $derived(classifierStatus?.runtime_source === 'planned');
     const liveWorkers = $derived(classifierStatus?.resolved_live_workers ?? 1);
     const backgroundWorkers = $derived(classifierStatus?.resolved_background_workers ?? 1);
     const ramPerCopy = $derived(classifierStatus?.active_model_estimated_ram_mb ?? null);
@@ -71,6 +75,8 @@
         <span class="text-sm font-bold text-slate-900 dark:text-white">{activeProviderLabel}</span>
         {#if classifierStatus?.fallback_reason}
             <span class="text-xs font-semibold text-amber-700 dark:text-amber-300">{$_('settings.detection.band_fallback_active')}</span>
+        {:else if runtimePlanned}
+            <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">{$_('settings.detection.band_runtime_planned', { default: 'loads on first detection' })}</span>
         {:else if providerVerified}
             <span class="inline-flex items-center gap-1 text-xs font-semibold text-accent-700 dark:text-accent-300">
                 {$_('settings.detection.band_verified')}

--- a/apps/ui/src/lib/components/settings/worker-fallback-band.layout.test.ts
+++ b/apps/ui/src/lib/components/settings/worker-fallback-band.layout.test.ts
@@ -20,3 +20,24 @@ describe('the status band states the in-process fallback in words', () => {
         expect(fallbackBlock).toContain('text-amber-700');
     });
 });
+
+describe('the status band does not claim a runtime that has not loaded yet', () => {
+    // Workers load on the first visit. Before that, the runtime cell shows the
+    // plan, and "verified" would be a claim about something that has not
+    // happened; the band says the model loads on first detection instead.
+
+    it('the API type carries where the runtime figure comes from', () => {
+        expect(classifierApiSource).toContain('runtime_source?:');
+        expect(classifierApiSource).toContain("'planned'");
+    });
+
+    it('a planned runtime is labelled as such, ahead of the verified mark', () => {
+        expect(bandSource).toContain("runtime_source === 'planned'");
+        const runtimeCell = bandSource.slice(bandSource.indexOf("band_runtime')"));
+        const plannedAt = runtimeCell.indexOf('runtimePlanned}');
+        const verifiedAt = runtimeCell.indexOf('providerVerified}');
+        expect(plannedAt).toBeGreaterThan(-1);
+        expect(plannedAt).toBeLessThan(verifiedAt);
+        expect(bandSource).toContain("settings.detection.band_runtime_planned'");
+    });
+});

--- a/apps/ui/src/lib/i18n/locales/de.json
+++ b/apps/ui/src/lib/i18n/locales/de.json
@@ -1509,6 +1509,7 @@
       "band_species_count": "{count} Arten",
       "band_verified": "verifiziert",
       "band_unverified": "hier noch nicht verifiziert",
+      "band_runtime_planned": "wird bei der ersten Erkennung geladen",
       "band_fallback_active": "Fallback aktiv",
       "band_worker_split": "{live} live · {background} im Hintergrund",
       "band_ram_per_copy": "~{mb} MB pro Kopie",

--- a/apps/ui/src/lib/i18n/locales/en.json
+++ b/apps/ui/src/lib/i18n/locales/en.json
@@ -1518,6 +1518,7 @@
       "band_species_count": "{count} species",
       "band_verified": "verified",
       "band_unverified": "not yet verified here",
+      "band_runtime_planned": "loads on first detection",
       "band_fallback_active": "fallback active",
       "band_worker_split": "{live} live · {background} background",
       "band_ram_per_copy": "~{mb} MB per copy",

--- a/apps/ui/src/lib/i18n/locales/es.json
+++ b/apps/ui/src/lib/i18n/locales/es.json
@@ -1509,6 +1509,7 @@
       "band_species_count": "{count} especies",
       "band_verified": "verificado",
       "band_unverified": "aún sin verificar aquí",
+      "band_runtime_planned": "se carga con la primera detección",
       "band_fallback_active": "usando alternativa",
       "band_worker_split": "{live} en vivo · {background} en segundo plano",
       "band_ram_per_copy": "~{mb} MB por copia",

--- a/apps/ui/src/lib/i18n/locales/fr.json
+++ b/apps/ui/src/lib/i18n/locales/fr.json
@@ -1509,6 +1509,7 @@
       "band_species_count": "{count} espèces",
       "band_verified": "vérifié",
       "band_unverified": "pas encore vérifié ici",
+      "band_runtime_planned": "se charge à la première détection",
       "band_fallback_active": "solution de repli active",
       "band_worker_split": "{live} en direct · {background} en arrière-plan",
       "band_ram_per_copy": "~{mb} Mo par copie",

--- a/apps/ui/src/lib/i18n/locales/it.json
+++ b/apps/ui/src/lib/i18n/locales/it.json
@@ -1518,6 +1518,7 @@
       "band_species_count": "{count} specie",
       "band_verified": "verificato",
       "band_unverified": "non ancora verificato qui",
+      "band_runtime_planned": "si carica alla prima rilevazione",
       "band_fallback_active": "ripiego attivo",
       "band_worker_split": "{live} dal vivo · {background} in background",
       "band_ram_per_copy": "~{mb} MB per copia",

--- a/apps/ui/src/lib/i18n/locales/ja.json
+++ b/apps/ui/src/lib/i18n/locales/ja.json
@@ -1509,6 +1509,7 @@
       "band_species_count": "{count}種",
       "band_verified": "検証済み",
       "band_unverified": "この環境では未検証",
+      "band_runtime_planned": "初回検出時に読み込み",
       "band_fallback_active": "フォールバック動作中",
       "band_worker_split": "ライブ{live}・バックグラウンド{background}",
       "band_ram_per_copy": "コピーあたり約{mb} MB",

--- a/apps/ui/src/lib/i18n/locales/pt.json
+++ b/apps/ui/src/lib/i18n/locales/pt.json
@@ -1518,6 +1518,7 @@
       "band_species_count": "{count} espécies",
       "band_verified": "verificado",
       "band_unverified": "ainda não verificado aqui",
+      "band_runtime_planned": "carrega na primeira deteção",
       "band_fallback_active": "alternativa ativa",
       "band_worker_split": "{live} ao vivo · {background} em segundo plano",
       "band_ram_per_copy": "~{mb} MB por cópia",

--- a/apps/ui/src/lib/i18n/locales/ru.json
+++ b/apps/ui/src/lib/i18n/locales/ru.json
@@ -1518,6 +1518,7 @@
       "band_species_count": "{count} видов",
       "band_verified": "проверено",
       "band_unverified": "здесь ещё не проверено",
+      "band_runtime_planned": "загрузится при первом обнаружении",
       "band_fallback_active": "работает запасной вариант",
       "band_worker_split": "{live} онлайн · {background} в фоне",
       "band_ram_per_copy": "~{mb} МБ на копию",

--- a/apps/ui/src/lib/i18n/locales/zh.json
+++ b/apps/ui/src/lib/i18n/locales/zh.json
@@ -1509,6 +1509,7 @@
       "band_species_count": "{count} 个物种",
       "band_verified": "已验证",
       "band_unverified": "尚未在此验证",
+      "band_runtime_planned": "首次检测时加载",
       "band_fallback_active": "正在使用备用方案",
       "band_worker_split": "{live} 个实时 · {background} 个后台",
       "band_ram_per_copy": "每份约 {mb} MB",

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -3494,10 +3494,8 @@ class ClassifierService:
         backend, provider = self._inference_backend, self._active_inference_provider
         if self._image_execution_mode == "subprocess" and not self._worker_process_mode:
             # The parent records health for work its workers did; key it on
-            # what they loaded, not on this process's never-used defaults.
-            backend, provider = self._effective_subprocess_runtime_fields(
-                None, self._latest_worker_reported_runtime(self._get_supervisor_metrics())
-            )
+            # what they loaded, or will load, not on its never-used defaults.
+            backend, provider, _source = self._subprocess_runtime_identity(self._get_supervisor_metrics())
         return RuntimeKey.from_values(backend, provider, self._resolve_active_model_id())
 
     def _gpu_unhealthy_signal_outcome(self, source: str) -> Outcome:
@@ -4394,6 +4392,57 @@ class ClassifierService:
             return dict(runtime)
         return None
 
+    def _planned_subprocess_runtime(self) -> dict[str, Any] | None:
+        """What a worker will load, resolved the way the worker resolves it.
+
+        Pools start on the first classification, so between startup and the
+        first visit nothing has loaded anywhere. The parent still knows the
+        active model, the host capabilities and the provider preference, which
+        is everything the loader uses to choose a backend, so it can say what
+        is coming rather than print its own idle default.
+        """
+        try:
+            spec = self._resolve_active_bird_model_spec()
+        except Exception:  # noqa: BLE001 - a status read must never fail over a missing spec
+            return None
+        model_id = spec.get("model_id")
+        if str(spec.get("runtime") or "tflite") != "onnx":
+            return {"inference_backend": "tflite", "active_provider": "tflite", "model_id": model_id}
+        try:
+            selection = _resolve_inference_selection(
+                self._selected_inference_provider,
+                self._accel_caps_for_read(),
+                supported_providers=list(spec.get("supported_inference_providers") or []),
+                preferred_providers=list(spec.get("host_provider_preference_order") or []),
+            )
+        except Exception:  # noqa: BLE001
+            return None
+        return {
+            "inference_backend": str(selection.get("backend") or "unavailable"),
+            "active_provider": str(selection.get("active_provider") or "unavailable"),
+            "model_id": model_id,
+        }
+
+    def _subprocess_runtime_identity(self, supervisor_metrics: dict[str, Any] | None) -> tuple[str, str, str]:
+        """(backend, provider, source) for a parent that runs workers.
+
+        Source is ``in_process_fallback`` when this process has loaded its own
+        model to cover for the workers, ``worker`` when a worker has reported
+        what it loaded, ``planned`` when nothing has loaded yet, and
+        ``default`` when even the plan cannot be resolved.
+        """
+        if self.model_loaded:
+            return self._inference_backend, self._active_inference_provider, "in_process_fallback"
+        reported = self._latest_worker_reported_runtime(supervisor_metrics)
+        if reported is not None:
+            backend, provider = self._effective_subprocess_runtime_fields(None, reported)
+            return backend, provider, "worker"
+        planned = self._planned_subprocess_runtime()
+        if planned is not None:
+            backend, provider = self._effective_subprocess_runtime_fields(None, planned)
+            return backend, provider, "planned"
+        return self._inference_backend, self._active_inference_provider, "default"
+
     def _effective_subprocess_runtime_fields(
         self,
         runtime_recovery: dict[str, Any] | None,
@@ -4662,14 +4711,15 @@ class ClassifierService:
             if self._image_execution_mode == "subprocess"
             else None
         ) or self._inference_health.most_recent_recovery()
-        effective_backend, effective_provider = (
-            self._effective_subprocess_runtime_fields(
+        if self._image_execution_mode == "subprocess":
+            base_backend, base_provider, runtime_source = self._subprocess_runtime_identity(supervisor_metrics)
+            effective_backend, effective_provider = self._effective_subprocess_runtime_fields(
                 effective_runtime_recovery,
-                self._latest_worker_reported_runtime(supervisor_metrics),
+                {"inference_backend": base_backend, "active_provider": base_provider},
             )
-            if self._image_execution_mode == "subprocess"
-            else (self._inference_backend, self._active_inference_provider)
-        )
+        else:
+            effective_backend, effective_provider = self._inference_backend, self._active_inference_provider
+            runtime_source = "in_process"
         active_model_id = None
         effective_model_id = None
         try:
@@ -4723,6 +4773,10 @@ class ClassifierService:
             # Honest degradation: when the worker circuit opens, classification
             # continues in-process and this says so instead of hiding it.
             "worker_in_process_fallback": self.get_worker_fallback_status(),
+            # Where the provider and backend above come from: a worker's ready
+            # message, this process's own fallback model, the plan for a pool
+            # that has not started yet, or a bare default.
+            "runtime_source": runtime_source,
             # The worker count is derived from concurrency and provider now, so
             # Settings must be able to show what it resolved to and what each
             # worker costs — the price is stated, not implied (#312).

--- a/backend/tests/test_worker_liveness_and_fallback.py
+++ b/backend/tests/test_worker_liveness_and_fallback.py
@@ -435,3 +435,101 @@ def test_a_recovery_after_load_still_overrides_the_ready_report():
     recovery = {"recovered_backend": "openvino", "recovered_provider": "intel_cpu"}
 
     assert service._effective_subprocess_runtime_fields(recovery, worker_runtime) == ("openvino", "intel_cpu")
+
+
+def _subprocess_service(monkeypatch, *, planned_backend="openvino", planned_provider="intel_npu"):
+    from app.services import classifier_service as module
+    from app.services.classifier_service import ClassifierService
+
+    service = ClassifierService()
+    service._image_execution_mode = "subprocess"
+    service._resolve_active_model_id = lambda: "rope_vit_b14_inat21"
+    service._resolve_active_bird_model_spec = lambda: {
+        "model_id": "rope_vit_b14_inat21",
+        "runtime": "onnx",
+        "supported_inference_providers": ["cpu", "intel_cpu", "intel_npu"],
+        "host_provider_preference_order": ["intel_npu", "cpu"],
+    }
+    monkeypatch.setattr(
+        module,
+        "_resolve_inference_selection",
+        lambda *_a, **_k: {"backend": planned_backend, "active_provider": planned_provider, "fallback_reason": None},
+    )
+    return service
+
+
+def test_before_any_worker_has_loaded_status_names_the_planned_runtime(monkeypatch):
+    """Pools start on the first visit. Until then the parent must say what a
+    worker will load, resolved the way the worker resolves it, not "tflite"."""
+    service = _subprocess_service(monkeypatch)
+    empty_pools = {"live": {"workers": 0, "runtime": None}, "background": {"workers": 0, "runtime": None}}
+
+    assert service._subprocess_runtime_identity(empty_pools) == ("openvino", "intel_npu", "planned")
+
+
+def test_a_workers_report_outranks_the_plan(monkeypatch):
+    service = _subprocess_service(monkeypatch, planned_provider="intel_npu")
+    pools = {
+        "live": {
+            "workers": 1,
+            "runtime": {
+                "inference_backend": "openvino",
+                "active_provider": "intel_cpu",
+                "model_id": "rope_vit_b14_inat21",
+            },
+        }
+    }
+
+    assert service._subprocess_runtime_identity(pools) == ("openvino", "intel_cpu", "worker")
+
+
+def test_the_parents_own_fallback_model_outranks_everything(monkeypatch):
+    """When this process has loaded a model to cover for the workers, it is the
+    one classifying, so status and health must name what it loaded."""
+    service = _subprocess_service(monkeypatch)
+
+    class _LoadedModel:
+        loaded = True
+
+    service._models["bird"] = _LoadedModel()
+    service._inference_backend = "onnxruntime"
+    service._active_inference_provider = "cpu"
+    pools = {
+        "live": {
+            "workers": 1,
+            "runtime": {
+                "inference_backend": "openvino",
+                "active_provider": "intel_npu",
+                "model_id": "rope_vit_b14_inat21",
+            },
+        }
+    }
+
+    assert service._subprocess_runtime_identity(pools) == ("onnxruntime", "cpu", "in_process_fallback")
+
+
+def test_a_tflite_model_is_planned_as_tflite(monkeypatch):
+    service = _subprocess_service(monkeypatch)
+    service._resolve_active_bird_model_spec = lambda: {"model_id": "legacy", "runtime": "tflite"}
+
+    assert service._subprocess_runtime_identity({}) == ("tflite", "tflite", "planned")
+
+
+def test_an_unresolvable_plan_falls_back_to_the_bare_default(monkeypatch):
+    service = _subprocess_service(monkeypatch)
+
+    def _no_spec():
+        raise RuntimeError("model manager not ready")
+
+    service._resolve_active_bird_model_spec = _no_spec
+
+    assert service._subprocess_runtime_identity({}) == ("tflite", "tflite", "default")
+
+
+def test_health_keys_use_the_planned_runtime_before_first_load(monkeypatch):
+    service = _subprocess_service(monkeypatch)
+    service._get_supervisor_metrics = lambda: {"live": {"workers": 0, "runtime": None}}
+
+    key = service._active_inference_runtime_key()
+
+    assert (key.backend, key.provider) == ("openvino", "intel_npu")


### PR DESCRIPTION
## Outcome

After a restart, the Detection tab names the runtime that will load and says it loads on first detection, instead of "tflite, not yet verified here". Found on the reference install straight after deploying #404: pools start lazily, so until the first bird no worker exists to report anything and the previous fix had nothing to show.

## Scope

- **Included:** `_planned_subprocess_runtime()` resolves the provider with the same pure resolver the loader uses, from the active model spec, the last-known capabilities and the provider preference. `_subprocess_runtime_identity()` orders the sources: the parent's own fallback model, then a worker's report, then the plan, then the default. Status carries `runtime_source`; the health key uses the same identity. UI: `runtime_source` on the status type, a "loads on first detection" line in the band ahead of the verified mark, the key in all nine locales, and a layout test. `ISSUES.md` records the SSE token appearing in nginx's error log during boot.
- **Explicitly excluded:** starting the pools eagerly at boot, which is a memory and startup-time decision; the stream-ticket change that would keep tokens out of nginx's error log.
- **Issue or roadmap outcome:** follow-up to #404 and #300.

## Verification

```text
backend$ pytest tests/test_worker_liveness_and_fallback.py tests/test_classifier_status_api.py tests/test_classifier_service.py
206 passed

backend$ pytest
2744 passed, 49 skipped in 62.31s

apps/ui$ npm run check
0 errors, 0 warnings

apps/ui$ npm test
184 files, 1011 tests passed

$ ruff check . && ruff format --check .
All checks passed!
```

## Data integrity and risk

- Detection-history or configuration risk: none.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none added. The token-in-log finding is pre-existing and documented.
- Deployment verification, if deployed: to follow on the reference install after merge.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.
