### PR TITLE
Show every frame kept from a visit in the review queue's record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- **The review queue shows every frame kept from a visit.** Its record showed only the crop and
+  its whole scene, so a visit with many frames read as two. The same strip as the detection
+  record now sits beneath the photograph; choosing a frame changes the photograph and nothing
+  else, and regeneration stays on the full record.
 - **One place to choose the frame and settle the species (#256).** The detection record's
   photograph now has one strip of the visit's moments beneath it, in time order, one thumbnail
   per moment. The "Frigate preview" and "footage extraction" split is gone, and so are the

--- a/apps/ui/src/lib/components/ReviewQueueModal.svelte
+++ b/apps/ui/src/lib/components/ReviewQueueModal.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
     import { onDestroy, untrack } from 'svelte';
-    import { fetchSnapshotCandidates, getThumbnailUrl } from '../api';
+    import { applySnapshotCandidate, fetchSnapshotCandidates, getThumbnailUrl } from '../api';
     import type { Detection, SnapshotCandidate } from '../api';
+    import FrameStrip from './FrameStrip.svelte';
+    import {
+        currentMoment,
+        groupCandidatesIntoMoments,
+        preferredCandidate,
+        type FrameMoment
+    } from '../utils/frame-moments';
+    import { getErrorMessage } from '../utils/error-handling';
+    import { toastStore } from '../stores/toast.svelte';
     import { advance, createReviewSession, remaining, type ReviewSession } from '../utils/review-session';
     import { formatDate, formatTime } from '../utils/datetime';
     import { trapFocus } from '../utils/focus-trap';
@@ -38,6 +47,19 @@
     let crop = $state<SnapshotCandidate | null>(null);
     let fullFrame = $state<SnapshotCandidate | null>(null);
     let cropLoading = $state(false);
+    // Every frame kept from the visit, in one strip, the same as the detection record (#256):
+    // a reviewer deciding what a blurred shape is should see every moment, not only the crop
+    // and its whole scene. Choosing one changes the photograph and nothing else.
+    let candidates = $state<SnapshotCandidate[]>([]);
+    let photograph = $state<SnapshotCandidate | null>(null);
+    let currentCandidateId = $state<string | null>(null);
+    let currentSource = $state<string | null>(null);
+    let applyingKey = $state<string | null>(null);
+    let applyPending = $state(false);
+    const moments = $derived<FrameMoment[]>(
+        groupCandidatesIntoMoments(candidates.filter((item) => item.thumbnail_url || item.image_url))
+    );
+    const activeMoment = $derived(currentMoment(moments, currentCandidateId, currentSource));
     let imageEl = $state<HTMLImageElement | null>(null);
     // The photograph is the crop; the whole scene is a look, not a mode (#256). Same
     // controller as the detection record, so the two surfaces behave alike.
@@ -68,55 +90,90 @@
         failedImageUrls = new Set();
     });
 
