### PR TITLE
Label every published image with its git revision

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -428,6 +428,13 @@ jobs:
             GIT_HASH=${{ env.SHORT_SHA }}
             APP_VERSION_BASE=${{ env.APP_VERSION_BASE }}
             APP_BRANCH=${{ env.APP_BRANCH }}
+          # OCI labels tie a pulled image to its commit for `docker inspect` and Dockhand.
+          # The in-app update prompt ignores them: it compares the GIT_HASH build-arg
+          # with the commit published to D1, so adding a label cannot trigger a prompt.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/wamf-backend:${{ env.IMAGE_TAG }}
             ghcr.io/${{ env.OWNER_LC }}/wamf-backend:${{ github.sha }}
@@ -501,6 +508,13 @@ jobs:
             GIT_HASH=${{ env.SHORT_SHA }}
             APP_VERSION_BASE=${{ env.APP_VERSION_BASE }}
             APP_BRANCH=${{ env.APP_BRANCH }}
+          # OCI labels tie a pulled image to its commit for `docker inspect` and Dockhand.
+          # The in-app update prompt ignores them: it compares the GIT_HASH build-arg
+          # with the commit published to D1, so adding a label cannot trigger a prompt.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/wamf-frontend:${{ env.IMAGE_TAG }}
             ghcr.io/${{ env.OWNER_LC }}/wamf-frontend:${{ github.sha }}
@@ -593,6 +607,13 @@ jobs:
             APP_VERSION_BASE=${{ env.APP_VERSION_BASE }}
             APP_BRANCH=${{ env.APP_BRANCH }}
             RUNTIME_FLAVOR=${{ matrix.flavor }}
+          # OCI labels tie a pulled image to its commit for `docker inspect` and Dockhand.
+          # The in-app update prompt ignores them: it compares the GIT_HASH build-arg
+          # with the commit published to D1, so adding a label cannot trigger a prompt.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ github.sha }}${{ matrix.suffix }}
           cache-from: type=gha,scope=monolith-${{ matrix.flavor }}
@@ -673,6 +694,13 @@ jobs:
             APP_VERSION_BASE=${{ env.APP_VERSION_BASE }}
             APP_BRANCH=${{ env.APP_BRANCH }}
             RUNTIME_FLAVOR=rpi
+          # OCI labels tie a pulled image to its commit for `docker inspect` and Dockhand.
+          # The in-app update prompt ignores them: it compares the GIT_HASH build-arg
+          # with the commit published to D1, so adding a label cannot trigger a prompt.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ github.sha }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **Every published image names its commit.** Each image now carries the OCI
+  `org.opencontainers.image.revision`, `version`, and `source` labels, so `docker inspect` and
+  Dockhand can tie a running container to the exact build without opening the app. The update
+  prompt is unaffected: it still compares the commit baked in at build time with the one
+  published for your channel, and never reads image labels.
 - **The ONNX Runtime floor is 1.29 on every CPU-capable image.** The `cpu`, `intel`, and ARM64 `full`
   requirement files asked for `onnxruntime>=1.28.0`, so pip has been resolving 1.29.0 for weeks anyway;
   the reference install has run it since it was published. Stating the floor the images actually

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Changed
+
+- **The ONNX Runtime floor is 1.29 on every CPU-capable image.** The `cpu`, `intel`, and ARM64 `full`
+  requirement files asked for `onnxruntime>=1.28.0`, so pip has been resolving 1.29.0 for weeks anyway;
+  the reference install has run it since it was published. Stating the floor the images actually
+  get lets the dependency-pin test and Dependabot agree with reality. The CUDA build keeps its own
+  `onnxruntime-gpu` window unchanged.
+
 ### Fixed
 
 - **The retention card no longer promises a 3 AM cleanup.** Settings → Data said "Automatic

--- a/backend/requirements-provider-cpu.txt
+++ b/backend/requirements-provider-cpu.txt
@@ -1,2 +1,2 @@
 # Portable ONNX CPU runtime.
-onnxruntime>=1.28.0
+onnxruntime>=1.29.0

--- a/backend/requirements-provider-full.txt
+++ b/backend/requirements-provider-full.txt
@@ -2,5 +2,5 @@
 # the CPU ORT package and omits OpenVINO; the dedicated RPi build selects the CPU
 # provider file directly.
 onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0 ; platform_machine != "aarch64" and platform_machine != "arm64"
-onnxruntime>=1.28.0 ; platform_machine == "aarch64" or platform_machine == "arm64"
+onnxruntime>=1.29.0 ; platform_machine == "aarch64" or platform_machine == "arm64"
 openvino>=2026.3.0,<2027.0 ; platform_machine != "aarch64" and platform_machine != "arm64"

--- a/backend/requirements-provider-intel.txt
+++ b/backend/requirements-provider-intel.txt
@@ -1,3 +1,3 @@
 # ONNX CPU fallback plus OpenVINO CPU/GPU/NPU support.
-onnxruntime>=1.28.0
+onnxruntime>=1.29.0
 openvino>=2026.3.0,<2027.0

--- a/backend/tests/test_dependency_pins.py
+++ b/backend/tests/test_dependency_pins.py
@@ -47,9 +47,9 @@ def test_cpu_onnxruntime_floor_is_consistent_across_runtime_flavors():
         for flavor in ("cpu", "intel", "full")
     }
 
