### PR TITLE
Hold onnxruntime-gpu below 1.27 until the CUDA 13 move is a 3.0 decision

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
       python-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # onnxruntime-gpu 1.27+ ships CUDA 13 userspace, which needs the NVIDIA 580 driver
+      # series on every CUDA host. Lifting the window is a 3.0 breaking change (ROADMAP
+      # 1.7), not a dependency bump; the pin lives in requirements-provider-{cuda,full}.txt.
+      - dependency-name: "onnxruntime-gpu"
+        versions: [">=1.27.0"]
 
   - package-ecosystem: npm
     directory: "/apps/ui"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   requirement files asked for `onnxruntime>=1.28.0`, so pip has been resolving 1.29.0 for weeks anyway;
   the reference install has run it since it was published. Stating the floor the images actually
   get lets the dependency-pin test and Dependabot agree with reality. The CUDA build keeps its own
-  `onnxruntime-gpu` window unchanged.
+  `onnxruntime-gpu` window below 1.27 on purpose: 1.27 and later ship CUDA 13 userspace, which
+  needs the NVIDIA 580 driver series on the host, so lifting it is a 3.0 change (`ROADMAP.md`,
+  1.7) and Dependabot is now told not to propose it.
 
 ### Fixed
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -36,6 +36,11 @@ Last reviewed against the GitHub issue tracker on **September 7, 2026**.
 - **Reported cache sizes undercount.** `get_cache_stats` counts `*.jpg` and `*.mp4` only, so the
   `.meta.json` sidecars beside every snapshot are not in the total. On the reference install that
   is 14,712 uncounted files.
+- **The CUDA and amd64 `full` images stay on ONNX Runtime 1.26.** 1.27 and later ship CUDA 13
+  userspace, which needs the NVIDIA 580 driver series on the host, so the bump Dependabot proposed
+  in #284 was closed and the window is held until 3.0 (`ROADMAP.md`, 1.7). Those images therefore
+  lack the input-validation hardening 1.29 added to several CUDA kernels. Exposure is limited: the
+  runtime only loads models the owner installed, never user-supplied files.
 - **API process memory is being watched again.** #314 closed at about 340 MB resident after the
   `MALLOC_ARENA_MAX=2` fix. On the reference install the API process measured 1.49 GB resident
   fourteen hours after a start in subprocess mode, where it holds no model. The RSS sampler is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -784,6 +784,13 @@ in-app and in docs; the release makes them final.
   RegNet-Y-8G EU, and UniFormer-S EU are already absent from the current application catalogue.
   Their release assets remain temporarily available so pre-3.0 applications can still download
   them; the 3.0 release retires those legacy assets after the compatibility window.
+- **CUDA image moves to CUDA 13.** The `cuda` and amd64 `full` images pin `onnxruntime-gpu`
+  below 1.27 because 1.27 and later ship CUDA 13 userspace, which needs the NVIDIA 580 driver
+  series or newer on the host (1.27 and 1.28 also name CUDA 13 packages PyPI does not carry).
+  Lifting the pin raises a host requirement, so it lands with 3.0 and is announced as such.
+  Until then those two images stay on ONNX Runtime 1.26 and miss the input-validation
+  hardening 1.29 added to several CUDA kernels; exposure is limited because the runtime only
+  loads models the owner installed.
 - **Migration must be lossless.** Existing split-deployment installs must be able to move to
   the monolith with unchanged `/config` and `/data` volumes (DB, models, `config.json`), and
   the [split-to-monolith guide](docs/setup/migrate-split-to-monolith.md) stays the supported

--- a/backend/requirements-provider-cuda.txt
+++ b/backend/requirements-provider-cuda.txt
@@ -1,4 +1,7 @@
 # ONNX Runtime with packaged CUDA 12 / cuDNN 9 userspace libraries. The host
 # still needs an NVIDIA driver and NVIDIA Container Toolkit GPU passthrough.
-# ORT 1.27 uses CUDA 13 extras that are not available from the normal PyPI index.
+# Held below 1.27 on purpose: 1.27 and 1.28 name CUDA 13 packages PyPI does not
+# carry, and 1.29+ installs CUDA 13 userspace, which needs the NVIDIA 580 driver
+# series on the host. Moving is a 3.0 breaking change (ROADMAP 1.7); Dependabot
+# is told not to propose it. test_dependency_pins.py keeps the two in step.
 onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0

--- a/backend/requirements-provider-full.txt
+++ b/backend/requirements-provider-full.txt
@@ -1,6 +1,7 @@
 # Compatibility image: CUDA 12 / cuDNN 9 plus OpenVINO CPU/GPU/NPU. ARM64 uses
 # the CPU ORT package and omits OpenVINO; the dedicated RPi build selects the CPU
-# provider file directly.
+# provider file directly. The GPU line is held below 1.27 for the reason given in
+# requirements-provider-cuda.txt.
 onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0 ; platform_machine != "aarch64" and platform_machine != "arm64"
 onnxruntime>=1.29.0 ; platform_machine == "aarch64" or platform_machine == "arm64"
 openvino>=2026.3.0,<2027.0 ; platform_machine != "aarch64" and platform_machine != "arm64"

--- a/backend/tests/test_dependency_pins.py
+++ b/backend/tests/test_dependency_pins.py
@@ -53,6 +53,25 @@ def test_cpu_onnxruntime_floor_is_consistent_across_runtime_flavors():
     assert "onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0" in requirements["full"]
 
 
