### PR TITLE
Promote the release build the tag run made; link the changelog for the running build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -567,6 +567,14 @@ jobs:
       - name: Set lowercase owner name
         run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
+      # Three runs can build this commit at once: a push to main, its release tag, and the
+      # dev fast-forward. Each stamps a different APP_BRANCH, and until 2.19.6 they all pushed
+      # the same `<sha>` canary tag, so the tag run promoted whichever build landed last
+      # (v2.19.4 shipped labelled `dev`, v2.19.5 `main`; #437). Keying the canary on the ref
+      # too means each run promotes only what it built.
+      - name: Name this run's canary image
+        run: echo "CANARY=${GITHUB_SHA}-$(printf '%s' "${GITHUB_REF_NAME}" | tr -c 'A-Za-z0-9_.-' '-')" >> $GITHUB_ENV
+
       # The GitHub Actions cache backend is unavailable with Buildx's default
       # Docker driver. Give every flavor job an isolated docker-container
       # builder before enabling the per-flavor GHA cache below.
@@ -615,14 +623,14 @@ jobs:
             org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
-            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ github.sha }}${{ matrix.suffix }}
+            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ env.CANARY }}${{ matrix.suffix }}
           cache-from: type=gha,scope=monolith-${{ matrix.flavor }}
           cache-to: ${{ matrix.cache_export }}
 
       - name: Smoke-test ${{ matrix.flavor }} image without an accelerator
         run: |
           tests/e2e/monolith_runtime_flavor_smoke.sh \
-            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ github.sha }}${{ matrix.suffix }}" \
+            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ env.CANARY }}${{ matrix.suffix }}" \
             "${{ matrix.flavor }}"
 
   build-monolith-rpi:
@@ -639,6 +647,14 @@ jobs:
 
       - name: Set lowercase owner name
         run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      # Three runs can build this commit at once: a push to main, its release tag, and the
+      # dev fast-forward. Each stamps a different APP_BRANCH, and until 2.19.6 they all pushed
+      # the same `<sha>` canary tag, so the tag run promoted whichever build landed last
+      # (v2.19.4 shipped labelled `dev`, v2.19.5 `main`; #437). Keying the canary on the ref
+      # too means each run promotes only what it built.
+      - name: Name this run's canary image
+        run: echo "CANARY=${GITHUB_SHA}-$(printf '%s' "${GITHUB_REF_NAME}" | tr -c 'A-Za-z0-9_.-' '-')" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -702,12 +718,12 @@ jobs:
             org.opencontainers.image.version=${{ env.APP_VERSION_BASE }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
-            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ github.sha }}
+            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ env.CANARY }}
 
       - name: Smoke-test Raspberry Pi image
         run: |
           tests/e2e/monolith_runtime_flavor_smoke.sh \
-            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ github.sha }}" \
+            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ env.CANARY }}" \
             "rpi" \
             "linux/arm64"
 
@@ -715,14 +731,14 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ env.IMAGE_TAG }} \
-            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ github.sha }}
+            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ env.CANARY }}
 
       - name: Tag Raspberry Pi monolithic latest
         if: env.PUBLISH_LATEST == 'true'
         run: |
           docker buildx imagetools create \
             -t ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:latest \
-            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ github.sha }}
+            ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic-rpi:${{ env.CANARY }}
 
   verify-monolith-flavor-switch:
     name: Verify full ↔ CPU persistent-state switching
@@ -738,6 +754,14 @@ jobs:
       - name: Set lowercase owner name
         run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
+      # Three runs can build this commit at once: a push to main, its release tag, and the
+      # dev fast-forward. Each stamps a different APP_BRANCH, and until 2.19.6 they all pushed
+      # the same `<sha>` canary tag, so the tag run promoted whichever build landed last
+      # (v2.19.4 shipped labelled `dev`, v2.19.5 `main`; #437). Keying the canary on the ref
+      # too means each run promotes only what it built.
+      - name: Name this run's canary image
+        run: echo "CANARY=${GITHUB_SHA}-$(printf '%s' "${GITHUB_REF_NAME}" | tr -c 'A-Za-z0-9_.-' '-')" >> $GITHUB_ENV
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -748,8 +772,8 @@ jobs:
       - name: Switch full to CPU and back with shared persistent state
         run: |
           tests/e2e/monolith_runtime_flavor_switch.sh \
-            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ github.sha }}" \
-            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ github.sha }}-cpu" \
+            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ env.CANARY }}" \
+            "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${{ env.CANARY }}-cpu" \
             cpu
 
   promote-monolith-flavors:
