### PR TITLE
Agree on what a stable build is called, so tabs stop asking for a refresh (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stable installs no longer see "YA-WAMF was updated while this tab was open" on every load**
+  ([#432](https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/issues/432)). The bundle and the
+  backend disagreed about what a stable build is called: the backend dropped the channel label for
+  `main`, `stable` and `unknown`, while the bundle dropped it only for `main` and `unknown`, so
+  every stable image shipped a bundle stamped `2.19.4-stable+hash` against a backend reporting
+  `2.19.4+hash`. The deploy-recovery check read that as two deployments, reloaded each tab once and
+  warned on every load after that, hard refresh included. Dev builds carry `-dev` on both sides,
+  which is why the reference install never showed it. One rule now lives in `app-version.ts` and
+  `backend/app/version.py`, a contract test keeps the two channel lists identical, and the
+  recovery check ignores a release-like label so bundles already installed stop warning as soon as
+  they load this backend. In passing, the backend's tag-name check was matching a literal
+  backslash and could never recognise `v2.19.4`; it does now.
+
 ## [2.19.4] - 2026-09-09
 
 ### Added

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -8,6 +8,12 @@ Last reviewed against the GitHub issue tracker on **September 7, 2026**.
 
 ## P0: Active Regressions
 
+- **#432 "YA-WAMF was updated while this tab was open" on every load of the 2.19.4 stable image.**
+  Root cause found and fixed in dev: the bundle kept the `-stable` channel label in its version
+  string and the backend did not, so the deploy-recovery check saw two deployments. Affects every
+  stable install of 2.19.4 (and 2.19.3, which had the same rule); the reference install runs the
+  dev channel and never showed it. Needs a 2.19.5 release to reach stable users.
+
 - None currently confirmed as unresolved in current `dev`.
 
 ## Pending Verification (Fixes in Dev, Awaiting Reporter Confirmation)

--- a/apps/ui/src/lib/app/app-version.test.ts
+++ b/apps/ui/src/lib/app/app-version.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { RELEASE_LIKE_CHANNELS, composeAppVersion, deploymentIdentity, isReleaseLikeChannel } from './app-version';
+
+describe('app version composition', () => {
+    it('omits the label for every release-like channel, stable included', () => {
+        for (const channel of RELEASE_LIKE_CHANNELS) {
+            expect(composeAppVersion('2.19.4', channel, 'e6f3ea6')).toBe('2.19.4+e6f3ea6');
+        }
+    });
+
+    it('treats a tag name as a release, as the backend does', () => {
+        expect(isReleaseLikeChannel('v2.19.4')).toBe(true);
+        expect(composeAppVersion('2.19.4', 'v2.19.4', 'e6f3ea6')).toBe('2.19.4+e6f3ea6');
+    });
+
+    it('keeps the label for a working channel', () => {
+        expect(composeAppVersion('2.19.4', 'dev', 'e6f3ea6')).toBe('2.19.4-dev+e6f3ea6');
+        expect(composeAppVersion('2.19.4', 'feature/x', 'e6f3ea6')).toBe('2.19.4-feature/x+e6f3ea6');
+    });
+});
+
+describe('deployment identity', () => {
+    it('is the same for a stable-labelled bundle and an unlabelled backend (#432)', () => {
+        expect(deploymentIdentity('2.19.4-stable+e6f3ea6')).toBe('2.19.4');
+        expect(deploymentIdentity('2.19.4+e6f3ea6')).toBe('2.19.4');
+    });
+
+    it('keeps a working channel distinct from a release', () => {
+        expect(deploymentIdentity('2.19.4-dev+e6f3ea6')).toBe('2.19.4-dev');
+        expect(deploymentIdentity('2.19.4')).toBe('2.19.4');
+    });
+});

--- a/apps/ui/src/lib/app/app-version.ts
+++ b/apps/ui/src/lib/app/app-version.ts
@@ -1,0 +1,33 @@
+/**
+ * One rule for what a build calls itself, shared by the bundle (vite.config.ts) and the
+ * deploy-recovery check. The backend applies the same rule in `backend/app/version.py`, and a
+ * contract test keeps the two channel lists identical.
+ */
+
+/** Channels whose builds are the release itself; their label never appears in the version. */
+export const RELEASE_LIKE_CHANNELS = ['main', 'stable', 'unknown'] as const;
+
+const TAG_NAME = /^v\d+\.\d+\.\d+(?:\.\d+)?$/;
+
+export function isReleaseLikeChannel(branch: string): boolean {
+    const name = branch.trim();
+    return name === '' || (RELEASE_LIKE_CHANNELS as readonly string[]).includes(name) || TAG_NAME.test(name);
+}
+
+/** `base-branch+hash`, with the branch omitted for release-like channels. */
+export function composeAppVersion(base: string, branch: string, hash: string): string {
+    return isReleaseLikeChannel(branch) ? `${base}+${hash}` : `${base}-${branch}+${hash}`;
+}
+
+/**
+ * What two builds share when only their channel label differs. A stable bundle stamped
+ * `2.19.4-stable+abc` and a backend reporting `2.19.4+abc` are the same deployment; a dev
+ * bundle against a release backend is not, and keeps its `-dev`.
+ */
+export function deploymentIdentity(version: string): string {
+    const core = version.split('+')[0]?.trim() ?? '';
+    const dash = core.indexOf('-');
+    if (dash < 0) return core;
+    const label = core.slice(dash + 1);
+    return isReleaseLikeChannel(label) ? core.slice(0, dash) : core;
+}

--- a/apps/ui/src/lib/app/deploy-recovery.test.ts
+++ b/apps/ui/src/lib/app/deploy-recovery.test.ts
@@ -171,6 +171,35 @@ describe('createDeployRecovery', () => {
         expect(reload).toHaveBeenCalledTimes(1);
     });
 
+    it('treats a stable-labelled bundle and an unlabelled backend of the same build as one deployment (#432)', () => {
+        const reload = vi.fn();
+        const warn = vi.fn();
+        const recovery = createDeployRecovery({
+            appVersion: '2.19.4-stable+e6f3ea6',
+            storage: createStorage(),
+            reload,
+            warn
+        });
+
+        expect(recovery.observeHealth({ version: '2.19.4+e6f3ea6' })).toBe('ignore');
+        expect(recovery.observeHealth({ version: '2.19.4+e6f3ea6' })).toBe('ignore');
+        expect(reload).not.toHaveBeenCalled();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('still reloads a stable bundle when the backend moves to a new build', () => {
+        const reload = vi.fn();
+        const recovery = createDeployRecovery({
+            appVersion: '2.19.4-stable+e6f3ea6',
+            storage: createStorage(),
+            reload,
+            warn: vi.fn()
+        });
+
+        expect(recovery.observeHealth({ version: '2.19.5+0badf00' })).toBe('reload');
+        expect(reload).toHaveBeenCalledTimes(1);
+    });
+
     it('reloads when transitioning from dev prerelease to a release build of the same version', () => {
         const storage = createStorage();
         const reload = vi.fn();

--- a/apps/ui/src/lib/app/deploy-recovery.ts
+++ b/apps/ui/src/lib/app/deploy-recovery.ts
@@ -1,3 +1,5 @@
+import { deploymentIdentity } from './app-version';
+
 export type DeployRecoveryAction = 'ignore' | 'reload' | 'warn';
 export type DeployRecoveryReason = 'runtime_failure' | 'version_mismatch';
 
@@ -43,11 +45,6 @@ function normalizeString(value: unknown): string {
     return typeof value === 'string' ? value.trim() : '';
 }
 
-function stripBuildMetadata(version: string): string {
-    const plusIdx = version.indexOf('+');
-    return plusIdx >= 0 ? version.slice(0, plusIdx) : version;
-}
-
 function getBuildMetadata(version: string): string {
     const plusIdx = version.indexOf('+');
     return plusIdx >= 0 ? version.slice(plusIdx + 1).trim().toLowerCase() : '';
@@ -63,13 +60,18 @@ function hasConcreteBuildMetadata(version: string): boolean {
  * suffix identifies the deployed frontend bundle. Two concrete, different
  * suffixes therefore mean an open tab is running stale code. Local/unknown
  * builds fall back to the SemVer identity to avoid reload loops in development.
+ *
+ * The channel label is not part of the identity when it is release-like: a stable
+ * bundle stamped `2.19.4-stable+abc` and a backend reporting `2.19.4+abc` are one
+ * deployment, and treating them as two reloaded every stable tab once and warned
+ * on every load after that (#432).
  */
 function isSameDeployment(appVersion: string, backendVersion: string): boolean {
-    if (stripBuildMetadata(appVersion) !== stripBuildMetadata(backendVersion)) {
+    if (deploymentIdentity(appVersion) !== deploymentIdentity(backendVersion)) {
         return false;
     }
     if (hasConcreteBuildMetadata(appVersion) && hasConcreteBuildMetadata(backendVersion)) {
-        return appVersion === backendVersion;
+        return getBuildMetadata(appVersion) === getBuildMetadata(backendVersion);
     }
     return true;
 }

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, type Plugin } from 'vite'
+import { composeAppVersion } from './src/lib/app/app-version';
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { execSync } from 'child_process'
 import { readFileSync } from 'fs'
@@ -87,11 +88,8 @@ const baseVersion = getBaseVersion();
 const gitHash = getGitHash();
 const appBranch = getAppBranch();
 
-// Format: version-branch+hash (omit branch if main or unknown)
-let appVersion = `${baseVersion}+${gitHash}`;
-if (appBranch && appBranch !== 'main' && appBranch !== 'unknown') {
-    appVersion = `${baseVersion}-${appBranch}+${gitHash}`;
-}
+// One rule with the backend: release-like channels (main, stable, a tag) carry no label.
+const appVersion = composeAppVersion(baseVersion, appBranch, gitHash);
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,6 @@ import asyncio
 import ipaddress
 import os
 import json
-import re
 from datetime import datetime, timedelta, timezone
 import sys  # Trigger CI rebuild
 from time import monotonic
@@ -32,6 +31,7 @@ from app.services.media_integrity_scan import (
     get_media_integrity_scan_status,
     run_media_integrity_scan,
 )
+from app.version import compose_app_version, normalize_app_branch
 from app.services.mqtt_service import mqtt_service
 from app.services.classifier_service import (
     CLASSIFIER_ACCEL_PROBE_TTL_SECONDS,
@@ -153,15 +153,8 @@ GIT_HASH = get_git_hash()
 ACCEL_CAPS_REFRESH_SECONDS = min(60.0, CLASSIFIER_ACCEL_PROBE_TTL_SECONDS)
 APP_BRANCH = get_app_branch()
 
-# Treat semver-like tags (e.g. v2.7.9.1) as releases, not branches.
-if re.fullmatch(r"v\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?", APP_BRANCH or ""):
-    APP_BRANCH = "main"
-
-# Format: version-branch+hash (omit branch for release-like channels)
-if APP_BRANCH and APP_BRANCH not in ["main", "stable", "unknown"]:
-    APP_VERSION = f"{BASE_VERSION}-{APP_BRANCH}+{GIT_HASH}"
-else:
-    APP_VERSION = f"{BASE_VERSION}+{GIT_HASH}"
+APP_BRANCH = normalize_app_branch(APP_BRANCH)
+APP_VERSION = compose_app_version(BASE_VERSION, APP_BRANCH, GIT_HASH)
 
 os.environ["APP_VERSION"] = APP_VERSION  # Make available to other services
 os.environ["APP_BRANCH"] = APP_BRANCH

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -1,0 +1,27 @@
+"""What a build calls itself. The bundle applies the same rule in
+`apps/ui/src/lib/app/app-version.ts`; a contract test keeps the two channel lists identical."""
+
+import re
+
+# Channels whose builds are the release itself; their label never appears in the version.
+RELEASE_LIKE_CHANNELS = ("main", "stable", "unknown")
+
+_TAG_NAME = re.compile(r"v\d+\.\d+\.\d+(?:\.\d+)?")
+
+
+def is_release_like_channel(branch: str | None) -> bool:
+    name = (branch or "").strip()
+    return name == "" or name in RELEASE_LIKE_CHANNELS or bool(_TAG_NAME.fullmatch(name))
+
+
+def normalize_app_branch(branch: str | None) -> str:
+    """A tag name is a release, not a branch."""
+    name = (branch or "").strip() or "unknown"
+    return "main" if _TAG_NAME.fullmatch(name) else name
+
+
+def compose_app_version(base: str, branch: str | None, git_hash: str) -> str:
+    """`base-branch+hash`, with the branch omitted for release-like channels."""
+    if is_release_like_channel(branch):
+        return f"{base}+{git_hash}"
+    return f"{base}-{branch}+{git_hash}"

--- a/backend/tests/test_app_version.py
+++ b/backend/tests/test_app_version.py
@@ -1,0 +1,37 @@
+"""The bundle and the backend must agree on what a build calls itself (#432).
+
+A stable image stamped its bundle `2.19.4-stable+hash` while the backend said `2.19.4+hash`;
+the browser read the two as different deployments, reloaded once and warned on every load.
+"""
+
+import re
+from pathlib import Path
+
+from app.version import RELEASE_LIKE_CHANNELS, compose_app_version, is_release_like_channel, normalize_app_branch
+
+
+def test_release_like_channels_carry_no_label():
+    for channel in RELEASE_LIKE_CHANNELS:
+        assert compose_app_version("2.19.4", channel, "e6f3ea6") == "2.19.4+e6f3ea6"
+
+
+def test_a_tag_name_is_a_release_not_a_branch():
+    assert normalize_app_branch("v2.19.4") == "main"
+    assert normalize_app_branch("v2.7.9.1") == "main"
+    assert is_release_like_channel("v2.19.4")
+    assert compose_app_version("2.19.4", "v2.19.4", "e6f3ea6") == "2.19.4+e6f3ea6"
+
+
+def test_a_working_channel_keeps_its_label():
+    assert normalize_app_branch("dev") == "dev"
+    assert compose_app_version("2.19.4", "dev", "e6f3ea6") == "2.19.4-dev+e6f3ea6"
+
+
+def test_the_bundle_uses_the_same_channel_list():
+    frontend = (
+        Path(__file__).resolve().parents[2] / "apps" / "ui" / "src" / "lib" / "app" / "app-version.ts"
+    ).read_text(encoding="utf-8")
+    match = re.search(r"RELEASE_LIKE_CHANNELS = \[([^\]]*)\]", frontend)
+    assert match, "the frontend no longer declares RELEASE_LIKE_CHANNELS"
+    frontend_channels = tuple(re.findall(r"'([^']+)'", match.group(1)))
+    assert frontend_channels == RELEASE_LIKE_CHANNELS


### PR DESCRIPTION
## Outcome
Fixes #432. On every stable image, the bundle called itself `2.19.4-stable+hash` while the backend reported `2.19.4+hash`: the backend omits the channel label for `main`, `stable` and `unknown`, the bundle omitted it only for `main` and `unknown`. The deploy-recovery check compares the part before `+`, saw two deployments, reloaded each tab once (session-scoped attempt memory) and warned on every load after that, hard refresh included. Dev builds carry `-dev` on both sides, so the reference install never showed it; the reporter had been on dev builds throughout #300 and 2.19.4 was the first stable image he ran.

Two-sided fix:
- **One rule.** `apps/ui/src/lib/app/app-version.ts` (`RELEASE_LIKE_CHANNELS`, `composeAppVersion`, `deploymentIdentity`) is used by `vite.config.ts`; `backend/app/version.py` (`compose_app_version`, `normalize_app_branch`) is used by `main.py`. A backend contract test reads the frontend file and asserts the two channel lists are identical.
- **Tolerant comparison.** `isSameDeployment` now compares the deployment identity with any release-like label removed, then the build hash. A `-stable` bundle already installed on a user's browser stops warning the moment it loads a backend with this fix, without waiting for a rebuilt bundle.
- **In passing:** the backend's tag-name regex was written with `\\d` inside a raw string, so it matched a literal backslash and never recognised `v2.19.4`. The extracted function uses the intended pattern and is tested.

## Verification
- Proven both ways: `APP_BRANCH=stable GIT_HASH=e6f3ea6 npm run build` now embeds `2.19.4+e6f3ea6`; the backend with the same env reports `2.19.4+e6f3ea6`; a tag-named `APP_BRANCH=v2.19.4` reports the same with branch `main`.
- New tests use the reporter's exact strings: recovery returns `ignore` for `2.19.4-stable+e6f3ea6` against `2.19.4+e6f3ea6`, still `reload` for a new build; existing semantics (dev-to-release reloads, hash change reloads, unknown metadata ignored) unchanged.
- `pytest` 2836 passed; `npm test` 187 files / 1031 tests; `svelte-check` 0/0; `npm run lint:dead` clean; `npm run build` ok; ruff clean repo-wide; docs consistency passed; `git diff --check` clean.

## Scope
- Included: the rule, the comparison, tests, changelog, tracker (P0 entry).
- Excluded: a release. Stable users need 2.19.5 to get this; until then the banner is cosmetic (the tab is running the right build).

## Risk
Version strings for dev builds are unchanged. Stable builds change from `X.Y.Z-stable+hash` to `X.Y.Z+hash` in the bundle only, which is what the backend, the diagnostics bundle and the update prompt already used.