### PR TITLE
Resolve names for the startup backfill without holding a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **The startup identity backfill no longer holds a database connection while it consults the
+  catalogue.** On every container start it took one of the five pooled connections and kept it for
+  the whole pass, resolving each distinct scientific name through the species catalogue, which is a
+  different database, before writing anything. On the reference install that was a 1.2 second hold
+  and a "Slow DB connection hold" warning on every boot; on an older install with hundreds of names
+  it would have sat in front of the dashboard's first load after each restart. The pass now reads
+  the names, gives the connection back, resolves them all, and takes a connection again only to
+  write. An unavailable catalogue now writes nothing rather than half a pass.
+
 - **Before the first visit of the day, the Detection tab names the runtime that will load.** Worker
   pools start on the first classification, so between a restart and the first bird nothing has
   loaded anywhere and the band fell back to the API process's idle default, "tflite, not yet

--- a/backend/app/repositories/detection_repository.py
+++ b/backend/app/repositories/detection_repository.py
@@ -4924,19 +4924,8 @@ class DetectionRepository:
             "sources": sources,
         }
 
-    async def backfill_audio_species_ids(self, *, resolver: Any = None, batch_size: int = 500) -> dict[str, int]:
-        """Give existing audio detections the identity new ones will carry.
-
-        Required rather than optional: grouping audio by identity while older
-        rows have none would split a species at the upgrade boundary, which is
-        the exact failure this phase removes.
-
-        Conservative and idempotent. Only rows with no identity are considered,
-        a name is resolved once rather than per row, and anything the catalogue
-        cannot pin to exactly one species is counted and left alone.
-        """
-        from app.services.audio_identity import resolve_audio_identity
-
+    async def pending_audio_scientific_names(self) -> list[tuple[str, int]]:
+        """Distinct names on audio rows that carry no identity yet, with row counts."""
         async with self.db.execute(
             """
             SELECT scientific_name, COUNT(*) FROM audio_detections
@@ -4944,12 +4933,17 @@ class DetectionRepository:
             GROUP BY scientific_name
             """
         ) as cursor:
-            pending = await cursor.fetchall()
+            rows = await cursor.fetchall()
+        return [(str(name), int(count or 0)) for name, count in rows]
 
+    async def assign_audio_species_ids(
+        self, pending: list[tuple[str, int]], identities: dict[str, Optional[int]]
+    ) -> dict[str, int]:
+        """Write resolved identities onto audio rows; names with no identity are counted and left."""
         identified = 0
         unresolved = 0
         for scientific_name, row_count in pending:
-            species_id = resolve_audio_identity(scientific_name, resolver=resolver)
+            species_id = identities.get(scientific_name)
             if species_id is None:
                 unresolved += int(row_count or 0)
                 continue
@@ -4965,6 +4959,25 @@ class DetectionRepository:
         if identified:
             await self.db.commit()
         return {"identified": identified, "unresolved": unresolved, "names_seen": len(pending)}
