### PR TITLE
Key inference-health samples on the runtime that classified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **Inference health is keyed on the runtime that did the work.** The entry the Detection tab reads
+  was named "tflite/tflite/<model>" on an install classifying through OpenVINO on the NPU, because
+  the admission context that stamps each sample copied the API process's idle defaults rather than
+  what the worker loaded. It now uses the same identity the status band uses.
+
 - **The startup identity backfill no longer holds a database connection while it consults the
   catalogue.** On every container start it took one of the five pooled connections and kept it for
   the whole pass, resolving each distinct scientific name through the species catalogue, which is a

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -6028,9 +6028,14 @@ class ClassifierService:
                 resolved_model_id = self._resolve_active_model_id()
             except Exception:
                 resolved_model_id = "unknown"
+        backend, provider = self._inference_backend, self._active_inference_provider
+        if self._image_execution_mode == "subprocess" and not self._worker_process_mode:
+            # Samples recorded here describe work a worker did, or the plan
+            # for one; the parent's own idle defaults name neither.
+            backend, provider, _source = self._subprocess_runtime_identity(self._get_supervisor_metrics())
         return {
-            "backend": self._inference_backend,
-            "provider": self._active_inference_provider,
+            "backend": backend,
+            "provider": provider,
             "model_id": resolved_model_id,
             "execution_mode": self._image_execution_mode,
         }

--- a/backend/tests/test_worker_liveness_and_fallback.py
+++ b/backend/tests/test_worker_liveness_and_fallback.py
@@ -533,3 +533,39 @@ def test_health_keys_use_the_planned_runtime_before_first_load(monkeypatch):
     key = service._active_inference_runtime_key()
 
     assert (key.backend, key.provider) == ("openvino", "intel_npu")
+
+
+def test_admission_samples_are_keyed_on_the_runtime_that_classified(monkeypatch):
+    """The dashboard's health entry was "tflite/tflite/<model>" on an NPU install
+    because the admission context copied the parent's idle defaults."""
+    service = _subprocess_service(monkeypatch)
+    service._get_supervisor_metrics = lambda: {
+        "live": {
+            "workers": 1,
+            "runtime": {
+                "inference_backend": "openvino",
+                "active_provider": "intel_npu",
+                "model_id": "rope_vit_b14_inat21",
+            },
+        }
+    }
+
+    context = service._classification_admission_context()
+    key = service._inference_runtime_key_from_context(context)
+
+    assert (context["backend"], context["provider"]) == ("openvino", "intel_npu")
+    assert (key.backend, key.provider, key.model_id) == ("openvino", "intel_npu", "rope_vit_b14_inat21")
+
+
+def test_admission_context_in_process_mode_still_names_the_parents_own_runtime(monkeypatch):
+    from app.services.classifier_service import ClassifierService
+
+    service = ClassifierService()
+    service._image_execution_mode = "in_process"
+    service._inference_backend = "onnxruntime"
+    service._active_inference_provider = "cpu"
+    service._resolve_active_model_id = lambda: "m"
+
+    context = service._classification_admission_context()
+
+    assert (context["backend"], context["provider"]) == ("onnxruntime", "cpu")


### PR DESCRIPTION
## Outcome

The inference-health entry on the Detection tab names the runtime that did the work. Found this morning on the reference install: after the first live worker loaded on the NPU, status said `openvino / intel_npu / worker` while the health entry for the same model said `tflite/tflite`.

## Scope

- **Included:** `_classification_admission_context()` routes backend and provider through `_subprocess_runtime_identity()` in subprocess mode, so the key stamped on each sample matches the status band. In-process mode is unchanged. Two tests.
- **Explicitly excluded:** nothing else.
- **Issue or roadmap outcome:** completes the runtime-identity work in #404 and #405.

## Verification

```text
backend$ pytest tests/test_worker_liveness_and_fallback.py tests/test_classifier_service.py tests/test_classifier_status_api.py
208 passed

backend$ pytest
2749 passed, 49 skipped in 59.28s

$ ruff check . && ruff format --check .
All checks passed!
```

## Data integrity and risk

- Detection-history or configuration risk: none.
- Migration/recovery path, if data changes: not applicable.
- Security or secret-handling risk: none.
- Deployment verification, if deployed: to follow on the reference install.

## Checklist

- [x] The change is one reviewable behaviour or maintenance slice.
- [x] Focused tests and the repository Definition of Done pass.
- [x] `CHANGELOG.md` and maintained documentation are current where needed.
- [x] Schema changes include a reversible migration and retain one Alembic head.
- [x] No secret, private runtime data, unrelated work, or generated user media is included.
- [x] Untrusted input, secret redaction, and soft/hard-delete boundaries remain intact.
