### PR TITLE
Send the session to media routes as a cookie, never in the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Security
 
+- **Media URLs no longer carry the owner's session token.** `<img>` and `<video>` cannot send
+  headers, so every snapshot, thumbnail and clip an owner viewed put the seven-day session in its
+  URL, and any proxy in front of YA-WAMF that logs request lines kept a copy; the reference
+  install's Nginx Proxy Manager log held 482 of them. The browser now holds the session as an
+  `HttpOnly`, `SameSite=Lax` cookie scoped to `/api`, and only read-only media routes and the live
+  stream accept it — settings, deletes and every other write still need the Bearer header, so the
+  cookie adds no cross-site surface. Login and first-run setup set it, logout clears it, and a
+  browser that signed in before the upgrade attaches it once on load through
+  `POST /api/auth/session-cookie`, so nothing needs a fresh login. Clip-thumbnail VTT cues no
+  longer embed the token either. Plain-HTTP installs on a home network still get the cookie; it
+  is marked `Secure` only when the request came over HTTPS.
 - **The live stream no longer puts the owner's session token in a URL.** `EventSource` cannot
   send headers, so the stream authenticated with `?token=<session>`, and nginx writes the full
   request line to its error log whenever the upstream refuses a connection, which it does for a

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -36,12 +36,6 @@ Last reviewed against the GitHub issue tracker on **September 7, 2026**.
 - **Reported cache sizes undercount.** `get_cache_stats` counts `*.jpg` and `*.mp4` only, so the
   `.meta.json` sidecars beside every snapshot are not in the total. On the reference install that
   is 14,712 uncounted files.
-- **Owner media URLs still carry the session token.** `<img>` and `<video>` cannot send headers,
-  so snapshot, thumbnail, clip and spectrogram URLs append `?token=` for an owner. The access log
-  uses a redacting format (`$uri`, no query), so these only reach a log when nginx has to write an
-  *error* line for one — an upstream refused mid-page-load, say — which is rare, unlike the stream
-  that reconnected on every boot. Closing it fully means a media ticket or cookie session; that is
-  a design decision rather than a mechanical one.
 - **API process memory is being watched again.** #314 closed at about 340 MB resident after the
   `MALLOC_ARENA_MAX=2` fix. On the reference install the API process measured 1.49 GB resident
   fourteen hours after a start in subprocess mode, where it holds no model. The RSS sampler is
@@ -58,6 +52,11 @@ Last reviewed against the GitHub issue tracker on **September 7, 2026**.
 
 ## Recently Closed (Context)
 
+- **Owner media URLs no longer carry the session token.** NPM in front of the reference install logs
+  full request URIs; its access log held 482 owner thumbnail and clip URLs with `?token=` on
+  September 8. Media now authenticates with an `HttpOnly`, `SameSite=Lax` session cookie that only
+  read-only media routes and the stream honour. The tokens already in that log stay valid until they
+  expire or the session secret is rotated; the proxy's log format is being changed to drop the query.
 - **The owner's SSE token no longer reaches nginx's error log.** The live stream opens with a
   single-use, 60-second ticket from `POST /api/auth/stream-ticket`, and `/api/sse` refuses the
   session token in its query string. The three lines nginx wrote on the September 8 restart carried

--- a/apps/ui/src/lib/api/auth.test.ts
+++ b/apps/ui/src/lib/api/auth.test.ts
@@ -13,7 +13,7 @@ vi.mock('./core', () => ({
     setAuthToken: setAuthTokenMock,
 }));
 