+
+    async def backfill_audio_species_ids(self, *, resolver: Any = None, batch_size: int = 500) -> dict[str, int]:
+        """Give existing audio detections the identity new ones will carry.
+
+        Required rather than optional: grouping audio by identity while older
+        rows have none would split a species at the upgrade boundary, which is
+        the exact failure this phase removes.
+
+        Conservative and idempotent. Only rows with no identity are considered,
+        a name is resolved once rather than per row, and anything the catalogue
+        cannot pin to exactly one species is counted and left alone. Resolves
+        on the caller's connection; the startup backfill resolves first and
+        calls :meth:`assign_audio_species_ids` so the pool is not held meanwhile.
+        """
+        from app.services.audio_identity import resolve_audio_identity
+
+        pending = await self.pending_audio_scientific_names()
+        identities = {name: resolve_audio_identity(name, resolver=resolver) for name, _count in pending}
+        return await self.assign_audio_species_ids(pending, identities)
 
     async def get_audio_species_counts(
         self,

--- a/backend/app/services/species_catalog_backfill.py
+++ b/backend/app/services/species_catalog_backfill.py
@@ -42,12 +42,8 @@ def _record_summary(summary: dict[str, Any]) -> None:
         _last_summary = dict(summary)
 
 
-async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolver] = None) -> dict[str, Any]:
-    """Fill `species_id` on rows whose scientific name resolves unambiguously."""
-    active_resolver = resolver or species_catalog_resolver
-    repository = DetectionRepository(db)
-
-    summary: dict[str, Any] = {
+def _new_summary() -> dict[str, Any]:
+    return {
         "status": "complete",
         "names_resolved": 0,
         "names_ambiguous": 0,
@@ -57,13 +53,73 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
         "rows_repaired": 0,
     }
 
-    names = await repository.distinct_scientific_names_without_identity()
+
+async def _read_names(repository: DetectionRepository) -> tuple[list[str], list[str], list[tuple[str, int]]]:
+    """Everything the backfill works from: detection names without identity,
+    detection names with one, and audio names without one."""
+    without_identity = await repository.distinct_scientific_names_without_identity()
+    with_identity = await repository.distinct_scientific_names_with_identity()
+    try:
+        pending_audio = await repository.pending_audio_scientific_names()
+    except Exception as error:  # pragma: no cover - defensive, as the audio pass always was
+        log.warning("Audio identity backfill skipped", error=str(error))
+        pending_audio = []
+    return without_identity, with_identity, pending_audio
+
+
+async def _resolve_audio_identities(pending: list[tuple[str, int]], resolver: SpeciesCatalogResolver) -> dict:
+    """The audio identities, resolved off any database connection."""
+    from app.services.audio_identity import resolve_audio_identity
+
+    identities: dict[str, Optional[int]] = {}
+    for name, _count in pending:
+        identities[name] = await asyncio.to_thread(resolve_audio_identity, name, resolver=resolver)
+    return identities
+
+
+async def _resolve_names(
+    names: list[str], resolver: SpeciesCatalogResolver
+) -> Optional[list[tuple[str, Optional[int], Optional[str]]]]:
+    """Ask the catalogue about each name. Needs no database connection.
+
+    Returns ``None`` when the catalogue is unavailable, so a caller writes
+    nothing rather than half of a pass.
+    """
+    resolved: list[tuple[str, Optional[int], Optional[str]]] = []
     for name in names:
-        species_id, reason = await asyncio.to_thread(active_resolver.resolve_scientific_name, name)
+        species_id, reason = await asyncio.to_thread(resolver.resolve_scientific_name, name)
         if reason == "unavailable":
-            summary["status"] = "unavailable"
-            _record_summary(summary)
-            return summary
+            return None
+        resolved.append((name, species_id, reason))
+    return resolved
+
+
+IdentityPlan = tuple[
+    list[tuple[str, Optional[int], Optional[str]]],
+    list[tuple[str, Optional[int], Optional[str]]],
+    list[tuple[str, int]],
+    dict[str, Optional[int]],
+]
+
+
+async def _resolve_plan(
+    names: tuple[list[str], list[str], list[tuple[str, int]]], resolver: SpeciesCatalogResolver
+) -> Optional[IdentityPlan]:
+    """Consult the catalogue for every name read; needs no database connection."""
+    without_identity, with_identity, pending_audio = names
+    resolved_without = await _resolve_names(without_identity, resolver)
+    if resolved_without is None:
+        return None
+    resolved_with = await _resolve_names(with_identity, resolver)
+    if resolved_with is None:
+        return None
+    audio_identities = await _resolve_audio_identities(pending_audio, resolver)
+    return resolved_without, resolved_with, pending_audio, audio_identities
+
+
+async def _apply_plan(repository: DetectionRepository, plan: IdentityPlan, summary: dict[str, Any]) -> None:
+    resolved_without, resolved_with, _pending_audio, _audio_identities = plan
+    for name, species_id, reason in resolved_without:
         if species_id is not None:
             summary["names_resolved"] += 1
             summary["rows_identified"] += await repository.assign_species_id_by_scientific_name(name, species_id)
@@ -71,16 +127,10 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
             summary["names_ambiguous"] += 1
         else:
             summary["names_unresolved"] += 1
-
     # A row whose identity contradicts its own scientific name is a manual
     # correction from before corrections carried identity. The name is the
     # owner's word; the stale id is not, and it splits the leaderboard.
-    for name in await repository.distinct_scientific_names_with_identity():
-        species_id, reason = await asyncio.to_thread(active_resolver.resolve_scientific_name, name)
-        if reason == "unavailable":
-            summary["status"] = "unavailable"
-            _record_summary(summary)
-            return summary
+    for name, species_id, _reason in resolved_with:
         if species_id is None:
             continue
         repaired = await repository.repair_species_id_by_scientific_name(name, species_id)
@@ -88,19 +138,23 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
             summary["names_repaired"] += 1
             summary["rows_repaired"] += repaired
 
+
+async def _backfill_audio_and_overrides(
+    db, repository: DetectionRepository, plan: IdentityPlan, summary: dict[str, Any]
+) -> None:
     # Audio detections carry the same identity, for the same reason: grouping
     # audio by identity while older rows have none would split a species at the
     # upgrade boundary. Reported separately so an audio-only shortfall is
     # visible rather than folded into the detection numbers.
+    _without, _with, pending_audio, audio_identities = plan
     try:
-        audio = await repository.backfill_audio_species_ids(resolver=active_resolver)
+        audio = await repository.assign_audio_species_ids(pending_audio, audio_identities)
         summary["audio_rows_identified"] = audio.get("identified", 0)
         summary["audio_rows_unresolved"] = audio.get("unresolved", 0)
     except Exception as error:  # pragma: no cover - defensive
         log.warning("Audio identity backfill skipped", error=str(error))
         summary["audio_rows_identified"] = 0
         summary["audio_rows_unresolved"] = 0
-
     # Owner renames move to the catalogue in the same pass, because they are
     # the one piece of naming the owner authored and they were living in a
     # cache of provider answers.
@@ -115,17 +169,61 @@ async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolve
         summary["overrides_migrated"] = 0
         summary["overrides_unresolved"] = 0
 
+
+async def backfill_catalog_identity(db, resolver: Optional[SpeciesCatalogResolver] = None) -> dict[str, Any]:
+    """Fill `species_id` on rows whose scientific name resolves unambiguously.
+
+    Works on a connection the caller already holds. The startup task uses
+    :func:`backfill_catalog_identity_in_short_holds` instead, so the pool is
+    not tied up while the catalogue is consulted.
+    """
+    active_resolver = resolver or species_catalog_resolver
+    repository = DetectionRepository(db)
+    summary = _new_summary()
+    plan = await _resolve_plan(await _read_names(repository), active_resolver)
+    if plan is None:
+        summary["status"] = "unavailable"
+        _record_summary(summary)
+        return summary
+    await _apply_plan(repository, plan, summary)
+    await _backfill_audio_and_overrides(db, repository, plan, summary)
+    _record_summary(summary)
+    return summary
+
+
+async def backfill_catalog_identity_in_short_holds(
+    resolver: Optional[SpeciesCatalogResolver] = None,
+) -> dict[str, Any]:
+    """The same backfill, holding a pooled connection only to read and to write.
+
+    Resolving a name means consulting the catalogue, which is not this
+    database, and there can be hundreds of names on an older install. Holding
+    one of the pool's five connections for the whole pass, at startup, put the
+    backfill in front of the dashboard's first load on every restart.
+    """
+    from app.database import get_db
+
+    active_resolver = resolver or species_catalog_resolver
+    summary = _new_summary()
+    async with get_db() as db:
+        names = await _read_names(DetectionRepository(db))
+    plan = await _resolve_plan(names, active_resolver)
+    if plan is None:
+        summary["status"] = "unavailable"
+        _record_summary(summary)
+        return summary
+    async with get_db() as db:
+        repository = DetectionRepository(db)
+        await _apply_plan(repository, plan, summary)
+        await _backfill_audio_and_overrides(db, repository, plan, summary)
     _record_summary(summary)
     return summary
 
 
 async def start_background_catalog_backfill() -> None:
     """Run the backfill detached from startup; never fatal, always reported."""
-    from app.database import get_db
-
     try:
-        async with get_db() as db:
-            summary = await backfill_catalog_identity(db)
+        summary = await backfill_catalog_identity_in_short_holds()
         log.info("Catalogue identity backfill finished", **summary)
     except Exception as error:
         _record_summary({"status": "failed", "error": str(error)})

--- a/backend/tests/test_species_catalog_backfill.py
+++ b/backend/tests/test_species_catalog_backfill.py
@@ -301,3 +301,106 @@ async def test_a_missing_catalogue_reports_and_changes_nothing(tmp_path):
         results = await _species_ids(db)
         assert results["evt-tit"][0] is None
         assert summary["status"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# The startup task holds a pooled connection only to read and to write
+# ---------------------------------------------------------------------------
+
+
+class _RecordingResolver:
+    """Answers like an empty catalogue and notes whether a pooled connection
+    was held by the calling task at the moment it was consulted."""
+
+    def __init__(self, reason: str = "unresolved"):
+        self.reason = reason
+        self.held_labels: list = []
+
+    def resolve_scientific_name(self, _name):
+        from app.database import _acquire_label
+
+        self.held_labels.append(_acquire_label.get())
+        return None, self.reason
+
+
+async def _seed_pool_detection(event_id: str, scientific_name: str) -> None:
+    from datetime import datetime, timezone
+
+    from app.database import get_db
+
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO detections (detection_time, detection_index, score, display_name, category_name,
+                                       frigate_event, camera_name, scientific_name, is_hidden)
+               VALUES (?, 1, 0.9, ?, 'bird', ?, 'garden', ?, 0)""",
+            (datetime.now(timezone.utc).isoformat(sep=" "), scientific_name, event_id, scientific_name),
+        )
+        await db.commit()
+
+
+async def _delete_pool_detection(event_id: str) -> None:
+    from app.database import get_db
+
+    async with get_db() as db:
+        await db.execute("DELETE FROM detections WHERE frigate_event = ?", (event_id,))
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_the_startup_backfill_never_consults_the_catalogue_under_a_held_connection():
+    from app.database import init_db
+    from app.services.species_catalog_backfill import backfill_catalog_identity_in_short_holds
+
+    await init_db()
+    resolver = _RecordingResolver()
+    await _seed_pool_detection("evt-short-hold", "Nonexistus shorthold")
+    try:
+        summary = await backfill_catalog_identity_in_short_holds(resolver=resolver)
+    finally:
+        await _delete_pool_detection("evt-short-hold")
+
+    assert summary["status"] == "complete"
+    assert summary["names_unresolved"] >= 1
+    assert resolver.held_labels, "the catalogue was never consulted"
+    assert all(label is None for label in resolver.held_labels), (
+        f"the catalogue was consulted while a pooled connection was held: {resolver.held_labels}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_startup_backfill_writes_nothing_when_the_catalogue_is_unavailable():
+    from app.database import get_db, init_db
+    from app.services.species_catalog_backfill import backfill_catalog_identity_in_short_holds
+
+    await init_db()
+    await _seed_pool_detection("evt-unavailable", "Cyanistes caeruleus")
+    try:
+        summary = await backfill_catalog_identity_in_short_holds(resolver=_RecordingResolver("unavailable"))
+        async with get_db() as db:
+            async with db.execute(
+                "SELECT species_id FROM detections WHERE frigate_event = ?", ("evt-unavailable",)
+            ) as cursor:
+                row = await cursor.fetchone()
+    finally:
+        await _delete_pool_detection("evt-unavailable")
+
+    assert summary["status"] == "unavailable"
+    assert row is not None and row[0] is None
+
+
+@pytest.mark.asyncio
+async def test_the_held_connection_variant_still_resolves_and_writes_in_one_pass(catalog):
+    """The signature callers already use keeps its behaviour; only the startup
+    task changed how it holds the pool."""
+    resolver = SpeciesCatalogResolver(catalog)
+    async with aiosqlite.connect(":memory:") as db:
+        await _seed_detections(
+            db, [("evt-tit", "Cyanistes caeruleus", None), ("evt-unknown", "Nonexistus maximus", None)]
+        )
+
+        summary = await backfill_catalog_identity(db, resolver=resolver)
+
+        results = await _species_ids(db)
+        assert results["evt-tit"][0] is not None
+        assert results["evt-unknown"][0] is None
+        assert (summary["names_resolved"], summary["names_unresolved"]) == (1, 1)


### PR DESCRIPTION
## Outcome

The catalogue identity backfill that runs on every container start no longer holds a pooled database connection while it consults the species catalogue. The "Slow DB connection hold" warning on every boot of the reference install goes away, and an older install with hundreds of distinct names no longer has the backfill sitting in front of the dashboard's first load after a restart.

## Scope

- **Included:** the backfill is split into read, resolve, and write phases. The startup task uses `backfill_catalog_identity_in_short_holds()`, which holds a connection only for the read and the write. `backfill_catalog_identity(db)` keeps its signature and behaviour for callers that already hold a connection. The audio backfill is split in the repository into `pending_audio_scientific_names()` and `assign_audio_species_ids()`, with `backfill_audio_species_ids()` kept as their composition. An unavailable catalogue now writes nothing rather than half a pass. A missing audio table is tolerated as it always was.
- **Explicitly excluded:** the audio identity resolver's synchronous call in the held-connection variant; the override migration, which is database work.
- **Issue or roadmap outcome:** follow-up to #300 and #392, same family.

## Verification

```text
backend$ pytest tests/test_species_catalog_backfill.py tests/test_audio_canonical_identity.py tests/test_species_catalog_overrides.py
37 passed

backend$ pytest
2747 passed, 49 skipped in 61.68s

$ ruff check . && ruff format --check .
All checks passed!
```

The new test seeds a row through the pool, runs the startup variant with a resolver that records whether a connection was held at the moment it was consulted, and asserts it never was. On its first run it failed on the audio pass, which is how that second hold was found.

## Data integrity and risk

- Detection-history or configuration risk: none. Same writes, same idempotence; an unavailable catalogue now writes nothing instead of a partial pass.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: to follow on the reference install after merge.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.
