### PR TITLE
Review queue peek, and the record on a phone (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - **The identification's actions read Confirm, Pick a different species, Score again**, in that
   order and in the shared button kit. "Reclassify" is now "Score again" here; the bulk action
   keeps its name.
+- **The review queue peeks at the whole scene the same way.** Its own Best crop / Full frame
+  switch is gone, along with the crop strategy name (`sliced_2x2`) that leaked beside it. On a
+  phone the picture block keeps its own height, so the date line no longer draws over the
+  "What is it?" heading.
+- **The record works on a phone.** The frame comparison opens as a sheet at the foot of the
+  screen with a backdrop and its own Close, since there is no hover to lose; the identification's
+  actions and the whole-scene actions stack full width; and the hero title, which repeated the
+  rail's "Identified as" while covering the bird, is left to the rail on small screens.
 
 ## [2.19.6] - 2026-09-10
 

--- a/apps/ui/src/lib/components/DetectionModal.svelte
+++ b/apps/ui/src/lib/components/DetectionModal.svelte
@@ -39,14 +39,8 @@
     import { appApiPath } from '../app/url-base';
     import ReclassificationOverlay from './ReclassificationOverlay.svelte';
     import FrameStrip from './FrameStrip.svelte';
-    import {
-        currentMoment,
-        groupCandidatesIntoMoments,
-        preferredCandidate,
-        wholeSceneOutline,
-        type FrameMoment,
-        type OutlineBox
-    } from '../utils/frame-moments';
+    import { currentMoment, groupCandidatesIntoMoments, preferredCandidate, type FrameMoment } from '../utils/frame-moments';
+    import { WholeScenePeek } from '../utils/whole-scene-peek.svelte';
     import VideoAnalysisFilmReel from './VideoAnalysisFilmReel.svelte';
     import { detectionsStore, type ReclassificationProgress } from '../stores/detections.svelte';
     import { settingsStore } from '../stores/settings.svelte';
@@ -717,13 +711,10 @@
         };
     });
 
-    // The photograph is always the crop. The whole scene is a look, not a mode (#256): hover
-    // or focus peeks at it with the crop outlined, and a click pins it so the one rescue that
-    // needs the whole scene can be offered. Persisting anything stays a named action.
-    let mediaView = $state<'stored' | 'whole'>('stored');
-    let wholeScenePinned = $state(false);
+    // The photograph is always the crop. The whole scene is a look, not a mode (#256): the shared
+    // controller peeks on hover or focus with the crop outlined and pins on click, so the one
+    // rescue that needs the whole scene can be offered. Persisting anything stays a named action.
     let heroImageEl = $state<HTMLImageElement | null>(null);
-    let wholeSceneOutlineBox = $state<OutlineBox | null>(null);
     // Frigate's own snapshot has no candidate record, so the "matching" whole frame would be
     // another moment's: different evidence, not a safe peek.
     const canPeekWholeScene = $derived(
@@ -731,17 +722,17 @@
         && currentSnapshotSource !== 'frigate_snapshot'
         && !!(fullFrameSnapshotCandidate?.image_url ?? fullFrameSnapshotCandidate?.thumbnail_url)
     );