@@ -762,6 +786,14 @@ jobs:
     steps:
       - name: Set lowercase owner name
         run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      # Three runs can build this commit at once: a push to main, its release tag, and the
+      # dev fast-forward. Each stamps a different APP_BRANCH, and until 2.19.6 they all pushed
+      # the same `<sha>` canary tag, so the tag run promoted whichever build landed last
+      # (v2.19.4 shipped labelled `dev`, v2.19.5 `main`; #437). Keying the canary on the ref
+      # too means each run promotes only what it built.
+      - name: Name this run's canary image
+        run: echo "CANARY=${GITHUB_SHA}-$(printf '%s' "${GITHUB_REF_NAME}" | tr -c 'A-Za-z0-9_.-' '-')" >> $GITHUB_ENV
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -788,14 +820,14 @@ jobs:
           set -euo pipefail
           for suffix in "" -cpu -intel -cuda; do
             docker buildx imagetools inspect \
-              "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${GITHUB_SHA}${suffix}" >/dev/null
+              "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${CANARY}${suffix}" >/dev/null
           done
 
       - name: Promote the verified flavor family
         run: |
           set -euo pipefail
           for suffix in "" -cpu -intel -cuda; do
-            source="ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${GITHUB_SHA}${suffix}"
+            source="ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${CANARY}${suffix}"
             docker buildx imagetools create \
               -t "ghcr.io/${{ env.OWNER_LC }}/yawamf-monalithic:${IMAGE_TAG}${suffix}" \
               "$source"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A release image is labelled as a release.** A push to `main`, its release tag, and the
+  `dev` fast-forward all build the same commit within minutes of each other, and each pushed
+  its monolith canary to the same `<sha>` tag. The tag run then promoted whichever build had
+  landed last: `latest*` for 2.19.4 carried the `dev` label and 2.19.5 the `main` label, never
+  the `stable` one the release job sets. Canary tags now carry the ref as well as the sha, so
+  each run promotes only the image it built.
+- **The footer's version link opens the changelog for the build you are running.** It pointed
+  every install, releases included, at the `dev` changelog, which read as "this image is the
+  dev branch" (#437). It now uses the same rule as the About page: a release links to `main`,
+  a working channel to its own branch, and a `stable`-labelled build no longer links to a
+  branch that does not exist.
+
 ## [2.19.5] - 2026-09-10
 
 ### Fixed

