### PR TITLE
Refuse a notification address without a scheme, and no email-only link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   choice, **Notification link opens**, points the link at Frigate instead: the same tracked object
   in Frigate's Explore page, through the public URL already saved under Integrations (Frigate 0.15
   or newer). A preview line shows the exact address the next notification will carry, and choosing
-  Frigate without a public URL says plainly that no link is sent until there is one. (#414)
+  Frigate without a public URL says plainly that no link is sent until there is one. An address
+  without `http://` or `https://` is refused when saved, since Discord and Telegram would reject
+  the link and drop the whole notification with it. (#414)
 
 ### Changed
 

--- a/apps/ui/src/lib/settings/notification-link.ts
+++ b/apps/ui/src/lib/settings/notification-link.ts
@@ -1,7 +1,7 @@
 export type NotificationLinkTarget = 'yawamf' | 'frigate';
 
 /** A representative event id so the preview reads like a real link. */
-export const PREVIEW_EVENT_ID = '1788874165.969381-ym7r9s';
+const PREVIEW_EVENT_ID = '1788874165.969381-ym7r9s';
 
 const trimBase = (url: string): string => url.trim().replace(/\/+$/, '');
 

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -24,7 +24,7 @@ from app.repositories.detection_repository import DetectionRepository
 from app.services.canonical_identity_repair_service import canonical_identity_repair_service
 from app.services.telemetry_service import collect_runtime_telemetry_payload, telemetry_service
 from app.services.notification_service import notification_service
-from app.services.notification_links import instance_base, notification_link
+from app.services.notification_links import instance_base, notification_link, public_base
 from app.services.auto_video_classifier_service import auto_video_classifier
 from app.services.birdweather_service import birdweather_service
 from app.services.inaturalist_service import inaturalist_service
@@ -2106,6 +2106,11 @@ async def update_settings(
         # The email-only dashboard link is the older name for the same address; keep them equal so a
         # clear in the UI clears both and nothing falls back to a stale value.
         instance_url = update.notifications_instance_url.strip().rstrip("/") or None
+        if instance_url and not public_base(instance_url):
+            raise HTTPException(
+                status_code=400,
+                detail="Instance address must start with http:// or https://, for example https://feeder.example.com",
+            )
         settings.notifications.instance_url = instance_url
         settings.notifications.email.dashboard_url = instance_url
     if "notifications_link_target" in fields_set and update.notifications_link_target is not None:

--- a/backend/app/services/notification_links.py
+++ b/backend/app/services/notification_links.py
@@ -5,6 +5,21 @@ from urllib.parse import quote
 
 from app.config_models import NotificationSettings
 
+_SCHEMES = ("http://", "https://")
+
+
+def public_base(url: Optional[str]) -> Optional[str]:
+    """A usable public address, or None.
+
+    Discord rejects an embed whose `url` has no scheme and Telegram rejects a button URL that is
+    not http(s); either way the whole notification is dropped, not just the link. So an address
+    without a scheme is treated as no address at all, and the settings API refuses to save one.
+    """
+    base = (url or "").strip().rstrip("/")
+    if not base or not base.lower().startswith(_SCHEMES):
+        return None
+    return base
+
 
 def instance_base(notifications: NotificationSettings) -> Optional[str]:
     """The public address of this install, or None when the owner never set one.
@@ -13,7 +28,7 @@ def instance_base(notifications: NotificationSettings) -> Optional[str]:
     install that only ever configured email links keeps them on every channel.
     """
     for candidate in (notifications.instance_url, notifications.email.dashboard_url):
-        base = (candidate or "").strip().rstrip("/")
+        base = public_base(candidate)
         if base:
             return base
     return None
@@ -35,7 +50,7 @@ def frigate_link(frigate_external_url: str, frigate_event: Optional[str]) -> Opt
     route is the one that works from an event id. No public Frigate address means no link, never
     a fallback to the internal one, which a phone could not reach anyway.
     """
-    base = (frigate_external_url or "").strip().rstrip("/")
+    base = public_base(frigate_external_url)
     if not base:
         return None
     if not frigate_event:

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -511,7 +511,8 @@ class NotificationService:
                 "timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
                 "audio_confirmed": audio_confirmed,
                 "has_image": snapshot_data is not None and cfg.include_snapshot,
-                "dashboard_url": detection_url or cfg.dashboard_url,
+                # The link the owner chose, or none: never a dashboard link the other channels lack.
+                "dashboard_url": detection_url,
                 "font_family": font_family,
                 "weather": weather,
             }

--- a/backend/tests/test_notification_links.py
+++ b/backend/tests/test_notification_links.py
@@ -76,3 +76,19 @@ def test_the_target_choice_decides_which_link_a_notification_carries():
 def test_frigate_target_with_no_public_address_sends_no_link_at_all():
     notifications = NotificationSettings(instance_url="https://feeder.example.com", link_target="frigate")
     assert notification_link(notifications, "", "abc") is None
+
+
+# --- an address without a scheme would sink the whole notification, so it counts as none --------
+
+from app.services.notification_links import public_base  # noqa: E402
+
+
+def test_an_address_without_a_scheme_is_no_address():
+    assert public_base("feeder.local:9852") is None
+    assert public_base("//feeder.example.com") is None
+    assert instance_base(NotificationSettings(instance_url="feeder.local:9852")) is None
+    assert frigate_link("frigate.local:8971", "abc") is None
+
+
+def test_scheme_matching_is_case_insensitive_and_keeps_the_host_as_typed():
+    assert public_base(" HTTPS://Feeder.Example.com/ ") == "HTTPS://Feeder.Example.com"

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -1669,3 +1669,24 @@ async def test_settings_roundtrip_notification_link_target(client: httpx.AsyncCl
         assert rejected.status_code == 422
     finally:
         settings.notifications.link_target = original
+
+
+@pytest.mark.asyncio
+async def test_settings_refuses_an_instance_address_without_a_scheme(client: httpx.AsyncClient):
+    settings.auth.enabled = False
+    settings.public_access.enabled = False
+    original = (settings.notifications.instance_url, settings.notifications.email.dashboard_url)
+    try:
+        before = (await client.get("/api/settings")).json()
+        payload = {
+            "frigate_url": before["frigate_url"],
+            "mqtt_server": before["mqtt_server"],
+            "classification_threshold": before["classification_threshold"],
+            "notifications_instance_url": "feeder.local:9852",
+        }
+        resp = await client.post("/api/settings", json=payload)
+        assert resp.status_code == 400, resp.text
+        assert "http://" in resp.json()["detail"]
+        assert settings.notifications.instance_url == original[0]
+    finally:
+        settings.notifications.instance_url, settings.notifications.email.dashboard_url = original

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -72,6 +72,10 @@ as above. **Frigate** opens the same tracked object in Frigate's Explore page in
 saved, notifications carry no link and the settings card says so, with a shortcut to Integrations.
 A preview line under the choice shows the exact address the next notification will carry.
 
+Either address must start with `http://` or `https://`; saving one without a scheme is refused
+with a message, because Discord and Telegram reject such a link and would drop the whole
+notification with it.
+
 Leave the field blank and notifications carry no link, as before. The link is only as reachable as
 the address you enter: a LAN address works on your network only, and a public address works from
 anywhere. Opening a detection needs the owner sign-in unless public access is enabled, so a link


### PR DESCRIPTION
## Outcome
Two defects found in the second-order review of #417/#422.

- **A scheme-less address silenced Discord and Telegram.** Discord rejects an embed `url` without a scheme and Telegram rejects a non-http(s) button URL; either error drops the whole notification, not just the link. An instance address typed as `feeder.local:9852` therefore killed those channels outright. The link builder now treats an address without `http://` or `https://` as no address (`public_base`), and `POST /api/settings` refuses to save one with a 400 whose message says what to type; the Settings page already surfaces that message as a toast.
- **Email contradicted the card.** With the Frigate target chosen and no Frigate public URL, the card says no link is sent, but email kept a "View in Dashboard" button from the legacy fallback. Email now carries exactly the link the other channels carry.

## Scope
Backend link module, one line in the email sender, settings validation, tests, notifications guide, changelog. No UI change: `type="url"` on the field plus the server message cover it.

## Verification
`pytest` on the touched files 91 passed (new: scheme-less instance and Frigate addresses, case-insensitive scheme, settings 400 with the original value untouched); `ruff` clean; docs consistency passed; `git diff --check` clean.

## Risk
An install that had saved a scheme-less `email.dashboard_url` before today loses that link until it is retyped with a scheme; it never worked as a clickable link in most mail clients anyway.