### PR TITLE
Open the frame sheet by the tap, not by the hover a phone replays first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A tap on a frame thumbnail opens the sheet on a phone.** It used to flicker and vanish: the
+  browser replays a tap as a hover first, the hover opened the sheet with its backdrop under the
+  finger, and the tap's click then landed on that backdrop and closed it. Hover now opens the
+  pop-out for a mouse alone and focus for the keyboard alone; a tap opens it by its click, and the
+  sheet closes by its backdrop, its Close, or Escape, not by the pointer drifting away.
+
 ### Changed
 
 - **One place to choose the frame and settle the species (#256).** The detection record's

--- a/apps/ui/src/lib/components/DetectionPreview.svelte
+++ b/apps/ui/src/lib/components/DetectionPreview.svelte
@@ -84,6 +84,18 @@
         anchor = { x: centre, y: above ? rect.top - GAP : rect.bottom + GAP, above };
     }
 
+    // A touch browser replays a tap as mouseenter and, on Chrome, focus before the click; a
+    // pop-out that opened on either would swallow the tap (iOS) or sit under the record (Chrome).
+    // Hover is for a hovering pointer and focus is for the keyboard; a tap opens by its click.
+    function isKeyboardFocus(target: EventTarget | null): boolean {
+        if (!(target instanceof Element)) return true;
+        try {
+            return target.matches(':focus-visible');
+        } catch {
+            return true;
+        }
+    }
+
     function show(index: number): void {
         if (closeTimer) {
             clearTimeout(closeTimer);
@@ -202,8 +214,8 @@
             class:-ml-1={index > 0}
             class:hidden={index > 0}
             class:sm:block={index > 0}
-            onmouseenter={() => show(index)}
-            onfocusin={() => show(index)}
+            onpointerenter={(event) => { if (event.pointerType !== 'touch') show(index); }}
+            onfocusin={(event) => { if (isKeyboardFocus(event.target)) show(index); }}
             role="presentation"
         >
             {#snippet thumbnail(frame: Detection)}

--- a/apps/ui/src/lib/components/FilteredFramePreview.svelte
+++ b/apps/ui/src/lib/components/FilteredFramePreview.svelte
@@ -21,6 +21,17 @@
     let rootEl = $state<HTMLElement | null>(null);
     let closeTimer: ReturnType<typeof setTimeout> | null = null;
 
+    // Same rule as the frame strip: hover for a hovering pointer, focus for the keyboard, a tap
+    // by its click, so a touch browser's replayed mouseenter cannot swallow the tap.
+    function isKeyboardFocus(target: EventTarget | null): boolean {
+        if (!(target instanceof Element)) return true;
+        try {
+            return target.matches(':focus-visible');
+        } catch {
+            return true;
+        }
+    }
+
     function show(): void {
         if (closeTimer) {
             clearTimeout(closeTimer);
@@ -69,9 +80,9 @@
     bind:this={rootEl}
     class="relative flex items-center"
     data-filtered-frame-preview
-    onmouseenter={show}
+    onpointerenter={(event) => { if (event.pointerType !== 'touch') show(); }}
     onmouseleave={() => hide()}
-    onfocusin={show}
+    onfocusin={(event) => { if (isKeyboardFocus(event.target)) show(); }}
     onfocusout={handleFocusOut}
     onkeydown={handleKeydown}
     role="presentation"

--- a/apps/ui/src/lib/components/FrameStrip.svelte
+++ b/apps/ui/src/lib/components/FrameStrip.svelte
@@ -67,10 +67,50 @@
     // a sheet at the foot of the screen, with a backdrop and its own Close.
     const SHEET_QUERY = '(max-width: 639px)';
 
+    function isSheet(): boolean {
+        return typeof window !== 'undefined' && window.matchMedia(SHEET_QUERY).matches;
+    }
+
+    // A tap is not a hover. A touch browser replays a tap as mouseenter, then (on Android and
+    // desktop Chrome, not iOS Safari, which does not focus a button on tap) focus, then click.
+    // If either of the first two opened the sheet, its backdrop would be under the finger by the
+    // time the click arrived and would close it again, so the sheet would only flicker. Hover
+    // opens the pop-out for a hovering pointer alone (a mouse or a pen held above the screen),
+    // focus opens it for the keyboard alone, and a tap opens it by its click. The sheet never
+    // opens on hover: a backdrop under a hovering pointer is a mouseleave, which would close
+    // what the mouseenter had just opened.
+    function hoverOpen(index: number, event: PointerEvent): void {
+        if (event.pointerType === 'touch' || isSheet()) return;
+        show(index);
+    }
+
+    function focusOpen(index: number, event: FocusEvent): void {
+        if (!isKeyboardFocus(event.target)) return;
+        show(index);
+    }
+
+    function isKeyboardFocus(target: EventTarget | null): boolean {
+        if (!(target instanceof Element)) return true;
+        try {
+            return target.matches(':focus-visible');
+        } catch {
+            // A browser without :focus-visible cannot tell a tap from a Tab; opening is the
+            // safer reading, and its taps close the pop-out by focusout in any case.
+            return true;
+        }
+    }
+
+    // The sheet has a backdrop, a Close and Escape; the pointer wandering off is not a
+    // dismissal there.
+    function hoverClose(): void {
+        if (anchor?.sheet) return;
+        hide();
+    }
+
     function place(index: number): void {
         const trigger = triggers[index];
         if (!trigger) return;
-        if (typeof window !== 'undefined' && window.matchMedia(SHEET_QUERY).matches) {
+        if (isSheet()) {
             anchor = { x: 0, y: 0, above: false, sheet: true };
             return;
         }
@@ -118,7 +158,14 @@
 
     function handleFocusOut(event: FocusEvent): void {
         const next = event.relatedTarget;
-        if (next instanceof Node && (rootEl?.contains(next) || panelEl?.contains(next))) return;
+        // In the sheet, focus that goes nowhere (a tap on its picture) is not focus moving on: the
+        // backdrop, Close and Escape dismiss it. A desktop pop-out closes as before, so a click
+        // on plain page or a switch away never strands it with only the record's Escape left.
+        if (!(next instanceof Node)) {
+            if (!anchor?.sheet) hide(true);
+            return;
+        }
+        if (rootEl?.contains(next) || panelEl?.contains(next)) return;
         hide(true);
     }
 
@@ -142,13 +189,16 @@
         queueMicrotask(() => panelEl?.querySelector<HTMLElement>('button, [tabindex]')?.focus());
     }
 
+    // Focus returns to the trigger before the pop-out hides: moving focus replays focusin on the
+    // trigger, and on an index that is still open that is a no-op, whereas after hiding it would
+    // reopen what Escape had just closed.
     function handlePanelKeydown(event: KeyboardEvent): void {
         if (event.key === 'Tab' || event.key === 'Escape') {
             event.preventDefault();
             event.stopPropagation();
             const index = openIndex;
-            if (event.key === 'Escape') hide(true);
             if (index !== null) triggers[index]?.focus();
+            if (event.key === 'Escape') hide(true);
         }
     }
 
@@ -267,7 +317,7 @@
     class="flex flex-col gap-1 px-3 pb-3"
     data-frame-strip
     aria-busy={loading || busy}
-    onmouseleave={() => hide()}
+    onmouseleave={hoverClose}
     onfocusout={handleFocusOut}
     onkeydown={handleKeydown}
     role="presentation"
@@ -301,8 +351,8 @@
                     {@const thumb = thumbnailFor(moment)}
                     <div
                         class="relative shrink-0"
-                        onmouseenter={() => show(index)}
-                        onfocusin={() => show(index)}
+                        onpointerenter={(event) => hoverOpen(index, event)}
+                        onfocusin={(event) => focusOpen(index, event)}
                         role="presentation"
                     >
                         <button
@@ -370,7 +420,7 @@
                                 role="presentation"
                                 data-frame-strip-panel
                                 onmouseenter={cancelScheduledClose}
-                                onmouseleave={() => hide()}
+                                onmouseleave={hoverClose}
                                 onfocusout={handleFocusOut}
                                 onkeydown={handlePanelKeydown}
                             >
@@ -386,7 +436,7 @@
                                     type="button"
                                     class="absolute right-2 top-2 z-10 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/25 bg-slate-950/60 text-white backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
                                     aria-label={$_('common.close', { default: 'Close' })}
-                                    onclick={(event) => { event.stopPropagation(); const current = openIndex; hide(true); if (current !== null) triggers[current]?.focus(); }}
+                                    onclick={(event) => { event.stopPropagation(); const current = openIndex; if (current !== null) triggers[current]?.focus(); hide(true); }}
                                 >
                                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" stroke-linecap="round" /></svg>
                                 </button>

--- a/apps/ui/src/lib/components/frame-strip.layout.test.ts
+++ b/apps/ui/src/lib/components/frame-strip.layout.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import stripSource from './FrameStrip.svelte?raw';
+import previewSource from './DetectionPreview.svelte?raw';
+import filteredSource from './FilteredFramePreview.svelte?raw';
 import modalSource from './DetectionModal.svelte?raw';
 
 describe('the frame strip is one ordered set of moments (#256)', () => {
@@ -12,8 +14,8 @@ describe('the frame strip is one ordered set of moments (#256)', () => {
     });
 
     it('opens a comparison pop-out by hover and by keyboard, per the layout standard', () => {
-        expect(stripSource).toContain('onmouseenter={() => show(index)}');
-        expect(stripSource).toContain('onfocusin={() => show(index)}');
+        expect(stripSource).toContain('onpointerenter={(event) => hoverOpen(index, event)}');
+        expect(stripSource).toContain('onfocusin={(event) => focusOpen(index, event)}');
         expect(stripSource).toContain('const CLOSE_GRACE_MS = 120;');
         expect(stripSource).toContain("event.key === 'Escape'");
         expect(stripSource).toContain('aria-expanded={openIndex === index}');
@@ -37,6 +39,37 @@ describe('the frame strip is one ordered set of moments (#256)', () => {
         expect(stripSource).toContain('data-frame-strip-backdrop');
         expect(stripSource).toContain("'inset-x-0 bottom-0 rounded-t-2xl motion-safe:slide-in-from-bottom-4'");
         expect(stripSource).toContain("aria-label={$_('common.close', { default: 'Close' })}");
+    });
+
+    it('opens the sheet by the tap itself, never by the hover or focus a touch browser replays first', () => {
+        // A tap arrives as mouseenter, focus, click. Had the first opened the sheet, its backdrop
+        // would sit under the finger when the click landed and close it again: a flicker.
+        expect(stripSource).toContain("if (event.pointerType === 'touch' || isSheet()) return;");
+        expect(stripSource).toContain("return target.matches(':focus-visible');");
+        expect(stripSource).toContain('if (!isKeyboardFocus(event.target)) return;');
+        // The click is what opens it on a phone.
+        expect(stripSource).toContain('onclick={(event) => { event.stopPropagation(); show(index); }}');
+        // With a backdrop, a Close and Escape, the pointer drifting off the strip is not a dismissal,
+        // and a tap on the sheet's own picture (focus going nowhere) is not either.
+        expect(stripSource).toContain('if (anchor?.sheet) return;\n        hide();');
+        expect(stripSource).toContain('onmouseleave={hoverClose}');
+        expect(stripSource).not.toContain('onmouseleave={() => hide()}');
+        // Only the sheet ignores focus going nowhere; a desktop pop-out still closes.
+        expect(stripSource).toContain('if (!(next instanceof Node)) {\n            if (!anchor?.sheet) hide(true);');
+    });
+
+    it('returns focus to the thumbnail before closing, so Escape from the panel closes once', () => {
+        expect(stripSource).toContain("if (index !== null) triggers[index]?.focus();\n            if (event.key === 'Escape') hide(true);");
+        expect(stripSource).toContain('if (current !== null) triggers[current]?.focus(); hide(true); }}');
+    });
+
+    it('gives the other hover pop-outs the same tap rule', () => {
+        for (const source of [previewSource, filteredSource]) {
+            expect(source).toContain("event.pointerType !== 'touch'");
+            expect(source).toContain("target.matches(':focus-visible')");
+            expect(source).not.toContain('onmouseenter={() => show(index)}');
+            expect(source).not.toContain('onmouseenter={show}');
+        }
     });
 
     it('labels what the model read in a frame as a read, with one action that names its effect', () => {

--- a/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
+++ b/apps/ui/src/lib/pages/dashboard-field-desk.layout.test.ts
@@ -98,8 +98,8 @@ describe('dashboard field desk layout', () => {
 
     it('opens the capture preview on hover and on keyboard focus, and dismisses it', () => {
         // Every frame in a visit previews itself, so the handlers take the frame index.
-        expect(previewSource).toContain('onmouseenter={() => show(index)}');
-        expect(previewSource).toContain('onfocusin={() => show(index)}');
+        expect(previewSource).toContain("onpointerenter={(event) => { if (event.pointerType !== 'touch') show(index); }}");
+        expect(previewSource).toContain('onfocusin={(event) => { if (isKeyboardFocus(event.target)) show(index); }}');
         expect(previewSource).toContain('let openIndex = $state<number | null>(null)');
         expect(previewSource).toContain('dashboard.field_log.preview_frame_position');
         expect(previewSource).toContain('onfocusout={handleFocusOut}');

--- a/apps/ui/src/lib/pages/health-timeline.layout.test.ts
+++ b/apps/ui/src/lib/pages/health-timeline.layout.test.ts
@@ -103,7 +103,7 @@ describe('filtered rows', () => {
 describe('filtered frame preview', () => {
     it('honours the hover pop-out contract', () => {
         // §4: hover alone fails WCAG 2.2 AA.
-        expect(filteredPreviewSource).toContain('onmouseenter');
+        expect(filteredPreviewSource).toContain('onpointerenter');
         expect(filteredPreviewSource).toContain('onfocusin');
         expect(filteredPreviewSource).toContain('CLOSE_GRACE_MS = 120');
         expect(filteredPreviewSource).toContain("event.key === 'Escape'");

--- a/docs/standards/layout-patterns.md
+++ b/docs/standards/layout-patterns.md
@@ -172,7 +172,13 @@ full list only once someone types.
 
 Any preview that opens on hover must satisfy all of this, because hover alone fails WCAG 2.2 AA:
 
-- Opens on `mouseenter` **and** on `focusin`, so keyboards reach it.
+- Opens on hover **and** on focus, so keyboards reach it. Hover means `pointerenter` from a
+  hovering pointer (`event.pointerType !== 'touch'`), focus means keyboard focus
+  (`:focus-visible`). A touch browser replays a tap as mouseenter, then on Chrome a focus (iOS
+  Safari does not focus a button on tap), then click. A pop-out that opened on the replay is
+  either closed by the click (when it has a backdrop) or swallows the click (iOS, when a
+  mouseenter handler changes the DOM), so on touch the click alone opens it. `DetectionPreview`
+  and `FilteredFramePreview` follow the same rule.
 - Stays open while the pointer travels into the panel. `DetectionPreview` and `FrameStrip` use a 120ms close grace
   window for exactly this (SC 1.4.13, "hoverable").
 - Dismisses on `Escape` without moving focus elsewhere unexpectedly.
@@ -183,6 +189,11 @@ Any preview that opens on hover must satisfy all of this, because hover alone fa
 Model any new popover on this and on `CameraStatus.svelte`, which established the pattern.
 A pop-out that holds a control (`FrameStrip`) is a `group` named for its subject, not a `tooltip`, and
 its Escape closes the pop-out before the dialog behind it.
+
+Below 640px `FrameStrip`'s pop-out is a bottom sheet with a backdrop and its own Close. A sheet never
+opens on hover: its backdrop would arrive under the pointer as a `mouseleave` and close it again. It
+opens by tap or keyboard, and it closes by its backdrop, its Close, Escape, or focus moving elsewhere,
+never by the pointer drifting off the strip.
 
 ---
 


### PR DESCRIPTION
## Outcome

On a phone, tapping a frame thumbnail in the detection record flickered the bottom sheet and never showed it. The sheet now opens on the tap and stays.

## Cause

A touch browser replays a tap as mouseenter, then (on Chrome) focus, then click. The strip opened the sheet on that mouseenter, so its full-screen backdrop was already under the finger when the click arrived; the click hit the backdrop and closed the sheet.

## Change

- Hover opens the pop-out for a hovering pointer only (`pointerenter`, not `touch`), never in sheet mode.
- Focus opens it only for keyboard focus (`:focus-visible`).
- A tap opens the sheet by its click; the sheet closes by its backdrop, its Close, Escape or focus moving elsewhere, not by the pointer drifting off or focus going nowhere. A desktop pop-out still closes when focus leaves.
- Focus returns to the thumbnail before the pop-out hides, so Escape from inside the panel closes it once instead of reopening it.
- `DetectionPreview` and `FilteredFramePreview` get the same rule (on iOS a DOM-mutating mouseenter swallowed the tap, so the record opened on the second tap).
- Layout standard section 4 records the touch rule.

## Verification

Reproduced in a scratch harness at 375px with an event trace (hover open, backdrop click, close, loop), then verified: tap opens and holds; tapping the sheet's picture keeps it; Use this frame fires; backdrop closes; desktop hover opens and moving away closes; Tab opens; Escape closes with focus on the thumbnail. `npm run check` clean, all UI tests pass, knip clean.

## Scope

Frontend only. No data, migration or security impact.
