### PR TITLE
Correct documentation privacy guidance and tighten the project voice

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,17 +62,16 @@ curl -H "Authorization: Bearer <token>" http://localhost:9852/api/events
 
 ### Session cookie for media
 
-`<img>`, `<video>` and `<audio>` cannot send an `Authorization` header, and a session token in a
-media URL is copied into the access log of every proxy in front of YA-WAMF — hundreds of times a
-day for an owner browsing thumbnails. So media never carries the session in the URL.
+`<img>`, `<video>` and `<audio>` cannot set an `Authorization` header. The app uses a session
+cookie for media requests to keep the session token out of URLs and proxy request logs.
 
 Instead, `POST /api/auth/login` (and first-run setup) also sets an `HttpOnly`, `SameSite=Lax`
 cookie named `yawamf_session`, scoped to `/api`, `Secure` when the request arrived over HTTPS,
 with the session's own lifetime. **Only read-only media routes and the live stream honour it**:
 snapshots, thumbnails, clips, recording clips, clip-thumbnail sprites and VTT, snapshot
-candidates, the camera live frame, audio spectrograms and clips, and `GET /api/sse`. Every other
-route still requires a Bearer header, which a cross-site page cannot forge, so the cookie adds no
-CSRF surface. `POST /api/auth/logout` clears it.
+candidates, the camera live frame, audio spectrograms and clips, and `GET /api/sse`. The cookie
+cannot authorise other routes or state-changing requests. Use a Bearer header for authenticated
+API calls. `POST /api/auth/logout` clears the cookie.
 
 - `POST /api/auth/session-cookie` (owner, **Bearer only**) — attaches the caller's existing session
   as the cookie. The app calls it once on load for a browser that signed in before the cookie
@@ -82,10 +81,9 @@ CSRF surface. `POST /api/auth/logout` clears it.
 
 ### Stream ticket
 
-`EventSource` cannot send an `Authorization` header, so the live stream needs a credential in
-its URL — and nginx writes the full request line to its error log whenever the upstream refuses
-a connection, which it does for a few seconds on every container start. A session token in that
-line is a week of owner access. So the stream never takes the session token; it takes a ticket:
+`EventSource` cannot set an `Authorization` header. The app exchanges its session for a
+single-use stream ticket, keeping the session token out of the URL. A client can open the
+stream with a ticket as follows:
 
 ```bash
 TICKET=$(curl -fsS -X POST -H "Authorization: Bearer <token>" \
@@ -93,12 +91,14 @@ TICKET=$(curl -fsS -X POST -H "Authorization: Bearer <token>" \
 curl -N "http://localhost:9852/api/sse?ticket=$TICKET"
 ```
 
-- A ticket is **single-use** and expires **60 seconds** after issue; a logged copy is worthless.
+- A ticket is **single-use** and expires **60 seconds** after issue. An unredeemed ticket
+  exposed in a log remains usable until it expires.
 - It inherits the session's expiry, so the stream still ends when the session would have.
 - Only a signed-in session is issued one (`403` for a guest, `401` with no session). A guest does
   not need one: with public access on, the bare `/api/sse` already opens as a guest.
 - The server keeps only a hash of each outstanding ticket, bounded to 256 at a time.
-- Clients that *can* send headers (`curl -N -H "Authorization: Bearer …"`) may skip the exchange.
+- Clients that can send a Bearer header may skip the exchange. The stream also accepts the
+  session cookie described above.
 
 ### Auth status
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -1,6 +1,7 @@
 # Authentication & Access Control
 
-YA-WAMF protects your settings and your history behind an owner login, and can separately offer a read-only public view to anyone you share the link with.
+Enable authentication to protect your settings and history with an owner login. You can also
+turn on a separate read-only public view to share your detections.
 
 ## Overview
 
@@ -92,13 +93,16 @@ medium is not shared rather than shown a broken image or an error.
 | **Share video with visitors** | On | Clip playback. |
 | **Allow clip downloads** | **Off** | Whether a guest can save a clip file, rather than only stream it. |
 | **Show AI conversation threads** | **Off** | Whether guests can read the AI Naturalist conversation, not just the summary. |
