### PR TITLE
docs: record the session secret rotation and the reverted proxy log change

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -55,8 +55,10 @@ Last reviewed against the GitHub issue tracker on **September 7, 2026**.
 - **Owner media URLs no longer carry the session token.** NPM in front of the reference install logs
   full request URIs; its access log held 482 owner thumbnail and clip URLs with `?token=` on
   September 8. Media now authenticates with an `HttpOnly`, `SameSite=Lax` session cookie that only
-  read-only media routes and the stream honour. The tokens already in that log stay valid until they
-  expire or the session secret is rotated; the proxy's log format is being changed to drop the query.
+  read-only media routes and the stream honour. The session secret on the reference install was
+  rotated on September 8, so every token that log holds is dead. Dropping the query from the proxy's
+  log format was tried the same day and reverted: NPM only reads its bundled format from its vendor
+  config tree, and mounting over that file broke its startup. The access log keeps its normal rotation.
 - **The owner's SSE token no longer reaches nginx's error log.** The live stream opens with a
   single-use, 60-second ticket from `POST /api/auth/stream-ticket`, and `/api/sse` refuses the
   session token in its query string. The three lines nginx wrote on the September 8 restart carried

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -239,7 +239,7 @@ Discord / Pushover / Telegram / Email:
 | `AUTH__ENABLED` | `false` | Require login for owner access. |
 | `AUTH__USERNAME` | `admin` | Owner username. |
 | `AUTH__PASSWORD_HASH` | _(unset)_ | Pre-hashed owner password. |
-| `AUTH__SESSION_SECRET` | _(auto-generated)_ | Session signing secret; set to keep it stable across restarts. |
+| `AUTH__SESSION_SECRET` | _(auto-generated)_ | Session signing secret; set to keep it stable across restarts. Changing it signs everyone out and invalidates every previously issued token. |
 | `AUTH__OAUTH_TOKEN_SECRET` | _(auto-generated)_ | Encryption key for stored OAuth tokens. |
 | `AUTH__SESSION_EXPIRY_HOURS` | `168` | Session lifetime in hours. |
 | `AUTH__INITIAL_SETUP_COMPLETE` | `false` | Marks first-run setup as done. |


### PR DESCRIPTION
## Outcome
`ISSUES.md` promised that the reverse proxy's log format was being changed to drop the query string. That was attempted on September 8 and reverted the same day (NPM reads its bundled log format only from its vendor config tree, and a mount over that file broke its startup), and the session secret on the reference install was rotated instead, which invalidates every token the access log holds. The record now says so.

`docs/setup/environment-variables.md` states what changing `AUTH__SESSION_SECRET` does, since rotating it is the remedy when a token leaks.

## Scope
- Included: `ISSUES.md` (Recently Closed), one table row in the environment reference.
- Excluded: no code, no behaviour change.

## Verification
- `backend/scripts/docs_consistency_check.py` passes; `git diff --check` clean.
- Rotation verified live: a token signed by the previous secret is refused, a fresh login works and sets the media cookie with the expected flags.

## Risk
None: documentation only.