-    const showingWholeScene = $derived(mediaView === 'whole' && canPeekWholeScene);
+    const wholeScene = new WholeScenePeek(() => canPeekWholeScene);
     const currentCropCandidate = $derived(
         snapshotCandidates.find((candidate) => candidate.candidate_id === currentSnapshotCandidateId)
             ?? snapshotCandidates.find((candidate) => candidate.selected)
             ?? null
     );
     const mediaImageUrl = $derived.by(() => {
-        if (showingWholeScene && fullFrameSnapshotCandidate?.image_url) {
+        if (wholeScene.showing && fullFrameSnapshotCandidate?.image_url) {
             return fullFrameSnapshotCandidate.image_url;
         }
-        if (showingWholeScene && fullFrameSnapshotCandidate?.thumbnail_url) {
+        if (wholeScene.showing && fullFrameSnapshotCandidate?.thumbnail_url) {
             return fullFrameSnapshotCandidate.thumbnail_url;
         }
         return snapshotImageUrl;
@@ -749,32 +740,23 @@
     $effect(() => {
         // A new detection starts on its own stored frame.
         void detection.frigate_event;
-        resetMediaView();
+        wholeScene.reset();
     });
-    // The outline is a DOM measurement: the drawn size of a `contain`ed image is not knowable
-    // from state, so it is read from the element once the whole scene has loaded and again
-    // when the window changes size.
+    // The outline is a DOM measurement, taken once the whole scene has loaded and again when
+    // the window changes size.
+    function measureWholeScene() {
+        wholeScene.measure(heroImageEl, currentCropCandidate?.crop_box);
+    }
     $effect(() => {
-        if (!showingWholeScene) {
-            wholeSceneOutlineBox = null;
+        if (!wholeScene.showing) {
+            wholeScene.outline = null;
             return;
         }
         measureWholeScene();
         window.addEventListener('resize', measureWholeScene);
         return () => window.removeEventListener('resize', measureWholeScene);
     });
-    function measureWholeScene() {
-        const element = heroImageEl;
-        if (!element || mediaView !== 'whole') {
-            wholeSceneOutlineBox = null;
-            return;
-        }
-        wholeSceneOutlineBox = wholeSceneOutline(
-            currentCropCandidate?.crop_box,
-            { width: element.naturalWidth, height: element.naturalHeight },
-            { width: element.clientWidth, height: element.clientHeight }
-        );
-    }
+    onDestroy(wholeScene.destroy);
     const canGenerateSnapshotCandidates = $derived(
         !snapshotApplyPending
         && !snapshotGeneratePending
@@ -1452,54 +1434,7 @@
     }
 
     function resetMediaView() {
-        mediaView = 'stored';
-        wholeScenePinned = false;
-    }
-
-    // A pointer crossing the photograph on its way to Play or Close is not a request to see
-    // the whole scene, and the whole frame is a large fetch. Hover waits for intent; focus and
-    // touch do not.
-    const PEEK_INTENT_MS = 250;
-    let peekTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function peekWholeScene() {
-        if (peekTimer) {
-            clearTimeout(peekTimer);
-            peekTimer = null;
-        }
-        if (!canPeekWholeScene) return;
-        mediaView = 'whole';
-    }
-
-    function peekWholeSceneAfterIntent() {
-        if (!canPeekWholeScene || peekTimer) return;
-        peekTimer = setTimeout(() => {
-            peekTimer = null;
-            peekWholeScene();
-        }, PEEK_INTENT_MS);
-    }
-
-    function unpeekWholeScene() {
-        if (peekTimer) {
-            clearTimeout(peekTimer);
-            peekTimer = null;
-        }
-        if (wholeScenePinned) return;
-        mediaView = 'stored';
-    }
-
-    onDestroy(() => {
-        if (peekTimer) clearTimeout(peekTimer);
-    });
-
-    function toggleWholeScenePin() {
-        if (!canPeekWholeScene) return;
-        if (wholeScenePinned) {
-            resetMediaView();
-            return;
-        }
-        wholeScenePinned = true;
-        mediaView = 'whole';
+        wholeScene.reset();
     }
 
     async function useWholeSceneAsPhotograph() {
@@ -2181,7 +2116,7 @@
     onkeydown={(e) => {
         if (e.key !== 'Escape') return;
         // A pinned whole scene closes first; the record stays open.
-        if (wholeScenePinned) {
+        if (wholeScene.pinned) {
             e.preventDefault();
             resetMediaView();
             return;
@@ -2278,7 +2213,7 @@
                             src={mediaImageUrl}
                             alt={detection.display_name}
                             onload={measureWholeScene}
-                            class="relative h-full w-full {showingWholeScene
+                            class="relative h-full w-full {wholeScene.showing
                                 ? 'object-contain'
                                 : canPeekWholeScene ? 'object-cover' : 'object-contain'}"
                         />
@@ -2288,32 +2223,32 @@
                                  the crop outlined; a click pins it and offers the one rescue that needs it. -->
                             <button
                                 type="button"
-                                class="absolute inset-0 z-10 {wholeScenePinned ? 'cursor-zoom-out' : 'cursor-zoom-in'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/70"
+                                class="absolute inset-0 z-10 {wholeScene.pinned ? 'cursor-zoom-out' : 'cursor-zoom-in'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/70"
                                 data-detection-whole-scene-peek
-                                aria-pressed={wholeScenePinned}
-                                aria-label={wholeScenePinned
+                                aria-pressed={wholeScene.pinned}
+                                aria-label={wholeScene.pinned
                                     ? $_('detection.whole_scene_back', { default: 'Back to the crop' })
                                     : $_('detection.whole_scene_show', { default: 'Show the whole scene' })}
-                                onmouseenter={peekWholeSceneAfterIntent}
-                                onmouseleave={unpeekWholeScene}
-                                onfocus={peekWholeScene}
-                                onblur={unpeekWholeScene}
-                                onclick={(event) => { event.stopPropagation(); toggleWholeScenePin(); }}
+                                onmouseenter={wholeScene.enter}
+                                onmouseleave={wholeScene.leave}
+                                onfocus={wholeScene.show}
+                                onblur={wholeScene.leave}
+                                onclick={(event) => { event.stopPropagation(); wholeScene.toggle(); }}
                             ></button>
-                            {#if showingWholeScene && wholeSceneOutlineBox}
+                            {#if wholeScene.showing && wholeScene.outline}
                                 <div
                                     class="pointer-events-none absolute z-10 rounded-sm border-2 border-dashed border-white/85 shadow-[0_0_0_9999px_rgba(2,6,23,0.35)]"
-                                    style="left: {wholeSceneOutlineBox.left}px; top: {wholeSceneOutlineBox.top}px; width: {wholeSceneOutlineBox.width}px; height: {wholeSceneOutlineBox.height}px;"
+                                    style="left: {wholeScene.outline.left}px; top: {wholeScene.outline.top}px; width: {wholeScene.outline.width}px; height: {wholeScene.outline.height}px;"
                                     data-detection-whole-scene-outline
                                     aria-hidden="true"
                                 ></div>
                             {/if}
-                            {#if showingWholeScene}
+                            {#if wholeScene.showing}
                                 <span
                                     class="pointer-events-none absolute left-3 top-3 z-30 rounded-full border border-white/15 bg-slate-950/70 px-2.5 py-1 text-[11px] font-semibold text-white backdrop-blur-sm"
                                     data-detection-whole-scene-chip
                                 >
-                                    {wholeScenePinned
+                                    {wholeScene.pinned
                                         ? $_('detection.whole_scene_chip_pinned', { default: 'Whole scene, the crop is outlined' })
                                         : $_('detection.whole_scene_chip', { default: 'Whole scene' })}
                                 </span>
@@ -2324,7 +2259,9 @@
                             data-detection-media-footer
                         >
                             <div class="flex flex-col gap-3 px-5 {showInlineFramePicker ? 'pb-2' : 'pb-5'}">
-                                <div data-detection-media-title>
+                                <!-- On a phone the rail's "Identified as" sits right under the picture, so the
+                                     hero title would say it twice while covering the bird. -->
+                                <div class="hidden sm:block" data-detection-media-title>
                                     <h3 id="detection-modal-title" class="truncate text-xl font-bold leading-tight text-white drop-shadow-lg">{primaryName}</h3>
                                     {#if subName && subName !== primaryName}
                                         <p class="-mt-0.5 mb-0.5 truncate text-sm italic text-white/70 drop-shadow">{subName}</p>
@@ -2334,11 +2271,11 @@
                                     </p>
                                 </div>
 
-                                {#if wholeScenePinned && showingWholeScene}
-                                    <div class="flex flex-wrap items-center gap-2" data-detection-whole-scene-actions>
+                                {#if wholeScene.pinned && wholeScene.showing}
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center" data-detection-whole-scene-actions>
                                         <button
                                             type="button"
-                                            class="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/25 bg-black/55 px-4 text-[11px] font-semibold text-white shadow-xl backdrop-blur-sm transition-colors hover:bg-black/70 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                                            class="inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-white/25 bg-black/55 px-4 text-[11px] font-semibold text-white shadow-xl backdrop-blur-sm transition-colors hover:bg-black/70 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
                                             disabled={snapshotApplyPending || snapshotGeneratePending}
                                             onclick={(event) => { event.stopPropagation(); void useWholeSceneAsPhotograph(); }}
                                         >
@@ -2349,7 +2286,7 @@
                                         </button>
                                         <button
                                             type="button"
-                                            class="inline-flex min-h-11 items-center rounded-full border border-white/25 bg-black/40 px-4 text-[11px] font-semibold text-white/85 shadow-xl backdrop-blur-sm transition-colors hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                                            class="inline-flex min-h-11 items-center justify-center rounded-full border border-white/25 bg-black/40 px-4 text-[11px] font-semibold text-white/85 shadow-xl backdrop-blur-sm transition-colors hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
                                             onclick={(event) => { event.stopPropagation(); resetMediaView(); }}
                                         >
                                             {$_('detection.whole_scene_back', { default: 'Back to the crop' })}
@@ -3608,7 +3545,7 @@
             {#if hasOwnerDetectionActions}
                 <!-- The two decisions an owner makes about an identification, then the retry.
                      Each control names its effect. -->
-                <div class="flex flex-wrap gap-2" data-detection-identification-actions>
+                <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap" data-detection-identification-actions>
                     {#if !detection.manual_tagged && !isUnknownSpecies}
                         <button
                             type="button"
@@ -3619,7 +3556,7 @@
                                 common_name: detection.common_name ?? null
                             } as SearchResult)}
                             disabled={updatingTag}
-                            class="btn btn-primary min-h-11 flex-1 px-4 text-sm"
+                            class="btn btn-primary min-h-11 w-full px-4 text-sm sm:w-auto sm:flex-1"
                             data-detection-confirm
                         >
                             {updatingTag
@@ -3635,7 +3572,7 @@
                         type="button"
                         onclick={() => showTagDropdown = !showTagDropdown}
                         disabled={updatingTag}
-                        class="btn btn-secondary min-h-11 flex-1 px-4 text-sm"
+                        class="btn btn-secondary min-h-11 w-full px-4 text-sm sm:w-auto sm:flex-1"
                     >
                         {updatingTag
                             ? $_('common.saving')
@@ -3646,7 +3583,7 @@
                         <button
                             type="button"
                             onclick={handleReclassifyClick}
-                            class="btn btn-ghost min-h-11 px-4 text-sm"
+                            class="btn btn-ghost min-h-11 w-full px-4 text-sm sm:w-auto"
                             title={$_('actions.reclassify')}
                         >
                             {$_('detection.score_again', { default: 'Score again' })}

--- a/apps/ui/src/lib/components/FrameStrip.svelte
+++ b/apps/ui/src/lib/components/FrameStrip.svelte
@@ -61,11 +61,19 @@
     const GAP = 8;
     const VIEWPORT_MARGIN = 8;
 
-    let anchor = $state<{ x: number; y: number; above: boolean } | null>(null);
+    let anchor = $state<{ x: number; y: number; above: boolean; sheet: boolean } | null>(null);
+
+    // On a phone there is no room beside a thumbnail and no hover to lose: the panel becomes
+    // a sheet at the foot of the screen, with a backdrop and its own Close.
+    const SHEET_QUERY = '(max-width: 639px)';
 
     function place(index: number): void {
         const trigger = triggers[index];
         if (!trigger) return;
+        if (typeof window !== 'undefined' && window.matchMedia(SHEET_QUERY).matches) {
+            anchor = { x: 0, y: 0, above: false, sheet: true };
+            return;
+        }
         const rect = trigger.getBoundingClientRect();
         // The strip sits at the foot of the photograph, so the panel normally opens above it
         // and only drops below when the top of the window is too close.
@@ -76,7 +84,7 @@
             Math.max(rect.left + rect.width / 2, half + VIEWPORT_MARGIN),
             window.innerWidth - half - VIEWPORT_MARGIN
         );
-        anchor = { x: centre, y: above ? rect.top - GAP : rect.bottom + GAP, above };
+        anchor = { x: centre, y: above ? rect.top - GAP : rect.bottom + GAP, above, sheet: false };
     }
 
     function show(index: number): void {
@@ -341,13 +349,24 @@
                             {@const image = imageFor(moment)}
                             {@const read = readLine(moment)}
                             {@const applying = applyingKey === moment.key}
+                            {#if anchor.sheet}
+                                <div
+                                    use:portal
+                                    class="fixed inset-0 z-[69] bg-slate-950/50"
+                                    data-frame-strip-backdrop
+                                    onclick={() => hide(true)}
+                                    role="presentation"
+                                ></div>
+                            {/if}
                             <div
                                 bind:this={panelEl}
                                 use:portal
-                                style="left: {anchor.x}px; top: {anchor.y}px;"
-                                class="fixed z-[70] w-72 max-w-[calc(100vw-16px)] overflow-hidden rounded-2xl border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl shadow-slate-950/40 motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 {anchor.above
-                                    ? '-translate-x-1/2 -translate-y-full'
-                                    : '-translate-x-1/2'}"
+                                style={anchor.sheet ? '' : `left: ${anchor.x}px; top: ${anchor.y}px;`}
+                                class="fixed z-[70] overflow-hidden border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl shadow-slate-950/40 motion-safe:animate-in motion-safe:fade-in {anchor.sheet
+                                    ? 'inset-x-0 bottom-0 rounded-t-2xl motion-safe:slide-in-from-bottom-4'
+                                    : anchor.above
+                                      ? 'w-72 max-w-[calc(100vw-16px)] -translate-x-1/2 -translate-y-full rounded-2xl motion-safe:zoom-in-95'
+                                      : 'w-72 max-w-[calc(100vw-16px)] -translate-x-1/2 rounded-2xl motion-safe:zoom-in-95'}"
                                 role="presentation"
                                 data-frame-strip-panel
                                 onmouseenter={cancelScheduledClose}
@@ -356,19 +375,28 @@
                                 onkeydown={handlePanelKeydown}
                             >
                               <div
+                                class="relative"
                                 role="group"
                                 aria-label={$_('detection.frame_position', {
                                     values: { position: moment.position, count: moments.length },
                                     default: 'Frame {position} of {count}'
                                 })}
                               >
+                                <button
+                                    type="button"
+                                    class="absolute right-2 top-2 z-10 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/25 bg-slate-950/60 text-white backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                                    aria-label={$_('common.close', { default: 'Close' })}
+                                    onclick={(event) => { event.stopPropagation(); const current = openIndex; hide(true); if (current !== null) triggers[current]?.focus(); }}
+                                >
+                                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" stroke-linecap="round" /></svg>
+                                </button>
                                 {#if image && !failed.has(moment.key)}
                                     <img
                                         src={image}
                                         alt={primaryName}
                                         loading="lazy"
                                         decoding="async"
-                                        class="h-40 w-full bg-slate-950 object-contain"
+                                        class="w-full bg-slate-950 object-contain {anchor.sheet ? 'h-56' : 'h-40'}"
                                         onerror={() => markFailed(moment.key)}
                                     />
                                 {:else}

--- a/apps/ui/src/lib/components/ReviewQueueModal.svelte
+++ b/apps/ui/src/lib/components/ReviewQueueModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { untrack } from 'svelte';
+    import { onDestroy, untrack } from 'svelte';
     import { fetchSnapshotCandidates, getThumbnailUrl } from '../api';
     import type { Detection, SnapshotCandidate } from '../api';
     import { advance, createReviewSession, remaining, type ReviewSession } from '../utils/review-session';
@@ -7,6 +7,7 @@
     import { trapFocus } from '../utils/focus-trap';
     import { portal } from '../utils/portal';
     import { findMatchingFullFrameCandidate } from '../utils/detection-evidence';
+    import { WholeScenePeek } from '../utils/whole-scene-peek.svelte';
     import type { ReviewReason } from '../utils/review-queue';
     import { _ } from 'svelte-i18n';
 
@@ -37,7 +38,13 @@
     let crop = $state<SnapshotCandidate | null>(null);
     let fullFrame = $state<SnapshotCandidate | null>(null);
     let cropLoading = $state(false);
-    let view = $state<'crop' | 'full'>('crop');
+    let imageEl = $state<HTMLImageElement | null>(null);
+    // The photograph is the crop; the whole scene is a look, not a mode (#256). Same
+    // controller as the detection record, so the two surfaces behave alike.
+    const canPeek = $derived(
+        Boolean(crop?.image_url || crop?.thumbnail_url) && Boolean(fullFrame?.image_url || fullFrame?.thumbnail_url)
+    );
+    const wholeScene = new WholeScenePeek(() => canPeek);
     let search = $state('');
     let busy = $state(false);
     let failedImageUrls = $state<Set<string>>(new Set());
@@ -65,7 +72,7 @@
         const eventId = session.current?.frigate_event;
         crop = null;
         fullFrame = null;
-        view = 'crop';
+        wholeScene.reset();
         if (!eventId) return;
 
         let cancelled = false;
@@ -103,14 +110,29 @@
     });
 
     const imageUrl = $derived(
-        view === 'crop' && (crop?.image_url || crop?.thumbnail_url)
-            ? (crop.image_url ?? crop.thumbnail_url ?? '')
-            : view === 'full' && (fullFrame?.image_url || fullFrame?.thumbnail_url)
-              ? (fullFrame.image_url ?? fullFrame.thumbnail_url ?? '')
+        wholeScene.showing && (fullFrame?.image_url || fullFrame?.thumbnail_url)
+            ? (fullFrame.image_url ?? fullFrame.thumbnail_url ?? '')
+            : crop?.image_url || crop?.thumbnail_url
+              ? (crop.image_url ?? crop.thumbnail_url ?? '')
             : session.current
               ? getThumbnailUrl(session.current.frigate_event)
               : ''
     );
+    // The outline is a DOM measurement, taken once the whole scene has loaded and again when
+    // the window changes size.
+    function measureWholeScene(): void {
+        wholeScene.measure(imageEl, crop?.crop_box);
+    }
+    $effect(() => {
+        if (!wholeScene.showing) {
+            wholeScene.outline = null;
+            return;
+        }
+        measureWholeScene();
+        window.addEventListener('resize', measureWholeScene);
+        return () => window.removeEventListener('resize', measureWholeScene);
+    });
+    onDestroy(wholeScene.destroy);
     const imageFailed = $derived(Boolean(imageUrl && failedImageUrls.has(imageUrl)));
 
     function markImageFailed(url: string): void {
@@ -181,6 +203,11 @@
     function handleKeydown(event: KeyboardEvent): void {
         if (event.key === 'Escape') {
             event.preventDefault();
+            // A pinned whole scene closes first; the queue stays open.
+            if (wholeScene.pinned) {
+                wholeScene.reset();
+                return;
+            }
             onclose();
             return;
         }
@@ -266,8 +293,10 @@
         {:else if session.current}
             {@const current = session.current}
             {@const isNewSpecies = reasons?.get(current.frigate_event) === 'new_species'}
-            <div class="grid min-h-0 flex-1 gap-0 overflow-y-auto md:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)] md:overflow-hidden">
-                <div class="flex min-h-0 flex-col justify-center bg-slate-950">
+            <!-- A column on phones: the media block keeps its own height and never overlaps the
+                 rail beneath it. The two-column grid only applies where there is room. -->
+            <div class="flex min-h-0 flex-1 flex-col overflow-y-auto md:grid md:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)] md:overflow-hidden">
+                <div class="flex shrink-0 flex-col bg-slate-950 md:min-h-0 md:justify-center">
                     {#if imageFailed}
                         <div class="flex items-center justify-center py-16 text-slate-600">
                             <svg class="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
@@ -275,37 +304,54 @@
                             </svg>
                         </div>
                     {:else}
-                        <img
-                            src={imageUrl}
-                            alt={$_('dashboard.review_session.image_alt', {
-                                values: { camera: current.camera_name },
-                                default: 'Unidentified detection on {camera}'
-                            })}
-                            class="max-h-[52vh] w-full object-contain"
-                            onerror={() => markImageFailed(imageUrl)}
-                        />
-                    {/if}
-                    {#if crop?.thumbnail_url && fullFrame?.thumbnail_url}
-                        <div class="flex gap-1 px-4 pt-2" role="group" aria-label={$_('dashboard.review_session.view_label', { default: 'Which frame to show' })}>
-                            <button
-                                class="min-h-11 rounded-lg px-2.5 py-1 text-[11px] font-semibold transition-colors focus-ring {view === 'crop' ? 'bg-white/15 text-white' : 'text-slate-400 hover:text-slate-200'}"
-                                aria-pressed={view === 'crop'}
-                                onclick={() => (view = 'crop')}
-                            >
-                                {$_('dashboard.review_session.crop', { default: 'Best crop' })}
-                            </button>
-                            <button
-                                class="min-h-11 rounded-lg px-2.5 py-1 text-[11px] font-semibold transition-colors focus-ring {view === 'full' ? 'bg-white/15 text-white' : 'text-slate-400 hover:text-slate-200'}"
-                                aria-pressed={view === 'full'}
-                                onclick={() => (view = 'full')}
-                            >
-                                {$_('dashboard.review_session.full_frame', { default: 'Full frame' })}
-                            </button>
-                            {#if crop.crop_strategy}
-                                <span class="ml-auto self-center text-[10px] text-slate-500">{crop.crop_strategy}</span>
+                        <div class="relative">
+                            <img
+                                bind:this={imageEl}
+                                src={imageUrl}
+                                alt={$_('dashboard.review_session.image_alt', {
+                                    values: { camera: current.camera_name },
+                                    default: 'Unidentified detection on {camera}'
+                                })}
+                                class="max-h-[52vh] w-full object-contain"
+                                onload={measureWholeScene}
+                                onerror={() => markImageFailed(imageUrl)}
+                            />
+                            {#if canPeek}
+                                <!-- Hover or focus peeks at the whole scene with the crop outlined; a tap or
+                                     click pins it. No switch, and no strategy name: how the crop was found is
+                                     the app's plumbing, not the reviewer's concern. -->
+                                <button
+                                    type="button"
+                                    class="absolute inset-0 {wholeScene.pinned ? 'cursor-zoom-out' : 'cursor-zoom-in'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/70"
+                                    data-review-whole-scene-peek
+                                    aria-pressed={wholeScene.pinned}
+                                    aria-label={wholeScene.pinned
+                                        ? $_('detection.whole_scene_back', { default: 'Back to the crop' })
+                                        : $_('detection.whole_scene_show', { default: 'Show the whole scene' })}
+                                    onmouseenter={wholeScene.enter}
+                                    onmouseleave={wholeScene.leave}
+                                    onfocus={wholeScene.show}
+                                    onblur={wholeScene.leave}
+                                    onclick={wholeScene.toggle}
+                                ></button>
+                                {#if wholeScene.showing && wholeScene.outline}
+                                    <div
+                                        class="pointer-events-none absolute rounded-sm border-2 border-dashed border-white/85 shadow-[0_0_0_9999px_rgba(2,6,23,0.35)]"
+                                        style="left: {wholeScene.outline.left}px; top: {wholeScene.outline.top}px; width: {wholeScene.outline.width}px; height: {wholeScene.outline.height}px;"
+                                        aria-hidden="true"
+                                    ></div>
+                                {/if}
+                                {#if wholeScene.showing}
+                                    <span class="pointer-events-none absolute left-3 top-3 rounded-full border border-white/15 bg-slate-950/70 px-2.5 py-1 text-[11px] font-semibold text-white backdrop-blur-sm">
+                                        {wholeScene.pinned
+                                            ? $_('detection.whole_scene_chip_pinned', { default: 'Whole scene, the crop is outlined' })
+                                            : $_('detection.whole_scene_chip', { default: 'Whole scene' })}
+                                    </span>
+                                {/if}
                             {/if}
                         </div>
-                    {:else if !cropLoading}
+                    {/if}
+                    {#if !canPeek && !cropLoading && !crop}
                         <p class="px-4 pt-2 text-[10px] text-slate-500">
                             {$_('dashboard.review_session.no_crop', {
                                 default: 'No crop stored for this detection. Open the full record to scan for one.'
@@ -323,7 +369,7 @@
                     </p>
                 </div>
 
-                <div class="flex min-h-0 flex-col gap-3 overflow-y-auto p-4">
+                <div class="flex flex-col gap-3 p-4 md:min-h-0 md:overflow-y-auto">
                     <div>
                         <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
                             {$_('dashboard.review_session.what_is_it', { default: 'What is it?' })}
@@ -384,7 +430,7 @@
                             : $_('dashboard.review_session.seen_here', { default: 'Seen at this feeder' })}
                     </p>
 
-                    <ul class="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
+                    <ul class="flex flex-col gap-1.5 md:min-h-0 md:flex-1 md:overflow-y-auto">
                         {#each matches as label (label)}
                             <li>
                                 <button

--- a/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
+++ b/apps/ui/src/lib/components/detection-surface-polish.layout.test.ts
@@ -112,7 +112,7 @@ describe('detection surface polish', () => {
         expect(detectionModalSource).not.toContain("absolute bottom-0 left-0 right-0 p-5 {showInlineFramePicker ? 'pb-28' : ''}");
         expect(detectionModalSource).not.toContain('absolute inset-x-0 bottom-0 z-20 flex flex-col gap-1');
         // Peeking stays non-mutating. Only a named action changes the photograph.
-        expect(detectionModalSource).toContain("mediaView = 'whole';");
+        expect(detectionModalSource).toContain('onfocus={wholeScene.show}');
         expect(detectionModalSource).not.toContain("canShowFullFrame ? 'top-16 left-3' : 'top-4 left-4'");
     });
 

--- a/apps/ui/src/lib/components/frame-strip.layout.test.ts
+++ b/apps/ui/src/lib/components/frame-strip.layout.test.ts
@@ -31,6 +31,14 @@ describe('the frame strip is one ordered set of moments (#256)', () => {
         expect(stripSource).toContain('onfocusout={handleFocusOut}');
     });
 
+    it('becomes a sheet with a backdrop and its own Close on a phone, where there is no hover', () => {
+        expect(stripSource).toContain("const SHEET_QUERY = '(max-width: 639px)';");
+        expect(stripSource).toContain('window.matchMedia(SHEET_QUERY).matches');
+        expect(stripSource).toContain('data-frame-strip-backdrop');
+        expect(stripSource).toContain("'inset-x-0 bottom-0 rounded-t-2xl motion-safe:slide-in-from-bottom-4'");
+        expect(stripSource).toContain("aria-label={$_('common.close', { default: 'Close' })}");
+    });
+
     it('labels what the model read in a frame as a read, with one action that names its effect', () => {
         expect(stripSource).toContain('detection.frame_model_read');
         expect(stripSource).toContain('detection.frame_read_note');
@@ -99,13 +107,13 @@ describe('the record uses the strip and drops the framing toggle (#256)', () => 
     it('peeks at the whole scene on hover or focus and pins it on click', () => {
         expect(modalSource).toContain('data-detection-whole-scene-peek');
         // A pointer crossing the photograph on its way to Play or Close is not a request.
-        expect(modalSource).toContain('const PEEK_INTENT_MS = 250;');
-        expect(modalSource).toContain('onmouseenter={peekWholeSceneAfterIntent}');
-        expect(modalSource).toContain('onfocus={peekWholeScene}');
-        expect(modalSource).toContain('onmouseleave={unpeekWholeScene}');
-        expect(modalSource).toContain('onblur={unpeekWholeScene}');
-        expect(modalSource).toContain('toggleWholeScenePin()');
-        expect(modalSource).toContain('aria-pressed={wholeScenePinned}');
+        expect(modalSource).toContain("import { WholeScenePeek } from '../utils/whole-scene-peek.svelte'");
+        expect(modalSource).toContain('onmouseenter={wholeScene.enter}');
+        expect(modalSource).toContain('onfocus={wholeScene.show}');
+        expect(modalSource).toContain('onmouseleave={wholeScene.leave}');
+        expect(modalSource).toContain('onblur={wholeScene.leave}');
+        expect(modalSource).toContain('wholeScene.toggle()');
+        expect(modalSource).toContain('aria-pressed={wholeScene.pinned}');
         // The peek only exists when the same moment has an uncropped frame to show, so never
         // over Frigate's own snapshot, whose "matching" frame would be another moment's.
         expect(modalSource).toContain('findMatchingFullFrameCandidate');
@@ -114,19 +122,18 @@ describe('the record uses the strip and drops the framing toggle (#256)', () => 
     });
 
     it('outlines the crop on the whole scene from a measurement, never a guess', () => {
-        expect(modalSource).toContain('wholeSceneOutline(');
-        expect(modalSource).toContain('element.naturalWidth');
+        expect(modalSource).toContain('wholeScene.measure(heroImageEl, currentCropCandidate?.crop_box)');
         expect(modalSource).toContain('onload={measureWholeScene}');
         expect(modalSource).toContain('data-detection-whole-scene-outline');
-        expect(modalSource).toContain('{#if showingWholeScene && wholeSceneOutlineBox}');
+        expect(modalSource).toContain('{#if wholeScene.showing && wholeScene.outline}');
     });
 
     it('offers the whole-scene rescue only while pinned, and Escape unpins before it closes', () => {
-        expect(modalSource).toContain('{#if wholeScenePinned && showingWholeScene}');
+        expect(modalSource).toContain('{#if wholeScene.pinned && wholeScene.showing}');
         expect(modalSource).toContain('detection.whole_scene_use');
         expect(modalSource).toContain('detection.whole_scene_back');
         expect(modalSource).toContain('useWholeSceneAsPhotograph()');
-        expect(modalSource).toMatch(/if \(e\.key !== 'Escape'\) return;[\s\S]{0,200}?if \(wholeScenePinned\) \{[\s\S]{0,120}?resetMediaView\(\);[\s\S]{0,60}?return;/);
+        expect(modalSource).toMatch(/if \(e\.key !== 'Escape'\) return;[\s\S]{0,200}?if \(wholeScene\.pinned\) \{[\s\S]{0,120}?resetMediaView\(\);[\s\S]{0,60}?return;/);
     });
 
     it('uses a frame straight from the pop-out, with no separate save step', () => {
@@ -147,8 +154,15 @@ describe('the record uses the strip and drops the framing toggle (#256)', () => 
         expect(confirm).toBeGreaterThan(-1);
         expect(pick).toBeGreaterThan(confirm);
         expect(score).toBeGreaterThan(pick);
-        expect(actions).toContain('class="btn btn-primary min-h-11 flex-1 px-4 text-sm"');
-        expect(actions).toContain('class="btn btn-secondary min-h-11 flex-1 px-4 text-sm"');
-        expect(actions).toContain('class="btn btn-ghost min-h-11 px-4 text-sm"');
+        expect(actions).toContain('class="btn btn-primary min-h-11 w-full px-4 text-sm sm:w-auto sm:flex-1"');
+        expect(actions).toContain('class="btn btn-secondary min-h-11 w-full px-4 text-sm sm:w-auto sm:flex-1"');
+        expect(actions).toContain('class="btn btn-ghost min-h-11 w-full px-4 text-sm sm:w-auto"');
+    });
+
+    it('stacks its controls full width on a phone and lets the rail name the bird', () => {
+        expect(modalSource).toContain('class="flex flex-col gap-2 sm:flex-row sm:flex-wrap" data-detection-identification-actions');
+        expect(modalSource).toContain('class="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center" data-detection-whole-scene-actions');
+        // The hero title repeats the rail's "Identified as" while covering the bird on a phone.
+        expect(modalSource).toContain('class="hidden sm:block" data-detection-media-title');
     });
 });

--- a/apps/ui/src/lib/components/review-queue-modal.layout.test.ts
+++ b/apps/ui/src/lib/components/review-queue-modal.layout.test.ts
@@ -41,12 +41,30 @@ describe('review queue walk-through', () => {
         expect(modalSource).toMatch(
             /findMatchingFullFrameCandidate\(\s*response\.candidates \?\? \[\],\s*preferredCrop\?\.candidate_id \?\? null\s*\)/
         );
-        expect(modalSource).toContain('dashboard.review_session.crop');
-        expect(modalSource).toContain('dashboard.review_session.full_frame');
-        expect(modalSource).toContain('aria-pressed={view === \'crop\'}');
-        expect(modalSource).toContain("{#if crop?.thumbnail_url && fullFrame?.thumbnail_url}");
         // Crops only exist for scanned events, so their absence is stated, not hidden.
         expect(modalSource).toContain('dashboard.review_session.no_crop');
+    });
+
+    it('peeks at the whole scene like the detection record, with no switch and no strategy name (#256)', () => {
+        expect(modalSource).toContain("import { WholeScenePeek } from '../utils/whole-scene-peek.svelte'");
+        expect(modalSource).toContain('data-review-whole-scene-peek');
+        expect(modalSource).toContain('onmouseenter={wholeScene.enter}');
+        expect(modalSource).toContain('onfocus={wholeScene.show}');
+        expect(modalSource).toContain('onclick={wholeScene.toggle}');
+        expect(modalSource).toContain('wholeScene.measure(imageEl, crop?.crop_box)');
+        expect(modalSource).toContain('detection.whole_scene_chip_pinned');
+        expect(modalSource).not.toContain('dashboard.review_session.crop\'');
+        expect(modalSource).not.toContain('dashboard.review_session.full_frame');
+        // "sliced_2x2" is how the crop was found, not something a reviewer decides with.
+        expect(modalSource).not.toContain('crop_strategy');
+        // Escape unpins before it closes the queue.
+        expect(modalSource).toMatch(/if \(wholeScene\.pinned\) \{\s*wholeScene\.reset\(\);\s*return;/);
+    });
+
+    it('keeps the media block its own height on phones so it never overlaps the rail', () => {
+        expect(modalSource).toContain('flex min-h-0 flex-1 flex-col overflow-y-auto md:grid');
+        expect(modalSource).toContain('flex shrink-0 flex-col bg-slate-950 md:min-h-0 md:justify-center');
+        expect(modalSource).toContain('flex flex-col gap-3 p-4 md:min-h-0 md:overflow-y-auto');
     });
 
     it('offers a way out of every item, including one that is not a bird', () => {

--- a/apps/ui/src/lib/utils/whole-scene-peek.svelte.ts
+++ b/apps/ui/src/lib/utils/whole-scene-peek.svelte.ts
@@ -1,0 +1,104 @@
+import { wholeSceneOutline, type OutlineBox } from './frame-moments';
+
+/**
+ * A pointer crossing the photograph on its way to Play or Close is not a request to see the
+ * whole scene, and the whole frame is a large fetch. Hover waits this long for intent; focus
+ * and touch do not.
+ */
+export const PEEK_INTENT_MS = 250;
+
+/**
+ * The whole scene is a look, not a mode (#256).
+ *
+ * The photograph is always the crop. Hover or focus peeks at the whole scene with the crop
+ * outlined; a click pins the peek so a control can be offered on it; Escape or a second click
+ * returns to the crop. One controller carries that for every surface that shows a photograph,
+ * so the detection record and the review queue behave the same way.
+ */
+export class WholeScenePeek {
+    private view = $state<'crop' | 'whole'>('crop');
+    pinned = $state(false);
+    outline = $state<OutlineBox | null>(null);
+    private intentTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /** `canPeek` is read live: it usually depends on which frame is the photograph now. */
+    constructor(
+        private readonly canPeek: () => boolean,
+        private readonly intentMs: number = PEEK_INTENT_MS
+    ) {}
+
+    /** True while the whole scene is what should be drawn. */
+    get showing(): boolean {
+        return this.view === 'whole' && this.canPeek();
+    }
+
+    private clearIntent(): void {
+        if (this.intentTimer) {
+            clearTimeout(this.intentTimer);
+            this.intentTimer = null;
+        }
+    }
+
+    /** Pointer arrives: peek after a moment of intent. */
+    enter = (): void => {
+        if (!this.canPeek() || this.intentTimer) return;
+        this.intentTimer = setTimeout(() => {
+            this.intentTimer = null;
+            this.show();
+        }, this.intentMs);
+    };
+
+    /** Focus or touch: peek at once. */
+    show = (): void => {
+        this.clearIntent();
+        if (!this.canPeek()) return;
+        this.view = 'whole';
+    };
+
+    /** Pointer or focus leaves: back to the crop unless the peek is pinned. */
+    leave = (): void => {
+        this.clearIntent();
+        if (this.pinned) return;
+        this.view = 'crop';
+    };
+
+    /** Click: pin the whole scene, or unpin it and return to the crop. */
+    toggle = (): void => {
+        if (!this.canPeek()) return;
+        if (this.pinned) {
+            this.reset();
+            return;
+        }
+        this.pinned = true;
+        this.view = 'whole';
+    };
+
+    /** Back to the crop, unpinned. Also the state a new subject starts in. */
+    reset = (): void => {
+        this.clearIntent();
+        this.view = 'crop';
+        this.pinned = false;
+        this.outline = null;
+    };
+
+    /**
+     * Where the crop sits on the drawn whole scene. A DOM measurement, because the drawn
+     * size of a `contain`ed image is not knowable from state; call it once the whole
+     * scene has loaded and again when the window changes size.
+     */
+    measure = (image: HTMLImageElement | null, cropBox: ReadonlyArray<number> | null | undefined): void => {
+        if (!image || this.view !== 'whole') {
+            this.outline = null;
+            return;
+        }
+        this.outline = wholeSceneOutline(
+            cropBox,
+            { width: image.naturalWidth, height: image.naturalHeight },
+            { width: image.clientWidth, height: image.clientHeight }
+        );
+    };
+
+    destroy = (): void => {
+        this.clearIntent();
+    };
+}

--- a/apps/ui/src/lib/utils/whole-scene-peek.test.ts
+++ b/apps/ui/src/lib/utils/whole-scene-peek.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PEEK_INTENT_MS, WholeScenePeek } from './whole-scene-peek.svelte';
+
+describe('WholeScenePeek (#256)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('starts on the crop and peeks at once for focus or touch', () => {
+        const peek = new WholeScenePeek(() => true);
+        expect(peek.showing).toBe(false);
+        peek.show();
+        expect(peek.showing).toBe(true);
+        peek.leave();
+        expect(peek.showing).toBe(false);
+    });
+
+    it('waits for intent before a pointer peeks, and forgets a pointer that moves on', () => {
+        const peek = new WholeScenePeek(() => true);
+        peek.enter();
+        expect(peek.showing).toBe(false);
+        vi.advanceTimersByTime(PEEK_INTENT_MS - 1);
+        expect(peek.showing).toBe(false);
+        vi.advanceTimersByTime(1);
+        expect(peek.showing).toBe(true);
+
+        peek.leave();
+        peek.enter();
+        peek.leave();
+        vi.advanceTimersByTime(PEEK_INTENT_MS * 2);
+        expect(peek.showing).toBe(false);
+    });
+
+    it('pins on a click, survives the pointer leaving, and unpins on the next click', () => {
+        const peek = new WholeScenePeek(() => true);
+        peek.toggle();
+        expect(peek.pinned).toBe(true);
+        expect(peek.showing).toBe(true);
+        peek.leave();
+        expect(peek.showing).toBe(true);
+        peek.toggle();
+        expect(peek.pinned).toBe(false);
+        expect(peek.showing).toBe(false);
+    });
+
+    it('never shows when there is nothing to peek at, even mid-peek', () => {
+        let allowed = true;
+        const peek = new WholeScenePeek(() => allowed);
+        peek.toggle();
+        expect(peek.showing).toBe(true);
+        allowed = false;
+        expect(peek.showing).toBe(false);
+        peek.reset();
+        peek.show();
+        peek.toggle();
+        expect(peek.pinned).toBe(false);
+    });
+
+    it('measures the outline only while the whole scene is drawn', () => {
+        const peek = new WholeScenePeek(() => true);
+        const image = { naturalWidth: 1600, naturalHeight: 900, clientWidth: 800, clientHeight: 600 } as HTMLImageElement;
+        peek.measure(image, [400, 225, 800, 675]);
+        expect(peek.outline).toBeNull();
+        peek.show();
+        peek.measure(image, [400, 225, 800, 675]);
+        expect(peek.outline).toEqual({ left: 200, top: 187.5, width: 200, height: 225 });
+        peek.measure(null, [400, 225, 800, 675]);
+        expect(peek.outline).toBeNull();
+    });
+
+    it('resets to the crop with nothing pending', () => {
+        const peek = new WholeScenePeek(() => true);
+        peek.enter();
+        peek.toggle();
+        peek.reset();
+        vi.advanceTimersByTime(PEEK_INTENT_MS * 2);
+        expect(peek.showing).toBe(false);
+        expect(peek.pinned).toBe(false);
+        expect(peek.outline).toBeNull();
+    });
+});

--- a/docs/standards/layout-patterns.md
+++ b/docs/standards/layout-patterns.md
@@ -116,7 +116,10 @@ visit's moments in time order (`FrameStrip`), one thumbnail per moment; where a 
 is not shown, and the framings of one moment fold into it. Each thumbnail opens a pop-out on
 hover or focus with the frame at decision size, what the model read in it (labelled as a read),
 and one action, "Use this frame", which changes the photograph and never the identification.
-There is no Best crop / Full frame switch and no preview-then-save step (#256).
+There is no Best crop / Full frame switch and no preview-then-save step (#256). The peek is
+`WholeScenePeek` in `utils/whole-scene-peek.svelte.ts`, and the review queue uses the same one.
+On a phone the comparison pop-out is a sheet at the foot of the screen with a backdrop and its
+own Close, because there is no hover to lose.
 
 ### Reference (About)
 


### PR DESCRIPTION
## Outcome

Follow-up to #440 from a phone screenshot of the review queue.

- **Review queue.** Its Best crop / Full frame switch and the leaked crop strategy name (`sliced_2x2`) are gone. It uses the same whole-scene peek as the detection record: hover or focus peeks with the crop outlined after a moment of intent, tap or click pins, Escape unpins before it closes the queue. On a phone the picture block keeps its own height, so the date line no longer draws over "What is it?".
- **Shared controller.** `WholeScenePeek` in `apps/ui/src/lib/utils/whole-scene-peek.svelte.ts` holds the peek state machine, the intent delay and the outline measurement; the detection record now uses it too instead of its own copy. Unit tested with fake timers.
- **The record on a phone.** The frame comparison becomes a bottom sheet with a backdrop and its own Close below 640 px, where there is no hover to lose. Confirm / Pick a different species / Score again and the whole-scene actions stack full width. The hero title is hidden on small screens; the rail's "Identified as" sits directly under the picture and said the same thing.

## Verification

- `npm run check`: 0 errors, 0 warnings. `npm test`: 191 files, 1080 tests. `npm run lint:dead`: clean.
- Dev server against the live backend at 375 px as a guest: the record opens with the hero title hidden, no toggle, the identification directly under the picture, no horizontal overflow, no console errors. Owner-only pieces (strip, sheet, peek) are covered by the layout tests and need an owner check on a phone after deploy.

## Risk

UI only. No API, schema or settings changes.