--- a/apps/ui/src/lib/app/app-version.test.ts
+++ b/apps/ui/src/lib/app/app-version.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { RELEASE_LIKE_CHANNELS, composeAppVersion, deploymentIdentity, isReleaseLikeChannel } from './app-version';
+import {
+    RELEASE_LIKE_CHANNELS,
+    composeAppVersion,
+    deploymentIdentity,
+    docsRefForBranch,
+    isReleaseLikeChannel
+} from './app-version';
 
 describe('app version composition', () => {
     it('omits the label for every release-like channel, stable included', () => {
@@ -28,5 +34,18 @@ describe('deployment identity', () => {
     it('keeps a working channel distinct from a release', () => {
         expect(deploymentIdentity('2.19.4-dev+e6f3ea6')).toBe('2.19.4-dev');
         expect(deploymentIdentity('2.19.4')).toBe('2.19.4');
+    });
+});
+
+describe('docs reference branch', () => {
+    it('sends every release-like build to main, stable and tag builds included (#437)', () => {
+        for (const channel of [...RELEASE_LIKE_CHANNELS, 'v2.19.5', '', ' stable ']) {
+            expect(docsRefForBranch(channel)).toBe('main');
+        }
+    });
+
+    it('sends a working channel to its own branch', () => {
+        expect(docsRefForBranch('dev')).toBe('dev');
+        expect(docsRefForBranch(' feature/x ')).toBe('feature/x');
     });
 });

--- a/apps/ui/src/lib/app/app-version.ts
+++ b/apps/ui/src/lib/app/app-version.ts
@@ -14,6 +14,15 @@ export function isReleaseLikeChannel(branch: string): boolean {
     return name === '' || (RELEASE_LIKE_CHANNELS as readonly string[]).includes(name) || TAG_NAME.test(name);
 }
 
+/**
+ * The branch whose changelog and docs a build should link to. A release-like build (`stable`,
+ * `main`, a tag, or no label at all) reads `main`; a working channel reads its own branch. The
+ * footer once linked every build, releases included, to the dev changelog (#437).
+ */
+export function docsRefForBranch(branch: string): string {
+    return isReleaseLikeChannel(branch) ? 'main' : branch.trim();
+}
+
 /** `base-branch+hash`, with the branch omitted for release-like channels. */
 export function composeAppVersion(base: string, branch: string, hash: string): string {
     return isReleaseLikeChannel(branch) ? `${base}+${hash}` : `${base}-${branch}+${hash}`;

--- a/apps/ui/src/lib/components/Footer.svelte
+++ b/apps/ui/src/lib/components/Footer.svelte
@@ -2,6 +2,7 @@
     import { onMount } from 'svelte';
     import { _, json } from 'svelte-i18n';
     import { fetchVersion, type VersionInfo } from '../api';
+    import { docsRefForBranch } from '../app/app-version';
 
     const appVersion = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'unknown';
     const appVersionBase = appVersion.includes('+') ? appVersion.split('+')[0] : appVersion;
@@ -97,7 +98,7 @@
                 </span>
                 <span class="hidden sm:inline text-slate-400 dark:text-slate-500">|</span>
                 <a
-                    href="https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/blob/dev/CHANGELOG.md"
+                    href={`https://github.com/Jellman86/YetAnother-WhosAtMyFeeder/blob/${docsRefForBranch(versionInfo.branch)}/CHANGELOG.md`}
                     target="_blank"
                     rel="noopener noreferrer"
                     class="hover:text-brand-600 dark:hover:text-brand-400 transition-colors"

--- a/apps/ui/src/lib/pages/About.svelte
+++ b/apps/ui/src/lib/pages/About.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { fetchVersion, type VersionInfo } from '../api';
+    import { docsRefForBranch } from '../app/app-version';
     import { APP_ICON_192_URL } from '../assets';
     import InstancePipeline from '../components/InstancePipeline.svelte';
     import InstanceSummary from '../components/InstanceSummary.svelte';
@@ -72,9 +73,7 @@
     });
 
     const repoUrl = 'https://github.com/Jellman86/YetAnother-WhosAtMyFeeder';
-    let docsRefBranch = $derived(
-        versionInfo.branch && versionInfo.branch !== 'unknown' ? versionInfo.branch : 'main'
-    );
+    let docsRefBranch = $derived(docsRefForBranch(versionInfo.branch));
 
     const linkToken = '{link}';
     const splitLinkTemplate = (text: string): LinkParts => {

--- a/backend/tests/test_deployment_contract.py
+++ b/backend/tests/test_deployment_contract.py
@@ -110,7 +110,7 @@ def test_each_published_runtime_flavor_gets_a_no_accelerator_smoke_test() -> Non
     assert smoke_script.exists()
     assert "monolith_runtime_flavor_smoke.sh" in workflow
     assert "${{ matrix.flavor }}" in workflow
-    assert "${{ github.sha }}${{ matrix.suffix }}" in workflow
+    assert "${{ env.CANARY }}${{ matrix.suffix }}" in workflow
 
 
 def test_runtime_flavor_builds_use_a_cache_capable_buildx_driver() -> None:
@@ -137,7 +137,7 @@ def test_publication_is_blocked_until_full_and_cpu_share_persistent_state() -> N
     assert "verify-monolith-flavor-switch:" in workflow
     assert "needs: [build-monolith]" in workflow
     assert "needs: [promote-monolith-flavors]" in workflow
-    assert "${{ github.sha }}-cpu" in workflow
+    assert "${{ env.CANARY }}-cpu" in workflow
     assert "/config/config.json" in switch_contract
     assert "/data/speciesid.db" in switch_contract
     assert "/data/models/runtime-flavor-switch-contract/model.onnx" in switch_contract
@@ -154,7 +154,7 @@ def test_mutable_monolith_tags_are_promoted_only_after_switch_verification() -> 
     assert "promote-monolith-flavors:" in workflow
     assert "needs: [verify-monolith-flavor-switch]" in promotion_job
     assert "${{ env.IMAGE_TAG }}${{ matrix.suffix }}" not in build_job
-    assert "${{ github.sha }}${{ matrix.suffix }}" in build_job
+    assert "${{ env.CANARY }}${{ matrix.suffix }}" in build_job
     assert "docker buildx imagetools inspect" in promotion_job
     assert "docker buildx imagetools create" in promotion_job
     assert "needs: [promote-monolith-flavors]" in workflow
@@ -220,7 +220,7 @@ def test_rpi_image_is_smoked_before_mutable_tags_are_promoted() -> None:
     rpi_job = workflow.split("  build-monolith-rpi:", 1)[1].split("  verify-monolith-flavor-switch:", 1)[0]
     smoke = (REPO_ROOT / "tests/e2e/monolith_runtime_flavor_smoke.sh").read_text(encoding="utf-8")
 
-    immutable_tag = "yawamf-monalithic-rpi:${{ github.sha }}"
+    immutable_tag = "yawamf-monalithic-rpi:${{ env.CANARY }}"
     assert immutable_tag in rpi_job
     assert "monolith_runtime_flavor_smoke.sh" in rpi_job
     assert '"rpi"' in rpi_job
@@ -229,6 +229,34 @@ def test_rpi_image_is_smoked_before_mutable_tags_are_promoted() -> None:
     assert 'docker_args+=(--platform "$platform")' in smoke
     assert "yawamf-monalithic-rpi:${{ env.IMAGE_TAG }}" not in rpi_job.split("Smoke-test Raspberry Pi image", 1)[0]
     assert rpi_job.index("Smoke-test Raspberry Pi image") < rpi_job.index("Promote Raspberry Pi monolithic tag")
+
+
+def test_each_run_promotes_only_the_canary_it_built() -> None:
+    """The canary tag is keyed on the ref as well as the sha (#437).
+
+    A push to main, its release tag, and the dev fast-forward build the same commit
+    within minutes, each stamped with a different APP_BRANCH. When all three pushed
+    the same `<sha>` canary, the tag run promoted whichever build landed last:
+    v2.19.4's `latest*` said `dev`, v2.19.5's said `main`, and neither said `stable`.
+    """
+    workflow = (REPO_ROOT / ".github/workflows/build-and-push.yml").read_text(encoding="utf-8")
+    monolith_jobs = workflow[workflow.index("  build-monolith:") : workflow.index("  publish-version:")]
+    canary_step = "CANARY=${GITHUB_SHA}-$(printf '%s' \"${GITHUB_REF_NAME}\""
+
+    for job in (
+        "build-monolith:",
+        "build-monolith-rpi:",
+        "verify-monolith-flavor-switch:",
+        "promote-monolith-flavors:",
+    ):
+        assert job in monolith_jobs
+    assert monolith_jobs.count(canary_step) == 4, "every monolith job names the canary the same way"
+    assert "yawamf-monalithic:${{ github.sha }}" not in monolith_jobs
+    assert "yawamf-monalithic-rpi:${{ github.sha }}" not in monolith_jobs
+    assert "yawamf-monalithic:${GITHUB_SHA}${suffix}" not in monolith_jobs
+    assert "yawamf-monalithic:${CANARY}${suffix}" in monolith_jobs
+    # The OCI revision label still names the commit; only the tag carries the ref.
+    assert "org.opencontainers.image.revision=${{ github.sha }}" in monolith_jobs
 
 
 def test_images_bundle_a_checksum_verified_cpu_fallback_classifier() -> None:


### PR DESCRIPTION
## Outcome

Fixes the mislabelled release images behind #437 and the footer link that made a release look like the dev branch.

- **Workflow.** The monolith canary tag is now `<sha>-<ref>` instead of `<sha>`. A push to `main`, its release tag, and the `dev` fast-forward all build the same commit within minutes, and until now each overwrote the same canary; the tag run's promote job then copied whichever build landed last. Checked against ghcr: `v2.19.4-intel` is stamped `APP_BRANCH=dev`, `v2.19.5-intel` is stamped `main`. Neither is the `stable` the tag job sets. Each run now promotes only what it built. Same treatment for the Raspberry Pi image.
- **UI.** `docsRefForBranch()` in `app-version.ts` is the one rule for which branch a build's changelog and docs links open: release-like builds (`stable`, `main`, a tag, unlabelled) go to `main`, working channels to their own branch. The footer used it in place of a hardcoded `blob/dev/CHANGELOG.md`; About used it in place of its own `unknown → main` fallback, which would have produced `blob/stable/...` once the workflow fix lands.

## Not included

The `wamf-backend` and `wamf-frontend` sha tags are overwritten the same way, but their `latest` tags are set inside the tag run's own build job, so the race does not reach users there.

## Verification

- `npm test`: 188 files, 1043 tests pass, including new cases for `docsRefForBranch`.
- `npm run check`: 0 errors, 0 warnings. `npm run lint:dead`: clean.
- Workflow YAML parses; the canary step is a one-line env export repeated in the four monolith jobs, matching the file's existing style.
- The workflow change itself can only be proven by the next tag build: `v2.19.6-intel` should report `APP_BRANCH=stable` in its image config.

## Risk

No schema, settings, or API changes. Image consumers pull channel tags (`dev-intel`, `latest-intel`, `v2.19.6-intel`), which are unchanged; only the internal canary tag name moves.