+    async function loadCandidates(eventId: string, isCancelled: () => boolean): Promise<void> {
+        cropLoading = true;
+        try {
+            const response = await fetchSnapshotCandidates(eventId);
+            if (isCancelled()) return;
+            const all = response.candidates ?? [];
+            const cropped = all.filter(
+                (candidate) => candidate.crop_box && (candidate.image_url || candidate.thumbnail_url)
+            );
+            const preferredCrop =
+                cropped.find((candidate) => candidate.selected) ??
+                cropped.sort((left, right) => right.ranking_score - left.ranking_score)[0] ??
+                null;
+            // The photograph is whatever is chosen, crop or whole scene; the peek needs a crop.
+            const selected = all.find((candidate) => candidate.selected && (candidate.image_url || candidate.thumbnail_url));
+            photograph = selected ?? preferredCrop;
+            crop = preferredCrop;
+            fullFrame = findMatchingFullFrameCandidate(
+                response.candidates ?? [],
+                preferredCrop?.candidate_id ?? null
+            );
+            candidates = all;
+            currentCandidateId = response.current_candidate_id ?? null;
+            currentSource = response.current_source ?? null;
+        } catch {
+            // No scan has been run for this event, so there is no crop to show.
+            if (!isCancelled()) {
+                crop = null;
+                fullFrame = null;
+                photograph = null;
+                candidates = [];
+            }
+        } finally {
+            if (!isCancelled()) cropLoading = false;
+        }
+    }
+
     $effect(() => {
         const eventId = session.current?.frigate_event;
         crop = null;
         fullFrame = null;
+        photograph = null;
+        candidates = [];
+        currentCandidateId = null;
+        currentSource = null;
         wholeScene.reset();
         if (!eventId) return;
 
         let cancelled = false;
-        cropLoading = true;
-        void (async () => {
-            try {
-                const response = await fetchSnapshotCandidates(eventId);
-                if (cancelled) return;
-                const cropped = (response.candidates ?? []).filter(
-                    (candidate) => candidate.crop_box && (candidate.image_url || candidate.thumbnail_url)
-                );
-                const preferredCrop =
-                    cropped.find((candidate) => candidate.selected) ??
-                    cropped.sort((left, right) => right.ranking_score - left.ranking_score)[0] ??
-                    null;
-                crop = preferredCrop;
-                fullFrame = findMatchingFullFrameCandidate(
-                    response.candidates ?? [],
-                    preferredCrop?.candidate_id ?? null
-                );
-            } catch {
-                // No scan has been run for this event, so there is no crop to show.
-                if (!cancelled) {
-                    crop = null;
-                    fullFrame = null;
-                }
-            } finally {
-                if (!cancelled) cropLoading = false;
-            }
-        })();
-
+        void loadCandidates(eventId, () => cancelled);
         return () => {
             cancelled = true;
         };
     });
 
+    async function useMoment(moment: FrameMoment): Promise<void> {
+        const eventId = session.current?.frigate_event;
+        const candidate = preferredCandidate(moment);
+        if (!eventId || !candidate || applyPending) return;
+        applyPending = true;
+        applyingKey = moment.key;
+        try {
+            await applySnapshotCandidate(eventId, { mode: 'candidate', candidate_id: candidate.candidate_id });
+            wholeScene.reset();
+            await loadCandidates(eventId, () => session.current?.frigate_event !== eventId);
+            toastStore.success($_('detection.snapshot_apply_success', { default: 'Snapshot updated' }));
+        } catch (e) {
+            toastStore.error(getErrorMessage(e) || $_('common.error', { default: 'Action failed' }));
+        } finally {
+            applyPending = false;
+            applyingKey = null;
+        }
+    }
+
     const imageUrl = $derived(
         wholeScene.showing && (fullFrame?.image_url || fullFrame?.thumbnail_url)
             ? (fullFrame.image_url ?? fullFrame.thumbnail_url ?? '')
-            : crop?.image_url || crop?.thumbnail_url
-              ? (crop.image_url ?? crop.thumbnail_url ?? '')
-            : session.current
-              ? getThumbnailUrl(session.current.frigate_event)
-              : ''
+            : photograph?.image_url || photograph?.thumbnail_url
+              ? (photograph.image_url ?? photograph.thumbnail_url ?? '')
+              : crop?.image_url || crop?.thumbnail_url
+                ? (crop.image_url ?? crop.thumbnail_url ?? '')
+                : session.current
+                  ? getThumbnailUrl(session.current.frigate_event)
+                  : ''
     );
     // The outline is a DOM measurement, taken once the whole scene has loaded and again when
     // the window changes size.
@@ -349,6 +406,19 @@
                                     </span>
                                 {/if}
                             {/if}