-| **History window** | 7 days | How far back the public detection list reaches (`0` = live only). |
-| **Media window** | 7 days | How far back snapshots and clips are served (`0` = live only). |
+| **History window** | Follow retention | How far back the public detection list reaches, capped at 365 days. In custom mode, `0` means today only. |
+| **Media window** | Follow retention | How far back snapshots and clips are served, capped at 365 days. In custom mode, `0` means today only. |
 | **Location precision** | **Approximate** | How precisely guest-facing features may use your configured location. |
 
-> **Location precision defaults to approximate on purpose.** The person doxxed by an exact
-> location is the person who never found this setting. Change it only if you are content for
-> visitors to know where your feeder is.
+**With the default Keep Everything retention policy, both public windows cover 365 days.**
+The stored seven-day values apply only when you select custom windows. Check both windows
+before sharing your URL.
+
+Location precision defaults to **Approximate**. Choose **Exact** only if you want
+guest-facing features to use your precise feeder location.
 
 Guests can never request the current live frame from a camera. Header camera previews and
 `/api/frigate/camera/{camera}/latest.jpg` always require owner access, even when camera names and
@@ -121,7 +125,8 @@ a glance which view you are looking at.
 
 ### Guest view: troubleshooting
 
-- **Guests see nothing:** confirm **Enable public access** is on and the history window is not `0`.
+- **Guests see nothing:** confirm **Enable public access** is on and there are detections within
+  the history window. A custom window of `0` shows only today’s detections.
 - **Guests see settings:** authentication is disabled. Enable it and set a password.
 - **Guests see grey placeholders instead of birds:** **Share photographs with visitors** is off, or
   the detection is older than the media window.
@@ -218,14 +223,15 @@ ingress:
 ## Technical Details
 
 - **Token Storage:** Authentication uses JWT (JSON Web Tokens) stored in your browser's Local Storage.
-- **Media and the live stream:** images, clips and the `EventSource` stream cannot send headers,
-  so the session also lives in an `HttpOnly` cookie that only those read-only routes accept. Media
-  URLs carry no token, so a proxy or container log that records request lines records nothing
-  useful. Everything that changes state still needs the Bearer header the browser holds in memory.
+- **Media:** the browser sends the session in an `HttpOnly` cookie for images, clips, and audio.
+  The app keeps the session token out of media URLs so it is not copied into URL logs. Only
+  read-only media routes and the live stream accept this cookie; it cannot authorise settings
+  changes or other writes. The app uses a Bearer header for those requests.
 - **Live stream:** the browser's `EventSource` cannot send headers, so the live-update stream is
   opened with a single-use ticket exchanged from the session (`POST /api/auth/stream-ticket`),
-  never with the session token itself. A ticket is spent on first use and expires after 60
-  seconds, so one caught in a proxy or container log is worthless by the time anyone reads it.
+  never with the session token in the URL. A ticket expires after 60 seconds and can be redeemed
+  once. An unredeemed ticket exposed in a log remains usable until it expires. The stream also
+  accepts the session cookie or a Bearer header.
 - **Session Expiry:** Sessions are valid for 7 days by default (configurable).
 - **Rate Limiting:** Login attempts are strictly rate-limited (5 per minute) to prevent brute-force attacks.
 - **Legacy API Key:** Older `YA_WAMF_API_KEY` authentication still works but is deprecated.

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -1,14 +1,14 @@
 # Notifications
 
-YA-WAMF includes a flexible multi-platform notification system that alerts you when birds are detected.
+YA-WAMF sends detection alerts through Discord, Pushover, Telegram, and email.
 
-## The Notifications surface
+## Notification history
 
 The bell icon in the header opens the notification centre; **Notifications** in the sidebar opens
-the full page. Both show one history, filtered by facet: **Everything**, **Birds**, **Updates**,
-**Jobs**, and **Errors**. The **Jobs** and **Errors** facets are owner-only.
+the full page. Both show one history, filtered by category: **Everything**, **Birds**, **Updates**,
+**Jobs**, and **Errors**. The **Jobs** and **Errors** categories are owner-only.
 
-The **Jobs** facet separates queued, running, and recent work. Video analysis, best-quality
+The **Jobs** category separates queued, running, and recent work. Video analysis, best-quality
 snapshots, full-visit clips, and backfills stay distinct, so a queued item is never presented as a
 running worker.
 
@@ -18,7 +18,7 @@ started, such as a backfill or a manual analysis. Routine per-detection media wo
 to browser live updates, so opening a second tab does not create a second job or invent a separate
 queue.
 