+def test_gpu_onnxruntime_window_is_held_below_cuda_13_everywhere():
+    """1.27+ means CUDA 13 userspace and a newer host driver: a 3.0 decision, not a bump.
+
+    Both amd64 GPU images must carry the same window, and Dependabot must be told not to
+    propose past it, or the next weekly PR re-opens the question with a green tick from a CI
+    job that never installs this file.
+    """
+    backend_root = Path(__file__).resolve().parents[1]
+    window = "onnxruntime-gpu[cuda,cudnn]>=1.24.0,<1.27.0"
+    for flavor in ("cuda", "full"):
+        content = (backend_root / f"requirements-provider-{flavor}.txt").read_text(encoding="utf-8")
+        assert window in content, flavor
+
+    dependabot = (backend_root.parent / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    pip_block = dependabot.split("- package-ecosystem: pip", 1)[1].split("- package-ecosystem:", 1)[0]
+    assert '- dependency-name: "onnxruntime-gpu"' in pip_block
+    assert 'versions: [">=1.27.0"]' in pip_block
+
+
 def test_openvino_floor_is_consistent_across_intel_capable_flavors():
     backend_root = Path(__file__).resolve().parents[1]
     for flavor in ("intel", "full"):

--- a/docs/setup/hardware-acceleration.md
+++ b/docs/setup/hardware-acceleration.md
@@ -98,7 +98,7 @@ also settable via the `CLASSIFICATION__INFERENCE_PROVIDER` environment variable)
 |---|---|---|---|---|
 | Auto | `auto` | any | — | Uses this model/install's measured passing order; without a sweep it stays within the registry's globally safe paths. |
 | CPU (ONNX Runtime) | `cpu` | any | none | Always packaged; the safe fallback. |
-| NVIDIA CUDA | `cuda` | `full` or `cuda` | NVIDIA GPU | Needs the NVIDIA Container Toolkit on the host. |
+| NVIDIA CUDA | `cuda` | `full` or `cuda` | NVIDIA GPU | Needs the NVIDIA Container Toolkit on the host. The image ships CUDA 12.9 userspace, so any driver that supports CUDA 12 (the 525 series or newer) works; CUDA 13 is planned for 3.0. |
 | Intel GPU (OpenVINO) | `intel_gpu` | `full` or `intel` | `/dev/dri` | Integrated Arc/UHD graphics. |
 | Intel CPU (OpenVINO) | `intel_cpu` | `full` or `intel` | none | OpenVINO on the CPU. |
 | Intel NPU (OpenVINO) | `intel_npu` | `full` or `intel` | `/dev/accel/accel0` | Core Ultra "AI Boost" NPU. |


### PR DESCRIPTION
## Outcome
Dependabot's #284 (onnxruntime-gpu `>=1.29.0,<1.30.0` for the CUDA image) is not a routine bump. Resolving it for Linux x86_64 shows:

| Window | Resolves from PyPI? | Userspace it installs |
|---|---|---|
| `>=1.24.0,<1.27.0` (current) | yes, 1.26.0 | CUDA 12.9 / cuDNN 9.25 (`-cu12` packages) |
| `==1.27.*` | **no**: `nvidia-cuda-nvrtc-cu13` on PyPI is a placeholder | – |
| `>=1.29.0,<1.30.0` (#284) | yes, 1.29.0 | CUDA 13.3 / cuDNN 9.25 (`nvidia-cuda-runtime` 13.3, `nvidia-cublas` 13.6, …) |

CUDA 13 userspace needs the NVIDIA 580 driver series or newer on the host, so merging #284 would silently raise a host requirement for every CUDA user, and the amd64 `full` image carries the same pin so a one-file bump would also split the two images. CI's backend job never installs the CUDA file, which is why #284 was green.

This PR holds the window deliberately and makes the hold visible:
- `.github/dependabot.yml`: ignore `onnxruntime-gpu >=1.27.0` for pip, with the reason.
- `test_dependency_pins.py`: the `cuda` and `full` windows must match and the ignore must exist.
- Requirement files say why the window is where it is.
- `docs/setup/hardware-acceleration.md`: the CUDA image ships CUDA 12.9 userspace, so any CUDA-12 driver (525 series or newer) works; CUDA 13 planned for 3.0.
- `ROADMAP.md` 1.7 (breaking changes at 3.0): the CUDA 13 move, with its driver requirement.
- `ISSUES.md`: known exposure. The held images miss the input-validation hardening 1.29 added to several CUDA kernels; exposure is limited because the runtime only loads owner-installed models.
- Changelog: the existing 1.29-floor entry now states the CUDA exception and why.

## Scope
- Included: the above. #284 is closed with this reason.
- Excluded: the move itself. Two routes exist when 3.0 takes it: CUDA 13 from PyPI (driver 580+), or ONNX Runtime's own `onnxruntime-cuda-12` feed, which carries 1.27.0 to 1.29.0 built for CUDA 12 but is a non-PyPI index. Either is a decision for the release, not for a weekly bot PR.

## Verification
- `pytest tests/test_dependency_pins.py` (5 passed); `ruff check .` and `ruff format --check .` clean; docs consistency check passed; `git diff --check` clean.
- Resolutions above from `pip install --dry-run --report` against PyPI with Linux manylinux tags, and PyPI's release lists for `nvidia-cuda-nvrtc`, `nvidia-cuda-nvrtc-cu13`, `nvidia-cuda-runtime`, `nvidia-cublas`, `nvidia-cudnn-cu13`.

## Risk
None at runtime: no pin changes. Dependabot stops proposing this one package past 1.27; security advisories for it will still need a manual look.