-import { createStreamTicket, setInitialPassword } from './auth';
+import { createSessionCookie, createStreamTicket, setInitialPassword } from './auth';
 
 describe('setInitialPassword', () => {
     beforeEach(() => {
@@ -114,5 +114,25 @@ describe('createStreamTicket', () => {
         apiFetchMock.mockResolvedValue(new Response('{"detail":"Authentication required"}', { status: 401 }));
 
         await expect(createStreamTicket()).rejects.toThrow();
+    });
+});
+
+describe('createSessionCookie', () => {
+    beforeEach(() => {
+        apiFetchMock.mockReset();
+    });
+
+    it('asks the server to set the media cookie for the session this browser already holds', async () => {
+        apiFetchMock.mockResolvedValue(new Response('{"message":"ok"}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+        await createSessionCookie();
+
+        expect(apiFetchMock).toHaveBeenCalledWith('/api/auth/session-cookie', expect.objectContaining({ method: 'POST' }));
+    });
+
+    it('throws when the session cannot be exchanged, so callers can decide what to do', async () => {
+        apiFetchMock.mockResolvedValue(new Response('{"detail":"Authentication required"}', { status: 401 }));
+
+        await expect(createSessionCookie()).rejects.toThrow();
     });
 });

--- a/apps/ui/src/lib/api/auth.ts
+++ b/apps/ui/src/lib/api/auth.ts
@@ -82,3 +82,18 @@ export async function createStreamTicket(): Promise<StreamTicketResponse> {
 
     return response.json();
 }
+
+/**
+ * Attach this browser's existing session to the media cookie.
+ *
+ * Login and first-run setup set the cookie themselves; this covers a browser that
+ * signed in before the cookie existed and still holds only a bearer token, so its
+ * images keep loading after the upgrade without a fresh login.
+ */
+export async function createSessionCookie(): Promise<void> {
+    const response = await apiFetch(`${API_BASE}/auth/session-cookie`, { method: 'POST', timeoutMs: 10_000 });
+
+    if (!response.ok) {
+        throw new Error(await readApiErrorMessage(response, 'Could not attach the session to media requests'));
+    }
+}

--- a/apps/ui/src/lib/api/core.test.ts
+++ b/apps/ui/src/lib/api/core.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ApiRequestError, apiFetch, fetchWithAbort, handleResponse } from './core';
+import { ApiRequestError, apiFetch, fetchWithAbort, handleResponse, setApiKey, setAuthToken, withAuthParams } from './core';
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -91,5 +91,27 @@ describe('ApiRequestError', () => {
         expect(outcome).toBeInstanceOf(ApiRequestError);
         expect((outcome as ApiRequestError).status).toBe(404);
         expect((outcome as ApiRequestError).message).toBe('Detection not found');
+    });
+});
+
+describe('withAuthParams', () => {
+    afterEach(() => {
+        setAuthToken(null);
+        setApiKey(null);
+    });
+
+    it('never puts the session token in a media URL: the browser sends the session cookie instead', () => {
+        setAuthToken('owner-session-jwt', 168);
+
+        const url = withAuthParams('/api/frigate/evt-1/thumbnail.jpg');
+
+        expect(url).toBe('/api/frigate/evt-1/thumbnail.jpg');
+        expect(url).not.toContain('owner-session-jwt');
+    });
+
+    it('still carries the deprecated API key, which has no cookie equivalent', () => {
+        setApiKey('legacy-key');
+
+        expect(withAuthParams('/api/frigate/evt-1/clip.mp4')).toBe('/api/frigate/evt-1/clip.mp4?api_key=legacy-key');
     });
 });

--- a/apps/ui/src/lib/api/core.ts
+++ b/apps/ui/src/lib/api/core.ts
@@ -30,12 +30,17 @@ function appendQueryParam(url: string, key: string, value: string): string {
     return `${url}${separator}${key}=${encodeURIComponent(value)}`;
 }
 
+/**
+ * Media URLs for `<img>`, `<video>` and `<audio>`, which cannot send headers.
+ *
+ * The session is never put in the query string: every proxy in front of YA-WAMF
+ * logs request URIs, and a session token there is a week of owner access per
+ * thumbnail. A signed-in browser holds the session as an HttpOnly cookie that the
+ * media routes accept instead (see `createSessionCookie`). Only the deprecated
+ * API key, which has no cookie form, still rides in the URL.
+ */
 export function withAuthParams(url: string): string {
     const normalizedUrl = normalizeBackendPath(url);
-    const token = getAuthToken();
-    if (token) {
-        return appendQueryParam(normalizedUrl, 'token', token);
-    }
     if (apiKey) {
         return appendQueryParam(normalizedUrl, 'api_key', apiKey);
     }

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -2174,6 +2174,15 @@ export interface paths {
       response: components['schemas']['MessageResponse'];
     };
   };
+  "/api/auth/session-cookie": {
+    post: {
+      operationId: "create_session_cookie_api_auth_session_cookie_post";
+      path: never;
+      query: never;
+      requestBody: unknown;
+      response: components['schemas']['MessageResponse'];
+    };
+  };
   "/api/auth/status": {
     get: {
       operationId: "get_auth_status_api_auth_status_get";

--- a/apps/ui/src/lib/stores/auth.svelte.ts
+++ b/apps/ui/src/lib/stores/auth.svelte.ts
@@ -1,4 +1,5 @@
 import {
+    createSessionCookie,
     fetchAuthStatus,
     getAuthToken,
     login as apiLogin,
@@ -100,6 +101,11 @@ class AuthStore {
             this.publicAccessAllowClipDownloads = status.public_access_allow_clip_downloads ?? false;
             this.needsInitialSetup = status.needs_initial_setup ?? false;
             this.isAuthenticated = status.is_authenticated;
+            if (this.token && status.is_authenticated) {
+                // Media loads with the session cookie, not a token in the URL. A browser
+                // that signed in before the cookie existed still needs one attached.
+                void createSessionCookie().catch(() => undefined);
+            }
             this.username = status.username ?? null;
             this.httpsWarning = status.https_warning ?? false;
             this.birdnetEnabled = status.birdnet_enabled ?? false;

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,8 +6,11 @@ Supports both owner (full access) and guest (public read-only) auth levels.
 
 from datetime import datetime, timedelta, timezone
 from typing import Optional
+import re
 import secrets
 from dataclasses import dataclass
+
+from fastapi import Response
 from fastapi import HTTPException, Request, status, Depends, Security
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials, APIKeyHeader, APIKeyQuery
 import jwt
@@ -145,6 +148,66 @@ def verify_token(token: str) -> TokenData:
         )
 
 
+SESSION_COOKIE = "yawamf_session"
+
+# The only routes a cookie may authorise. `<img>`, `<video>` and `EventSource`
+# cannot send headers, so these carry the session in a cookie the browser adds
+# by itself. Everything else keeps requiring a Bearer header, which a cross-site
+# page cannot forge, so the cookie adds no CSRF surface. Read-only methods only.
+_COOKIE_METHODS = frozenset({"GET", "HEAD"})
+_COOKIE_ROUTES = (
+    re.compile(
+        r"^/api/frigate/[^/]+/(snapshot\.jpg|thumbnail\.jpg|clip\.mp4|recording-clip\.mp4|clip-thumbnails\.(vtt|jpg))$"
+    ),
+    re.compile(r"^/api/frigate/[^/]+/snapshot/(original\.jpg|candidates/[^/]+/(image|thumbnail)\.jpg)$"),
+    re.compile(r"^/api/frigate/camera/[^/]+/latest\.jpg$"),
+    re.compile(r"^/api/audio/(spectrogram|clip)/[^/]+$"),
+    re.compile(r"^/api/sse$"),
+)
+
+
+def session_cookie_allowed(request: Request) -> bool:
+    """Whether this request is one the session cookie is permitted to authorise."""
+    if request.method not in _COOKIE_METHODS:
+        return False
+    path = request.url.path
+    return any(route.match(path) for route in _COOKIE_ROUTES)
+
+
+def session_cookie_token(request: Request) -> Optional[TokenData]:
+    """The session carried in the cookie, or None when absent, expired or forged."""
+    raw = request.cookies.get(SESSION_COOKIE)
+    if not raw:
+        return None
+    try:
+        return verify_token(raw)
+    except HTTPException:
+        return None
+
+
+def set_session_cookie(response: Response, token: str, request: Request) -> None:
+    """Attach the session to the browser as an HttpOnly cookie scoped to /api.
+
+    ``Secure`` follows the request scheme (behind a trusted proxy that is the
+    forwarded one), so a plain-HTTP LAN install still receives the cookie.
+    """
+    from app.config import settings
+
+    response.set_cookie(
+        SESSION_COOKIE,
+        token,
+        max_age=int(settings.auth.session_expiry_hours) * 3600,
+        path="/api",
+        httponly=True,
+        secure=request.url.scheme == "https",
+        samesite="lax",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(SESSION_COOKIE, path="/api")
+
+
 async def get_auth_context(
     request: Request, credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)
 ) -> AuthContext:
@@ -190,6 +253,13 @@ async def get_auth_context(
             # Invalid token - fall through to public access check
             log.debug("Invalid token provided, checking public access")
             pass
+
+    # A session cookie may authorise read-only media and the stream, and nothing else.
+    if session_cookie_allowed(request):
+        cookie_session = session_cookie_token(request)
+        if cookie_session is not None:
+            log.debug("Authenticated media request via session cookie", username=cookie_session.username)
+            return AuthContext(auth_level=cookie_session.auth_level, username=cookie_session.username)
 
     # Check if auth is disabled completely (backward compatibility).
     # Auth-disabled mode must remain owner-equivalent even when public access
@@ -292,6 +362,13 @@ async def get_stream_auth_context(
             )
         except HTTPException:
             log.debug("Invalid bearer token on stream, checking ticket and public access")
+
+    cookie_session = session_cookie_token(request)
+    if cookie_session is not None:
+        return StreamAuth(
+            context=AuthContext(auth_level=cookie_session.auth_level, username=cookie_session.username),
+            session_exp=cookie_session.exp,
+        )
 
     ticket = request.query_params.get("ticket")
     if ticket:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -2,7 +2,7 @@
 
 import aiosqlite
 import asyncio
-from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi import APIRouter, Depends, HTTPException, Response, status, Request
 from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Optional
 from datetime import datetime
@@ -21,6 +21,8 @@ from app.auth import (
     require_owner,
     get_auth_context,
     validate_bcrypt_password_length,
+    set_session_cookie,
+    clear_session_cookie,
 )
 from app.config import settings
 from app.services.stream_tickets import STREAM_TICKET_TTL_SECONDS, stream_tickets
@@ -166,7 +168,7 @@ class InitialSetupResponse(BaseModel):
 
 @router.post("/auth/login", response_model=LoginResponse)
 @login_rate_limit()
-async def login(request: Request, login_data: LoginRequest):
+async def login(request: Request, login_data: LoginRequest, response: Response):
     """Authenticate user and return JWT token.
 
     Rate limited to 5 attempts per minute, 20 per hour per IP.
@@ -210,10 +212,27 @@ async def login(request: Request, login_data: LoginRequest):
     token = create_access_token(login_data.username, AuthLevel.OWNER)
 
     log.info("AUTH_AUDIT: Login successful", username=login_data.username, event_type="login_success")
+    set_session_cookie(response, token, request)
 
     return LoginResponse(
         access_token=token, username=login_data.username, expires_in_hours=settings.auth.session_expiry_hours
     )
+
+
+@router.post("/auth/session-cookie", response_model=MessageResponse)
+async def create_session_cookie(request: Request, response: Response, auth: AuthContext = Depends(get_auth_context)):
+    """Attach the caller's existing session to the browser as the media cookie.
+
+    Browsers that signed in before the cookie existed still hold a bearer token;
+    the app calls this once on load so their images keep working without a new
+    login. Only a Bearer session qualifies: the cookie is not accepted here, so
+    a media-scoped cookie can never widen its own reach.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth.is_owner or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="A signed-in session is required")
+    set_session_cookie(response, auth_header[7:], request)
+    return MessageResponse(message="Session cookie set")
 
 
 @router.post("/auth/stream-ticket", response_model=StreamTicketResponse)
@@ -355,7 +374,9 @@ async def get_auth_status(request: Request):
 
 
 @router.post("/auth/initial-setup", response_model=InitialSetupResponse)
-async def set_initial_password(request: InitialPasswordRequest) -> InitialSetupResponse:
+async def set_initial_password(
+    request_obj: Request, request: InitialPasswordRequest, response: Response
+) -> InitialSetupResponse:
     """Set initial password for first-run setup.
 
     Can only be called before initial setup is complete and while no password is
@@ -420,6 +441,7 @@ async def set_initial_password(request: InitialPasswordRequest) -> InitialSetupR
         return InitialSetupResponse(message="Setup completed successfully")
 
     token = create_access_token(settings.auth.username, AuthLevel.OWNER)
+    set_session_cookie(response, token, request_obj)
     return InitialSetupResponse(
         message="Setup completed successfully",
         access_token=token,
@@ -430,12 +452,13 @@ async def set_initial_password(request: InitialPasswordRequest) -> InitialSetupR
 
 
 @router.post("/auth/logout", response_model=MessageResponse)
-async def logout(_auth: AuthContext = Depends(require_owner)) -> MessageResponse:
+async def logout(response: Response, _auth: AuthContext = Depends(require_owner)) -> MessageResponse:
     """Logout endpoint (client-side token deletion).
 
     Note: JWT tokens cannot be invalidated server-side without a blacklist.
     Client should delete token from storage.
     """
+    clear_session_cookie(response)
     try:
         async with get_db() as db:
             await OAuthTokenRepository(db).delete_all()

--- a/backend/app/routers/proxy.py
+++ b/backend/app/routers/proxy.py
@@ -382,12 +382,12 @@ def _build_sprite_url(request: Request, event_id: str) -> str:
     # reverse-proxy Host header rewriting.
     sprite_url = request.url_for("proxy_clip_thumbnails_sprite", event_id=event_id).path
     params: list[str] = []
+    # A share link is the guest's only credential for this event, so it must be
+    # carried into the sprite URL. The owner's session is not: the browser sends
+    # it as a cookie, and a token in a cue URL would land in every proxy log.
     share_token = request.query_params.get("share")
     if share_token:
         params.append(f"share={quote_plus(share_token)}")
-    token = request.query_params.get("token")
-    if token:
-        params.append(f"token={quote_plus(token)}")
     if params:
         sprite_url = f"{sprite_url}?{'&'.join(params)}"
     return sprite_url

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -16243,6 +16243,33 @@
         ]
       }
     },
+    "/api/auth/session-cookie": {
+      "post": {
+        "description": "Attach the caller's existing session to the browser as the media cookie.\n\nBrowsers that signed in before the cookie existed still hold a bearer token;\nthe app calls this once on load so their images keep working without a new\nlogin. Only a Bearer session qualifies: the cookie is not accepted here, so\na media-scoped cookie can never widen its own reach.",
+        "operationId": "create_session_cookie_api_auth_session_cookie_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Session Cookie",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/api/auth/status": {
       "get": {
         "description": "Get current authentication status and public access settings.\n\nUsed by frontend to determine if login is required.",

--- a/backend/tests/test_proxy.py
+++ b/backend/tests/test_proxy.py
@@ -1115,7 +1115,10 @@ async def test_proxy_clip_thumbnails_vtt_success(client: httpx.AsyncClient):
             assert response.status_code == 200
             assert response.headers["content-type"].startswith("text/vtt")
             assert "WEBVTT" in response.text
-            assert "clip-thumbnails.jpg?token=abc123#xywh=0,0,160,90" in response.text
+            # The sprite is fetched with the session cookie; a session token in a
+            # cue URL would be copied into every proxy log that sees it.
+            assert "clip-thumbnails.jpg#xywh=0,0,160,90" in response.text
+            assert "token=" not in response.text
             assert "http://" not in response.text
             assert "https://" not in response.text
         finally:

--- a/backend/tests/test_session_cookie.py
+++ b/backend/tests/test_session_cookie.py
@@ -1,0 +1,251 @@
+"""Media loads with a scoped session cookie, never the session token in the URL.
+
+`<img>` and `<video>` cannot send headers, so owner media URLs carried
+`?token=<session>` and every proxy in front of YA-WAMF logged a week of owner
+access with each thumbnail. The session now also lives in an HttpOnly cookie
+that only read-only media routes and the live stream honour, so a cookie the
+browser sends by itself can never authorise a write.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.auth import (
+    SESSION_COOKIE,
+    AuthLevel,
+    create_access_token,
+    get_auth_context,
+    get_stream_auth_context,
+    hash_password,
+    session_cookie_allowed,
+)
+from app.config import settings
+from app.main import app
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def https_client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="https://test") as client:
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def owner_password_configured():
+    original = (
+        settings.auth.enabled,
+        settings.auth.password_hash,
+        settings.auth.username,
+        settings.auth.initial_setup_complete,
+        settings.auth.session_expiry_hours,
+        settings.public_access.enabled,
+        settings.api_key,
+    )
+    settings.auth.enabled = True
+    settings.auth.password_hash = hash_password("correct-horse-1")
+    settings.auth.username = "owner"
+    settings.auth.initial_setup_complete = True
+    settings.auth.session_expiry_hours = 168
+    settings.public_access.enabled = False
+    settings.api_key = None
+    yield
+    (
+        settings.auth.enabled,
+        settings.auth.password_hash,
+        settings.auth.username,
+        settings.auth.initial_setup_complete,
+        settings.auth.session_expiry_hours,
+        settings.public_access.enabled,
+        settings.api_key,
+    ) = original
+
+
+def _request(path: str, method: str = "GET", cookie: str | None = None, scheme: str = "http") -> Request:
+    headers = [(b"cookie", f"{SESSION_COOKIE}={cookie}".encode())] if cookie else []
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": method,
+            "scheme": scheme,
+            "path": path,
+            "raw_path": path.encode("utf-8"),
+            "query_string": b"",
+            "headers": headers,
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "root_path": "",
+        }
+    )
+
+
+def _set_cookie_header(response: httpx.Response) -> str:
+    headers = [v for k, v in response.headers.multi_items() if k.lower() == "set-cookie" and SESSION_COOKIE in v]
+    assert len(headers) == 1, response.headers.multi_items()
+    return headers[0]
+
+
+# --- where the cookie is honoured: read-only media and the stream, nothing else ----
+
+
+@pytest.mark.parametrize(
+    "method, path, allowed",
+    [
+        ("GET", "/api/frigate/1788686951.128889-si0jon/snapshot.jpg", True),
+        ("GET", "/api/frigate/1788686951.128889-si0jon/thumbnail.jpg", True),
+        ("GET", "/api/frigate/1788686951.128889-si0jon/clip.mp4", True),
+        ("GET", "/api/frigate/1788686951.128889-si0jon/recording-clip.mp4", True),
+        ("GET", "/api/frigate/1788686951.128889-si0jon/clip-thumbnails.vtt", True),
+        ("GET", "/api/frigate/1788686951.128889-si0jon/clip-thumbnails.jpg", True),
+        ("GET", "/api/frigate/1788686951.128889-si0jon/snapshot/original.jpg", True),
+        ("GET", "/api/frigate/1788686951.128889-si0jon/snapshot/candidates/c1/image.jpg", True),
+        ("GET", "/api/frigate/camera/birdcam/latest.jpg", True),
+        ("GET", "/api/audio/spectrogram/42", True),
+        ("GET", "/api/audio/clip/42", True),
+        ("GET", "/api/sse", True),
+        ("HEAD", "/api/frigate/1788686951.128889-si0jon/clip.mp4", True),
+        ("POST", "/api/frigate/1788686951.128889-si0jon/snapshot/apply", False),
+        ("GET", "/api/frigate/config", False),
+        ("GET", "/api/events", False),
+        ("GET", "/api/settings", False),
+        ("POST", "/api/settings", False),
+        ("DELETE", "/api/events/1788686951.128889-si0jon", False),
+        ("POST", "/api/backfill/reset", False),
+    ],
+)
+def test_the_cookie_is_scoped_to_read_only_media_routes(method: str, path: str, allowed: bool):
+    assert session_cookie_allowed(_request(path, method=method)) is allowed
+
+
+@pytest.mark.asyncio
+async def test_a_media_request_with_only_the_cookie_is_the_owner():
+    token = create_access_token("owner", AuthLevel.OWNER)
+    request = _request("/api/frigate/1788686951.128889-si0jon/thumbnail.jpg", cookie=token)
+
+    context = await get_auth_context(request, None)
+
+    assert context.is_owner
+    assert context.username == "owner"
+
+
+@pytest.mark.asyncio
+async def test_the_same_cookie_authorises_nothing_outside_media():
+    token = create_access_token("owner", AuthLevel.OWNER)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await get_auth_context(_request("/api/events", cookie=token), None)
+    assert excinfo.value.status_code == 401
+
+    with pytest.raises(HTTPException) as excinfo:
+        await get_auth_context(_request("/api/settings", method="POST", cookie=token), None)
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a_stale_cookie_falls_through_to_what_the_bare_request_gets():
+    settings.public_access.enabled = True
+    context = await get_auth_context(_request("/api/frigate/e1/snapshot.jpg", cookie="not-a-token"), None)
+    assert context.auth_level == AuthLevel.GUEST
+
+
+@pytest.mark.asyncio
+async def test_the_stream_opens_from_the_cookie_alone():
+    token = create_access_token("owner", AuthLevel.OWNER)
+    stream_auth = await get_stream_auth_context(_request("/api/sse", cookie=token), None, None, None)
+
+    assert stream_auth.context.is_owner
+    assert stream_auth.session_exp is not None
+
+
+# --- issuing and clearing it -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_sets_an_httponly_lax_cookie_scoped_to_the_api(client: httpx.AsyncClient):
+    response = await client.post("/api/auth/login", json={"username": "owner", "password": "correct-horse-1"})
+    assert response.status_code == 200, response.text
+
+    cookie = _set_cookie_header(response)
+    lowered = cookie.lower()
+    assert "httponly" in lowered
+    assert "samesite=lax" in lowered
+    assert "path=/api" in lowered
+    assert f"max-age={168 * 3600}" in lowered
+    assert "secure" not in lowered, "plain-http LAN installs must still receive the cookie"
+    assert response.json()["access_token"] in cookie, "the cookie carries the session itself"
+
+
+@pytest.mark.asyncio
+async def test_over_https_the_cookie_is_secure(https_client: httpx.AsyncClient):
+    response = await https_client.post("/api/auth/login", json={"username": "owner", "password": "correct-horse-1"})
+    assert response.status_code == 200, response.text
+    assert "secure" in _set_cookie_header(response).lower()
+
+
+@pytest.mark.asyncio
+async def test_a_signed_in_browser_can_mint_the_cookie_for_its_existing_session(client: httpx.AsyncClient):
+    token = create_access_token("owner", AuthLevel.OWNER)
+
+    response = await client.post("/api/auth/session-cookie", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200, response.text
+    assert token in _set_cookie_header(response)
+
+
+@pytest.mark.asyncio
+async def test_the_cookie_cannot_mint_itself(client: httpx.AsyncClient):
+    """A media-scoped cookie must not be able to renew its own reach."""
+    token = create_access_token("owner", AuthLevel.OWNER)
+
+    response = await client.post("/api/auth/session-cookie", cookies={SESSION_COOKIE: token})
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_no_session_means_no_cookie(client: httpx.AsyncClient):
+    response = await client.post("/api/auth/session-cookie")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_the_cookie(client: httpx.AsyncClient):
+    token = create_access_token("owner", AuthLevel.OWNER)
+
+    response = await client.post("/api/auth/logout", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200, response.text
+    cookie = _set_cookie_header(response).lower()
+    assert "max-age=0" in cookie or "expires=" in cookie
+
+
+@pytest.mark.asyncio
+async def test_first_run_setup_with_a_password_sets_the_cookie_too(client: httpx.AsyncClient):
+    settings.auth.initial_setup_complete = False
+    settings.auth.password_hash = None
+    settings.auth.enabled = False
+
+    response = await client.post(
+        "/api/auth/initial-setup",
+        json={"username": "owner", "password": "correct-horse-1", "enable_auth": True},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["access_token"] in _set_cookie_header(response)
+
+
+def test_cookie_lifetime_follows_the_session():
+    exp = datetime.now(timezone.utc) + timedelta(hours=settings.auth.session_expiry_hours)
+    assert exp > datetime.now(timezone.utc)

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,26 @@ curl -H "Authorization: Bearer <token>" http://localhost:9852/api/events
 # curl -H "Authorization: Bearer <token>" http://localhost:8946/api/events
 ```
 
+### Session cookie for media
+
+`<img>`, `<video>` and `<audio>` cannot send an `Authorization` header, and a session token in a
+media URL is copied into the access log of every proxy in front of YA-WAMF — hundreds of times a
+day for an owner browsing thumbnails. So media never carries the session in the URL.
+
+Instead, `POST /api/auth/login` (and first-run setup) also sets an `HttpOnly`, `SameSite=Lax`
+cookie named `yawamf_session`, scoped to `/api`, `Secure` when the request arrived over HTTPS,
+with the session's own lifetime. **Only read-only media routes and the live stream honour it**:
+snapshots, thumbnails, clips, recording clips, clip-thumbnail sprites and VTT, snapshot
+candidates, the camera live frame, audio spectrograms and clips, and `GET /api/sse`. Every other
+route still requires a Bearer header, which a cross-site page cannot forge, so the cookie adds no
+CSRF surface. `POST /api/auth/logout` clears it.
+
+- `POST /api/auth/session-cookie` (owner, **Bearer only**) — attaches the caller's existing session
+  as the cookie. The app calls it once on load for a browser that signed in before the cookie
+  existed. The cookie itself is not accepted here, so a media-scoped cookie can never widen its
+  own reach.
+- The deprecated `api_key` query parameter still works on media routes until it is removed in 3.0.
+
 ### Stream ticket
 
 `EventSource` cannot send an `Authorization` header, so the live stream needs a credential in
@@ -115,6 +135,7 @@ This is the current route map (grouped). Use OpenAPI for full schemas.
   Settings API.
 - `POST /api/auth/logout`
 - `POST /api/auth/stream-ticket` (owner) — single-use, 60-second ticket that opens `GET /api/sse`; see [Stream ticket](#stream-ticket).
+- `POST /api/auth/session-cookie` (owner, Bearer only) — sets the media session cookie for an already-signed-in browser; see [Session cookie for media](#session-cookie-for-media).
 
 ### Guided setup
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -218,6 +218,10 @@ ingress:
 ## Technical Details
 
 - **Token Storage:** Authentication uses JWT (JSON Web Tokens) stored in your browser's Local Storage.
+- **Media and the live stream:** images, clips and the `EventSource` stream cannot send headers,
+  so the session also lives in an `HttpOnly` cookie that only those read-only routes accept. Media
+  URLs carry no token, so a proxy or container log that records request lines records nothing
+  useful. Everything that changes state still needs the Bearer header the browser holds in memory.
 - **Live stream:** the browser's `EventSource` cannot send headers, so the live-update stream is
   opened with a single-use ticket exchanged from the session (`POST /api/auth/stream-ticket`),
   never with the session token itself. A ticket is spent on first use and expires after 60


### PR DESCRIPTION
## Outcome

No owner media URL carries the session token any more, so a proxy that logs request lines logs nothing useful. The session reaches media routes as an `HttpOnly` cookie that only those read-only routes accept.

## What was wrong

`<img>`, `<video>` and `<audio>` cannot send headers, so `withAuthParams` appended `?token=<7-day session>` to every snapshot, thumbnail, clip and spectrogram URL. The container's access log uses a redacting format, but Nginx Proxy Manager one hop out logs `$request_uri`: measured on the reference install today, **482 lines** in `proxy-host-4_access.log` carry an owner session. Recorded in `ISSUES.md` as the media-URL residual after #412.

## Included

**Backend**
- `auth.py`: `SESSION_COOKIE`, `session_cookie_allowed(request)` (GET/HEAD on an explicit allowlist of media routes and `/api/sse`), `session_cookie_token`, `set_session_cookie` (`HttpOnly`, `SameSite=Lax`, `Path=/api`, `Secure` iff the request scheme is https, `Max-Age` = session lifetime), `clear_session_cookie`. `get_auth_context` honours the cookie only when the request is on the allowlist, after Bearer/query tokens and before the auth-disabled / public / 401 fallbacks. `get_stream_auth_context` honours it too, before the ticket.
- `routers/auth.py`: login and first-run setup set the cookie alongside the token; logout clears it; new `POST /api/auth/session-cookie` (Bearer only — the cookie cannot mint itself).
- `routers/proxy.py`: clip-thumbnail VTT cues no longer copy the session token into every sprite URL (share links still carry theirs; they are the guest's only credential).

**Frontend**
- `withAuthParams` drops the token; the deprecated `api_key` query survives until 3.0.
- `createSessionCookie()`; the auth store calls it once on status load when it holds a token, so browsers that signed in before this ships keep their images without a new login.
- OpenAPI artifact and generated types regenerated.

**Records** — `CHANGELOG.md` Security; `docs/api.md` ("Session cookie for media" + endpoint map); `docs/features/authentication.md`; `ISSUES.md` moves the residual to Recently Closed and notes the tokens already logged stay valid until the secret is rotated.

## Why a cookie and not a media ticket

A ticket in the URL is still logged (shorter-lived) and rotating URLs defeats the browser's image cache, so every page load re-fetches every thumbnail. The cookie is invisible to logs and cacheable. Scoping it to read-only routes is what keeps it from becoming a CSRF vector.

## Verification

- TDD: `backend/tests/test_session_cookie.py` (16 tests: the allowlist across 20 method/path cases, cookie-only media request is owner, the same cookie authorises nothing outside media, stale cookie falls through, stream from cookie, login flags on http and https, exchange endpoint requires Bearer, cookie cannot mint itself, logout clears, first-run sets) and `withAuthParams`/`createSessionCookie` unit tests were red before implementation, green after. The VTT test now forbids a propagated token.
- Full backend suite **2804 passed**; `ruff check .` / `ruff format --check .` clean from the repo root.
- Frontend: `npm run check` 0 errors / 0 warnings; `npm test` 1021 tests; `npm run lint:dead` clean.
- `export_openapi.py --check`, `export_openapi_types.py --check`, `docs_consistency_check.py` (179 routes), changelog heading check, `git diff --check` all pass.

## Risk

Low-medium. Home Assistant's sidebar proxy injects its own Bearer header on forwarded requests, so media there never used the query token and is unaffected. Split-deployment installs proxy `/api` same-origin, so `Path=/api` applies. Plain-HTTP LAN installs receive a non-`Secure` cookie by design. Tokens already sitting in proxy logs remain valid until they expire or `AUTH__SESSION_SECRET` is rotated — that rotation is the next step on the reference install, alongside a redacting log format for the proxy.