-If live job status cannot be read, the page keeps the last known progress, shows a calm warning,
+If live job status cannot be read, the page keeps the last known progress, shows a warning,
 and retries automatically. **Try again** on a paused video-analysis lane reopens the circuit
 breaker; it does not discard queued detections.
 
@@ -82,14 +82,14 @@ a control:
 ![Settings → Notifications: the Global Notification Filters card reading "Tell me about new visits that are at least 70% sure of any species on nowhere yet", with the notification cooldown, notification language, and the three species filter modes beneath](../images/settings-notifications.png)
 
 ### Minimum confidence
-Only alert at or above this score (default `0.7`). Set it higher than your detection threshold so
-you hear about sure things only, and leave the borderline visits to the Explorer.
+Only alert at or above this score (default `0.7`). Raise it to reduce alerts for lower-confidence
+identifications. A high score does not guarantee that the identification is correct.
 
 ### Audio confirmed only
-Alert only when the visual model identified a bird **and** BirdNET-Go heard the *same species* at
-the same time. Two independent sensors agreeing is a strong signal, so this all but eliminates
-false alerts — at the cost of missing every silent visitor. The sentence changes to
-**"70% sure and heard"** when it is on.
+Alert only when the visual model identified a bird **and** BirdNET-Go heard the *same species*
+within the configured correlation window. This requires supporting audio
+evidence, but both models can still make mistakes. Visits without matching audio do not trigger
+an alert. The sentence changes to **"70% sure and heard"** when it is on.
 
 ### Species filter
 Three modes, chosen with the tiles under **Species filter**:
@@ -97,16 +97,15 @@ Three modes, chosen with the tiles under **Species filter**:
 | Mode | Effect |
 |---|---|
 | **No species filter** | Notify for every species that passes the other filters. This is the default. |
-| **Block selected species** | Notify for everything *except* the species you list. Good for a Wood Pigeon that visits four hundred times a day. |
-| **Only selected species** | Notify *only* for the species you list. Good for waiting on one rarity. |
+| **Block selected species** | Notify for everything *except* the species you list. Use this to exclude frequent visitors. |
+| **Only selected species** | Notify *only* for the species you list. Use this to watch for particular species. |
 
 Species are matched on taxonomic identity rather than on display text, so a name change or a
 different UI language does not quietly break your filter.
 
 ### Notification cooldown
-A minimum gap in minutes between notifications, across all channels (default `0`, disabled). This
-is the blunt instrument for a busy feeder: it caps how often you are interrupted regardless of how
-many birds arrive.
+A minimum gap in minutes between notifications, across all channels (default `0`, disabled).
+Use it to reduce notification frequency when the feeder is busy.
 
 ## Notification Modes
 
@@ -121,7 +120,7 @@ Choose a delivery mode in **Settings → Notifications**:
 ## How it Works
 
 1. **Event Trigger:** A detection is processed and saved to the database.
-2. **Filter Check:** The system checks your confidence, audio, and whitelist settings.
+2. **Filter Check:** The system checks your confidence, audio, and species filters.
 3. **Dispatch:** If passed, the notification service dispatches async requests to all enabled platforms simultaneously.
 4. **Rich Media:** If enabled, the system fetches the high-quality crop from Frigate to attach to the message.
 

--- a/docs/features/taxonomy.md
+++ b/docs/features/taxonomy.md
@@ -1,6 +1,7 @@
 # Taxonomy & Naming
 