-    assert "onnxruntime>=1.28.0" in requirements["cpu"]
-    assert "onnxruntime>=1.28.0" in requirements["intel"]
-    assert 'onnxruntime>=1.28.0 ; platform_machine == "aarch64"' in requirements["full"]
+    assert "onnxruntime>=1.29.0" in requirements["cpu"]
+    assert "onnxruntime>=1.29.0" in requirements["intel"]
+    assert 'onnxruntime>=1.29.0 ; platform_machine == "aarch64"' in requirements["full"]
     assert "onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0" in requirements["full"]
 
 

--- a/backend/tests/test_deployment_contract.py
+++ b/backend/tests/test_deployment_contract.py
@@ -286,3 +286,22 @@ def test_legacy_intel_gpu_assets_are_pinned_verified_and_do_not_downgrade_gmmlib
     assert "intel-level-zero-gpu-legacy1_${LEGACY_LEVEL_ZERO_VER}_amd64.deb" in dockerfile
     assert "libigdgmm12_22.5.0_amd64.deb" not in dockerfile
     assert "./*.deb" not in dockerfile
+
+
+def test_every_published_image_names_its_git_revision() -> None:
+    """A running container can be tied to its commit with `docker inspect` alone.
+
+    Every image the workflow pushes carries the OCI revision, version, and source
+    labels. The in-app update prompt does not read them: it compares the GIT_HASH
+    build argument with the published commit, so the labels are metadata for
+    operators and Dockhand, never an input to "is there an update?".
+    """
+    workflow = (REPO_ROOT / ".github/workflows/build-and-push.yml").read_text(encoding="utf-8")
+    steps = workflow.split("uses: docker/build-push-action@")[1:]
+    assert len(steps) >= 4, "expected the backend, frontend, monolith and rpi image builds"
+    for step in steps:
+        with_block = step.split("\n      - name:", 1)[0]
+        assert "labels: |" in with_block
+        assert "org.opencontainers.image.revision=${{ github.sha }}" in with_block
+        assert "org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}" in with_block
+        assert "org.opencontainers.image.source=https://github.com/${{ github.repository }}" in with_block

--- a/docs/troubleshooting/diagnostics.md
+++ b/docs/troubleshooting/diagnostics.md
@@ -37,6 +37,23 @@ not mean a missing classifier was reported as ready. Published images are gated 
 inference smoke test, so seeing this phase on a clean image should be treated as a model/storage
 problem and included in a diagnostic bundle.
 
+## Which build is this container?
+
+Every published image carries its commit in an OCI label, so you can name the exact build
+without opening the app:
+
+```bash
+docker inspect yawamf-monalithic \
+  --format '{{index .Config.Labels "org.opencontainers.image.revision"}} {{index .Config.Labels "org.opencontainers.image.version"}} {{index .Config.Labels "io.yawamf.image.flavor"}}'
+```
+
+You should see the full git SHA, the base version, and the image flavour (`full`, `cpu`,
+`intel`, `cuda`, or `rpi`). `GET /api/version` reports the same commit in short form. Quote the
+SHA in a bug report alongside the diagnostics bundle.
+
+The in-app update prompt does not read these labels: it compares the commit baked in at build
+time with the newest published commit for your channel.
+
 ## MQTT pipeline
 If detections are not appearing, prove the path from Frigate to the broker:
 


### PR DESCRIPTION
## Outcome

`docker inspect` on any YA-WAMF image names the commit, base version and source repository that built it. Dockhand's container view and a bug report can cite the exact build without opening the app.

## Included

- `labels:` on all four `docker/build-push-action` steps (split backend, split frontend, the monolith flavour matrix, and the Raspberry Pi build): `org.opencontainers.image.revision=${{ github.sha }}`, `org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}`, `org.opencontainers.image.source`. The promote steps use `imagetools create`, which preserves image config, so the moving `dev*`, `main*` and `latest*` tags carry the labels too.
- `test_deployment_contract.py::test_every_published_image_names_its_git_revision` pins the labels on every build step (red before the workflow change, green after).
- `docs/troubleshooting/diagnostics.md` gains the one-line `docker inspect` recipe.
- `CHANGELOG.md` Unreleased → Changed.

## Interaction with the update mechanism — checked, none

`GET /api/update-status` (`backend/app/services/update_service.py`) compares `GIT_HASH` — the short SHA passed as a build argument and read by `get_git_hash()` in `main.py` — against the `commit_sha` the `publish-version` job writes to D1. Nothing in `backend/app`, the Home Assistant component, or the telemetry worker reads image labels (`grep opencontainers` is empty). The label is inert to the prompt; the contract test's docstring and a comment in the workflow record that boundary so nobody later wires it in by accident.

## Excluded

- No `org.opencontainers.image.created` label: it would need a timestamp step or `docker/metadata-action`, a new action dependency for a value the registry already records.
- No change to the Dockerfile's own `io.yawamf.image.flavor` label.

## Verification

- `pytest tests/test_deployment_contract.py`: 18 passed (17 existing + the new one).
- `test_changelog_heading_check.py` passes; `docs_consistency_check.py` passes; `git diff --check` clean.
- Workflow YAML parses.

## Risk

None to runtime. First real proof is the next `dev` build: `docker inspect` on Quark should print the SHA.

Stacked on #410 so the changelog edits do not conflict; merge #410 first.