+                        </div>
+                    {/if}
+                    {#if moments.length > 0}
+                        <div class="pt-2" data-review-frame-strip>
+                            <FrameStrip
+                                {moments}
+                                current={activeMoment}
+                                primaryName={current.display_name}
+                                loading={cropLoading}
+                                {applyingKey}
+                                busy={applyPending || busy}
+                                onuse={(moment) => { void useMoment(moment); }}
+                            />
                         </div>
                     {/if}
                     {#if !canPeek && !cropLoading && !crop}

--- a/apps/ui/src/lib/components/review-queue-modal.layout.test.ts
+++ b/apps/ui/src/lib/components/review-queue-modal.layout.test.ts
@@ -61,6 +61,19 @@ describe('review queue walk-through', () => {
         expect(modalSource).toMatch(/if \(wholeScene\.pinned\) \{\s*wholeScene\.reset\(\);\s*return;/);
     });
 
+    it('shows every frame kept from the visit in the same strip as the record, and choosing one changes only the photograph', () => {
+        expect(modalSource).toContain("import FrameStrip from './FrameStrip.svelte'");
+        expect(modalSource).toContain('groupCandidatesIntoMoments(candidates.filter((item) => item.thumbnail_url || item.image_url))');
+        expect(modalSource).toContain('data-review-frame-strip');
+        expect(modalSource).toContain('current={activeMoment}');
+        expect(modalSource).toContain("applySnapshotCandidate(eventId, { mode: 'candidate', candidate_id: candidate.candidate_id })");
+        // The photograph is whatever is chosen, crop or whole scene; the strip reflects it after a change.
+        expect(modalSource).toContain('photograph = selected ?? preferredCrop;');
+        expect(modalSource).toContain('await loadCandidates(eventId, () => session.current?.frigate_event !== eventId);');
+        // Regeneration stays on the full record, where the scan's status is shown.
+        expect(modalSource).not.toContain('onregenerate=');
+    });
+
     it('keeps the media block its own height on phones so it never overlaps the rail', () => {
         expect(modalSource).toContain('flex min-h-0 flex-1 flex-col overflow-y-auto md:grid');
         expect(modalSource).toContain('flex shrink-0 flex-col bg-slate-950 md:min-h-0 md:justify-center');

--- a/docs/standards/layout-patterns.md
+++ b/docs/standards/layout-patterns.md
@@ -117,7 +117,9 @@ is not shown, and the framings of one moment fold into it. Each thumbnail opens 
 hover or focus with the frame at decision size, what the model read in it (labelled as a read),
 and one action, "Use this frame", which changes the photograph and never the identification.
 There is no Best crop / Full frame switch and no preview-then-save step (#256). The peek is
-`WholeScenePeek` in `utils/whole-scene-peek.svelte.ts`, and the review queue uses the same one.
+`WholeScenePeek` in `utils/whole-scene-peek.svelte.ts`, and the review queue uses the same one, and
+the same `FrameStrip` beneath its photograph, so every frame kept from a visit is there to decide
+with; only regeneration stays on the full record.
 On a phone the comparison pop-out is a sheet at the foot of the screen with a backdrop and its
 own Close, because there is no hover to lose.
 


### PR DESCRIPTION
## Outcome

The review queue's record showed only the crop and its whole-scene peek, so a visit with many candidate frames (the squirrel on the live instance) read as two frames. The same frame strip as the detection record now sits beneath the photograph.

## Change

- `ReviewQueueModal` keeps every candidate, folds them into moments with the shared `groupCandidatesIntoMoments`, and renders `FrameStrip` under the photograph.
- "Use this frame" applies the candidate and reloads the list; the photograph becomes whatever is chosen (crop or whole scene) and the peek still works on a crop.
- Regeneration stays on the full record, where the scan's status is shown.
- Layout test, layout standard, changelog.

## Verification

Harness with six stubbed candidate frames: strip renders six thumbnails, hover opens the pop-out with the model's read, Use this frame moves the Chosen mark and swaps the photograph, phone width stacks the strip under the photo. svelte-check clean, all UI tests pass, knip clean. Frontend only.