-YA-WAMF uses a professional taxonomy engine to ensure every bird sighting is recorded with both its common and scientific identity.
+YA-WAMF resolves common and scientific names for detections and uses a species catalogue to
+keep identities consistent when names change.
 
 ## iNaturalist Integration
 The system is connected to the [iNaturalist API](https://www.inaturalist.org/). Every time a new species is detected, YA-WAMF:
@@ -90,5 +91,5 @@ recorded, rewrite a model's label, or withdraw an identity is refused outright: 
 correction, and a correction needs a deliberate decision rather than arriving in an update.
 
 **The catalogue is a separate file from your detection history.** Rolling a release back changes
-names, never your recorded sightings. Both live under `/data`, so a backup of that directory covers
-the catalogue, the detections database, and your configuration together.
+names, never your recorded sightings. Both databases live under `/data`. Back up that directory
+and `/config` to preserve the catalogue, detection history, and configuration.

--- a/docs/features/video-analysis.md
+++ b/docs/features/video-analysis.md
@@ -1,6 +1,9 @@
 # Deep Video Analysis
 
-While real-time detection uses a single snapshot, YA-WAMF provides a **Deep Video Analysis** mode for the most accurate identification possible. By sampling many frames from the full clip and combining their predictions, it significantly reduces errors from motion blur, partial occlusion, or a bad angle in a single frame.
+**Deep Video Analysis** samples multiple frames from a clip and checks whether their
+identifications agree. It can provide clearer evidence when a snapshot is blurred or the bird
+is partly hidden. If neither the video nor the snapshot fallback provides sufficient evidence,
+YA-WAMF keeps the existing identification.
 
 ## How It Works
 
@@ -82,8 +85,11 @@ be traced back to the media position that produced it.
 
 | Setting | Location | Description |
 |---------|----------|-------------|
-| **Frame count** | Settings → Detection | Number of frames sampled per clip (default: 15). Higher values improve accuracy on long clips but take longer. |
-| **Max concurrent jobs** | Settings → Detection | How many video analysis jobs can run in parallel (default: 1). Raise this if you have spare CPU/GPU headroom. |
+| **Frame count** | Settings → Detection | Number of frames sampled per clip (default: 15). Higher values sample more of the clip but take longer and do not guarantee a better identification. |
+
+Video-job concurrency follows `CLASSIFICATION__BACKGROUND_WORKER_COUNT` (one worker when
+unset), with one clip per worker. The legacy `video_classification_max_concurrent` setting is
+ignored. See [Maintenance concurrency](../setup/configuration.md#maintenance-concurrency).
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ The sidebar splits into **Observe** (what the feeder saw) and **Manage** (how it
 </div>
 
 ### Mobile Ready
-YA-WAMF is fully responsive and works great on phones and tablets.
+The layout adapts to phones and tablets, with the dashboard counts above the field log.
 
 <div align="center">
   <img src="images/dashboard-mobile.png" width="300" alt="The dashboard on a phone: today's counts stacked above the field log, with nearby eBird rarities below" />

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -82,7 +82,8 @@ How a snapshot becomes a species. This is the section that balances accuracy aga
    *Saved as **Unknown Bird**.* YA-WAMF is confident something was there, but not confident
    enough to name it. The visit is kept; your species statistics stay clean.
 3. **Score below the Floor**
-   *Discarded.* Almost always a shadow, an insect, or an unusable frame.
+   *Discarded.* The score is too low to keep the event; this can also exclude a real bird
+   in an unclear image.
 
 ### 🎯 Personalized re-ranking details
 
@@ -114,8 +115,8 @@ a saved credential can be re-tested without typing it again.
   [BirdNET-Go](../integrations/birdnet-go.md).
 - **BirdWeather** — enter your Station Token to contribute identified detections to the
   community project. **Test connection** sends a mock House Sparrow to your station.
-- **eBird** — an API key unlocks nearby and notable sightings, plus the CSV export. The export
-  button lives here, under **eBird**, not under Data.
+- **eBird** — an API key enables nearby and notable sightings. Enable the integration to show
+  the CSV export controls here; exporting your detections does not require an API key.
 - **iNaturalist** — owner-reviewed submissions over OAuth. Needs App Owner approval from
   iNaturalist first.
 - **Home Assistant weather** — take each visit's weather from your own HA instance instead of a
@@ -154,8 +155,8 @@ on the leaderboard.
   OpenRouter also accepts any model ID you type.
 - **Test AI Connection:** a staged panel that checks configuration, provider availability,
   vision support, multi-frame admission, and response generation. It sends five generated
-  1280×720 frames — the same shape as a real analysis request — so a pass proves the model
-  accepts production traffic.
+  1280×720 frames to check that the provider accepts a multi-frame image request. A pass
+  confirms this test request succeeded; it does not guarantee every later analysis will succeed.
 - **Usage:** calls, tokens, and estimated cost per feature, with the reference pricing the
   estimate used.
 
@@ -171,8 +172,8 @@ of **any species** on **Discord*** — and each highlighted part is a control.
 | Control | Default | Description |
 |---|---|---|
 | **Notification mode** | Standard | `Final-only`, `Standard`, `Realtime`, `Silent`, or `Advanced (custom)` triggers. |
-| **Minimum confidence** | `0.7` | Only notify at or above this score. Set it higher than your detection threshold to hear about sure things only. |
-| **Audio confirmed only** | Off | Notify only when BirdNET-Go heard the same species at the same time. |
+| **Minimum confidence** | `0.7` | Only notify at or above this score. Raise it to reduce alerts for lower-confidence identifications. |
+| **Audio confirmed only** | Off | Notify only when BirdNET-Go heard the same species within the configured correlation window. |
 | **Species filter** | No species filter | `No species filter`, `Block selected species`, or `Only selected species`. |
 | **Notification cooldown** | `0` minutes | Minimum gap between notifications. `0` disables the cooldown. |
 | **Notification language** | English | The language used in message text, independent of the UI language. |
@@ -261,19 +262,20 @@ Retention, caching, imports, and the destructive tools.
   `DB_PRE_MIGRATION_BACKUP_RETENTION` to keep more. At least one restore point is always kept,
   and manual backups are never removed.
 
-> **The Danger Zone is genuinely dangerous.** **Reset Database & Cache** permanently deletes
+> **These actions permanently delete data.** **Reset Database & Cache** permanently deletes
 > *every* detection and clears the media cache; **Clear Personalization Data** deletes every
 > manual correction the re-ranker learned from. Both ask first, and neither can be undone. There
-> is no automatic backup of your detection history — take your own copy of `/data` before you use
-> either.
+> is no automatic backup tied to these actions. Take a backup of `/data` and `/config` before
+> using them; migration restore points may not contain your latest history.
 
 ### Maintenance concurrency
 
 `maintenance_max_concurrent` (default `1`) controls how many jobs of the *same* maintenance
 kind may overlap — backfill, weather backfill, video classification, taxonomy repair, timezone
 repair, and analyse-unknowns each get that many slots. Different kinds already run
-independently. `1` is the recommendation: it keeps maintenance from competing with live event
-processing.
+independently, subject to `maintenance.total_max_concurrent` (default `3`) across all kinds.
+`maintenance.per_kind_capacity` can override the limit for an individual kind. Keep the per-kind
+default at `1` to limit competition with live event processing.
 
 Video-analysis concurrency is separate, and no longer has its own setting. It follows the
 background worker count (`CLASSIFICATION__BACKGROUND_WORKER_COUNT`) — one clip per worker.

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -249,9 +249,9 @@ Discord / Pushover / Telegram / Email:
 | `PUBLIC_ACCESS__SHOW_AI_CONVERSATION` | `false` | Expose the AI chat to guests. |
 | `PUBLIC_ACCESS__ALLOW_CLIP_DOWNLOADS` | `false` | Let guests download clips. |
 | `PUBLIC_ACCESS__HISTORICAL_DAYS_MODE` | `retention` | `retention` (follow `MAINTENANCE__RETENTION_DAYS`) or `custom` history window for guests. |
-| `PUBLIC_ACCESS__SHOW_HISTORICAL_DAYS` | `7` | Guest history window in days (when the mode is `custom`). `0` means live only. |
+| `PUBLIC_ACCESS__SHOW_HISTORICAL_DAYS` | `7` | Guest history window in days (when the mode is `custom`). `0` means today only. |
 | `PUBLIC_ACCESS__MEDIA_DAYS_MODE` | `retention` | `retention` or `custom` media window for guests. |
-| `PUBLIC_ACCESS__MEDIA_HISTORICAL_DAYS` | `7` | Guest media window in days (when the mode is `custom`). `0` means live only. |
+| `PUBLIC_ACCESS__MEDIA_HISTORICAL_DAYS` | `7` | Guest media window in days (when the mode is `custom`). `0` means today only. |
 | `PUBLIC_ACCESS__RATE_LIMIT_PER_MINUTE` | `30` | Per-IP guest request limit. |
 | `PUBLIC_ACCESS__EXTERNAL_BASE_URL` | _(unset)_ | Public base URL for guest links. |
 


### PR DESCRIPTION
Correct the guest history and media defaults, explain the lifetime of exposed stream tickets, and clarify that eBird CSV export does not require an API key. Backup guidance now includes both `/data` and `/config`, and video concurrency guidance matches the background worker setting.

Tighten eight documentation pages to use plain, practical language and remove unsupported accuracy guarantees and dramatic warnings. This changes documentation only; application behaviour, schemas, and screenshots are unchanged.

Validation: documentation consistency check (179 routes), `git diff --check`, repository-wide Ruff lint and format checks, backend pytest, frontend Svelte checks, and frontend unit tests. No runtime or migration changes.
