### PR TITLE
Raise the ONNX Runtime floor to 1.29 where the images already resolve it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **The ONNX Runtime floor is 1.29 on every CPU-capable image.** The `cpu`, `intel`, and ARM64 `full`
+  requirement files asked for `onnxruntime>=1.28.0`, so pip has been resolving 1.29.0 for weeks anyway;
+  the reference install has run it since it was published. Stating the floor the images actually
+  get lets the dependency-pin test and Dependabot agree with reality. The CUDA build keeps its own
+  `onnxruntime-gpu` window unchanged.
+
 ### Fixed
 
 - **The retention card no longer promises a 3 AM cleanup.** Settings → Data said "Automatic

--- a/backend/requirements-provider-cpu.txt
+++ b/backend/requirements-provider-cpu.txt
@@ -1,2 +1,2 @@
 # Portable ONNX CPU runtime.
-onnxruntime>=1.28.0
+onnxruntime>=1.29.0

--- a/backend/requirements-provider-full.txt
+++ b/backend/requirements-provider-full.txt
@@ -2,5 +2,5 @@
 # the CPU ORT package and omits OpenVINO; the dedicated RPi build selects the CPU
 # provider file directly.
 onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0 ; platform_machine != "aarch64" and platform_machine != "arm64"
-onnxruntime>=1.28.0 ; platform_machine == "aarch64" or platform_machine == "arm64"
+onnxruntime>=1.29.0 ; platform_machine == "aarch64" or platform_machine == "arm64"
 openvino>=2026.3.0,<2027.0 ; platform_machine != "aarch64" and platform_machine != "arm64"

--- a/backend/requirements-provider-intel.txt
+++ b/backend/requirements-provider-intel.txt
@@ -1,3 +1,3 @@
 # ONNX CPU fallback plus OpenVINO CPU/GPU/NPU support.
-onnxruntime>=1.28.0
+onnxruntime>=1.29.0
 openvino>=2026.3.0,<2027.0

--- a/backend/tests/test_dependency_pins.py
+++ b/backend/tests/test_dependency_pins.py
@@ -47,9 +47,9 @@ def test_cpu_onnxruntime_floor_is_consistent_across_runtime_flavors():
         for flavor in ("cpu", "intel", "full")
     }
 
-    assert "onnxruntime>=1.28.0" in requirements["cpu"]
-    assert "onnxruntime>=1.28.0" in requirements["intel"]
-    assert 'onnxruntime>=1.28.0 ; platform_machine == "aarch64"' in requirements["full"]
+    assert "onnxruntime>=1.29.0" in requirements["cpu"]
+    assert "onnxruntime>=1.29.0" in requirements["intel"]
+    assert 'onnxruntime>=1.29.0 ; platform_machine == "aarch64"' in requirements["full"]
     assert "onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0" in requirements["full"]
 
 


### PR DESCRIPTION
## Outcome

The declared `onnxruntime` floor matches what every CPU-capable image has actually been installing.

## Why

`requirements-provider-cpu.txt`, `-intel.txt` and the ARM64 line of `-full.txt` said `onnxruntime>=1.28.0`. That is a floor, so pip resolves the newest release: the `dev-intel` image on the reference install reports `onnxruntime 1.29.0` today. Dependabot #283 tried to raise the floor but touched only the `cpu` file, and `test_dependency_pins.py::test_cpu_onnxruntime_floor_is_consistent_across_runtime_flavors` rightly refused a floor that differs across flavours.

## Included

- The three floors move to `>=1.29.0` together, and the test's expected strings with them.
- `CHANGELOG.md` Unreleased → Changed.

## Excluded

- `onnxruntime-gpu` (CUDA and x86 `full`) keeps `>=1.24.0,<1.27.0`. It is a different package with a CUDA-13 packaging caveat and nothing here can exercise it; Dependabot #284 stays open for a separate decision.

## Verification

- `pytest tests/test_dependency_pins.py`: 4 passed.
- `ruff check` / `ruff format --check` clean on the changed test.
- No code path changes; the resolved package on the reference install is already 1.29.0, so the built image will not differ.

## Risk

None to behaviour. Supersedes Dependabot #283, which will be closed once this merges.
