### PR TITLE
Queue a visit again when its video worker is lost, and never hand work to a dead worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A visit is not failed because its classifier worker was restarted.** When the video worker
+  was replaced mid-analysis, the visit in hand was marked failed and so was the next one waiting,
+  which the supervisor handed to the dead worker before its replacement had loaded; that second
+  failure also spawned a duplicate worker and counted twice against the restart breaker. A slot
+  under replacement is now invisible to queued work and to the watchdog until its new worker is
+  ready, so queued work waits for it; a visit whose worker was lost goes back on the queue after
+  a short pause, twice at most, with its durable status returned to pending so a restart in the
+  gap recovers it too. The video pool is judged on its own heartbeat budget
+  (`CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS`, thirty seconds) instead of the five
+  seconds meant for image workers, and every worker kill is logged with the numbers it rested on.
 - **A tap on a frame thumbnail opens the sheet on a phone.** It used to flicker and vanish: the
   browser replays a tap as a hover first, the hover opened the sheet with its backdrop under the
   finger, and the tap's click then landed on that backdrop and closed it. Hover now opens the

--- a/backend/app/config_loader.py
+++ b/backend/app/config_loader.py
@@ -85,6 +85,7 @@ CLASSIFICATION_ENV_OVERRIDES: dict[str, tuple[str, ...]] = {
     "live_worker_count": ("CLASSIFICATION__LIVE_WORKER_COUNT",),
     "background_worker_count": ("CLASSIFICATION__BACKGROUND_WORKER_COUNT",),
     "worker_heartbeat_timeout_seconds": ("CLASSIFICATION__WORKER_HEARTBEAT_TIMEOUT_SECONDS",),
+    "video_worker_heartbeat_timeout_seconds": ("CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS",),
     "worker_hard_deadline_seconds": ("CLASSIFICATION__WORKER_HARD_DEADLINE_SECONDS",),
     "background_worker_hard_deadline_seconds": ("CLASSIFICATION__BACKGROUND_WORKER_HARD_DEADLINE_SECONDS",),
     "worker_ready_timeout_seconds": ("CLASSIFICATION__WORKER_READY_TIMEOUT_SECONDS",),
@@ -259,6 +260,9 @@ def load_settings_instance(settings_cls: type[Any], config_path: Path) -> Any:
         "background_worker_count": _optional_int(os.environ.get("CLASSIFICATION__BACKGROUND_WORKER_COUNT")),
         "worker_heartbeat_timeout_seconds": float(
             os.environ.get("CLASSIFICATION__WORKER_HEARTBEAT_TIMEOUT_SECONDS", "5.0")
+        ),
+        "video_worker_heartbeat_timeout_seconds": float(
+            os.environ.get("CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS", "30.0")
         ),
         "worker_hard_deadline_seconds": float(os.environ.get("CLASSIFICATION__WORKER_HARD_DEADLINE_SECONDS", "35.0")),
         "background_worker_hard_deadline_seconds": float(

--- a/backend/app/config_models.py
+++ b/backend/app/config_models.py
@@ -373,6 +373,11 @@ class ClassificationSettings(BaseModel):
     worker_heartbeat_timeout_seconds: float = Field(
         default=5.0, ge=0.5, le=60.0, description="Classifier worker heartbeat timeout in seconds"
     )
+    # A video analysis is one long native job; a silence that means a hung
+    # image worker is routine for it, and the hard deadline remains the backstop.
+    video_worker_heartbeat_timeout_seconds: float = Field(
+        default=30.0, ge=1.0, le=300.0, description="Video classifier worker heartbeat timeout in seconds"
+    )
     worker_hard_deadline_seconds: float = Field(
         default=60.0, ge=1.0, le=300.0, description="Hard deadline before killing a stuck classifier worker"
     )

--- a/backend/app/services/auto_video_classifier_service.py
+++ b/backend/app/services/auto_video_classifier_service.py
@@ -130,6 +130,20 @@ _VIDEO_TOP_FRAMES_LIMIT = 8
 # then retry once. 60 seconds covers the common Frigate clip-finalisation lag
 # without piling up retries during a real outage.
 _PRECHECK_NO_CLIP_RETRY_DELAY_SECONDS = 60
+
+# A classifier worker restarted mid-analysis says nothing about the visit, so
+# the visit goes back on the queue once the worker has had time to come back.
+# Bounded, so a clip that reliably hangs the worker still fails in the end.
+WORKER_FAILURE_REQUEUE_REASONS: frozenset[str] = frozenset(
+    {
+        "video_worker_unavailable",
+        "video_worker_heartbeat_timeout",
+        "video_worker_startup_timeout",
+        "video_worker_circuit_open",
+    }
+)
+WORKER_FAILURE_MAX_REQUEUES = 2
+WORKER_FAILURE_REQUEUE_DELAY_SECONDS = 20.0
 _PRECHECK_NO_CLIP_MAX_RETRIES = 1
 _RETRIABLE_ON_LATE_CLIP_ERRORS: frozenset[str] = frozenset(
     {
@@ -257,6 +271,11 @@ class AutoVideoClassifierService:
         # so stop()/reset_state() can cancel them and so we never schedule a
         # second concurrent retry for the same event_id.
         self._precheck_retry_tasks: Dict[str, asyncio.Task] = {}
+        # How often each visit has gone back on the queue after its worker was
+        # lost, and the sleeping tasks that will queue them; both cleared when
+        # the visit ends one way or the other.
+        self._worker_failure_requeues: Dict[str, int] = {}
+        self._worker_failure_retry_tasks: Dict[str, asyncio.Task] = {}
 
     @property
     def _classifier(self):  # type: ignore[override]
@@ -318,6 +337,7 @@ class AutoVideoClassifierService:
         for retry_task in list(self._precheck_retry_tasks.values()):
             retry_task.cancel()
         self._precheck_retry_tasks.clear()
+        self._cancel_worker_failure_requeues()
         while not self._pending_queue.empty():
             try:
                 self._pending_queue.get_nowait()
@@ -338,7 +358,7 @@ class AutoVideoClassifierService:
         self._cleanup_completed_tasks()
         if event_id in self._active_tasks or event_id in self._pending_ids:
             return
-        if event_id in self._precheck_retry_tasks:
+        if event_id in self._precheck_retry_tasks or event_id in self._worker_failure_retry_tasks:
             return
         if self._is_circuit_open("live") and self._is_circuit_open("maintenance"):
             return
@@ -394,6 +414,7 @@ class AutoVideoClassifierService:
         for retry_task in list(self._precheck_retry_tasks.values()):
             retry_task.cancel()
         self._precheck_retry_tasks.clear()
+        self._cancel_worker_failure_requeues()
         for task in self._active_tasks.values():
             task.cancel()
         for task in list(self._active_tasks.values()):
@@ -781,6 +802,7 @@ class AutoVideoClassifierService:
             )
 
     def _record_success(self, event_id: str, *, source: JobSource = "live"):
+        self._worker_failure_requeues.pop(event_id, None)
         self._prune_failures(source)
         failure_events = cast(deque[tuple[float, str]], self._breaker_bucket(source)["failure_events"])
         failure_event_ids = cast(set[str], self._breaker_bucket(source)["failure_event_ids"])
@@ -1839,6 +1861,14 @@ class AutoVideoClassifierService:
                     return
                 except VideoClassificationWorkerError as exc:
                     reason_code = exc.reason_code
+                    if await self._requeue_after_worker_failure(
+                        frigate_event,
+                        camera,
+                        reason_code=reason_code,
+                        fallback_to_snapshot=fallback_to_snapshot,
+                        source=source,
+                    ):
+                        return
                     worker_context = {"error": reason_code}
                     if snapshot_fallback_requested():
                         worker_context["snapshot_fallback_attempted"] = True
@@ -1875,6 +1905,7 @@ class AutoVideoClassifierService:
                         severity="error",
                         context=worker_context,
                     )
+                    self._worker_failure_requeues.pop(frigate_event, None)
                     await self._update_status(frigate_event, "failed", error=reason_code, broadcast=True)
                     self._record_failure(frigate_event, reason_code, source=source)
                     await self._broadcast_reclassification_completed(
@@ -2341,6 +2372,118 @@ class AutoVideoClassifierService:
 
     async def _clip_file_valid(self, clip_path: str) -> bool:
         return await self._clip_file_error(clip_path) is None
+
+    async def _requeue_after_worker_failure(
+        self,
+        frigate_event: str,
+        camera: str,
+        *,
+        reason_code: str,
+        fallback_to_snapshot: bool,
+        source: JobSource,
+    ) -> bool:
+        """Put a visit back on the queue when its classifier worker was lost
+        mid-analysis. Returns False when the failure is the visit's own to
+        report: a reason that a fresh worker would not change, or a visit that
+        has already been queued again as often as allowed."""
+        if reason_code not in WORKER_FAILURE_REQUEUE_REASONS or not self._running:
+            return False
+        attempt = self._worker_failure_requeues.get(frigate_event, 0) + 1
+        if attempt > WORKER_FAILURE_MAX_REQUEUES:
+            return False
+        self._worker_failure_requeues[frigate_event] = attempt
+        log.warning(
+            "Video classification worker lost mid-analysis; visit queued again",
+            event_id=frigate_event,
+            reason=reason_code,
+            attempt=attempt,
+            max_attempts=WORKER_FAILURE_MAX_REQUEUES,
+            delay_seconds=WORKER_FAILURE_REQUEUE_DELAY_SECONDS,
+            source=source,
+        )
+        self._record_diagnostic(
+            frigate_event,
+            reason_code="auto_classify_retry_after_worker_failure",
+            message=(
+                "The classifier worker was restarted during this analysis; the visit is queued again "
+                "rather than marked failed."
+            ),
+            severity="warning",
+            context={
+                "prior_error": reason_code,
+                "attempt": attempt,
+                "max_attempts": WORKER_FAILURE_MAX_REQUEUES,
+                "delay_seconds": WORKER_FAILURE_REQUEUE_DELAY_SECONDS,
+            },
+        )
+        # Durable state says pending again, so a process restart in the gap
+        # recovers the visit the same way it recovers any other queued one.
+        await self._update_status(frigate_event, "pending", error=None, broadcast=False)
+        self._schedule_worker_failure_requeue(
+            frigate_event=frigate_event,
+            camera=camera,
+            reason_code=reason_code,
+            fallback_to_snapshot=fallback_to_snapshot,
+            source=source,
+        )
+        return True
+
+    def _schedule_worker_failure_requeue(
+        self,
+        *,
+        frigate_event: str,
+        camera: str,
+        reason_code: str,
+        fallback_to_snapshot: bool,
+        source: JobSource,
+    ) -> None:
+        if frigate_event in self._worker_failure_retry_tasks:
+            return
+
+        async def _delayed_requeue() -> None:
+            try:
+                await asyncio.sleep(WORKER_FAILURE_REQUEUE_DELAY_SECONDS)
+            except asyncio.CancelledError:
+                return
+            if not self._running:
+                return
+            if frigate_event in self._active_tasks or frigate_event in self._pending_ids:
+                log.debug(
+                    "Worker-failure requeue skipped; another job already owns this event",
+                    event_id=frigate_event,
+                )
+                return
+            outcome = await self.queue_classification(
+                frigate_event,
+                camera,
+                skip_delay=True,
+                fallback_to_snapshot=fallback_to_snapshot,
+                source=source,
+            )
+            if outcome in {"queued", "duplicate", "deferred"}:
+                return
+            # The queue would not take it back (its circuit is open, or it is
+            # full with no durable fallback): report the original failure honestly.
+            log.warning(
+                "Worker-failure requeue refused; marking the visit failed",
+                event_id=frigate_event,
+                reason=reason_code,
+                queue_outcome=outcome,
+            )
+            self._worker_failure_requeues.pop(frigate_event, None)
+            await self._update_status(frigate_event, "failed", error=reason_code, broadcast=True)
+            self._record_failure(frigate_event, reason_code, source=source)
+            await self._broadcast_reclassification_completed(frigate_event, [], outcome="failed", reason=reason_code)
+
+        task = create_background_task(_delayed_requeue(), name=f"video_classifier_requeue:{frigate_event}")
+        self._worker_failure_retry_tasks[frigate_event] = task
+        task.add_done_callback(lambda _t, eid=frigate_event: self._worker_failure_retry_tasks.pop(eid, None))
+
+    def _cancel_worker_failure_requeues(self) -> None:
+        for retry_task in list(self._worker_failure_retry_tasks.values()):
+            retry_task.cancel()
+        self._worker_failure_retry_tasks.clear()
+        self._worker_failure_requeues.clear()
 
     def _schedule_precheck_retry(
         self,

--- a/backend/app/services/classifier_service.py
+++ b/backend/app/services/classifier_service.py
@@ -2800,6 +2800,9 @@ class ClassifierService:
                 heartbeat_timeout_seconds=float(
                     getattr(settings.classification, "worker_heartbeat_timeout_seconds", 5.0) or 5.0
                 ),
+                video_heartbeat_timeout_seconds=float(
+                    getattr(settings.classification, "video_worker_heartbeat_timeout_seconds", 30.0) or 30.0
+                ),
                 hard_deadline_seconds=image_hard_deadline_seconds,
                 background_hard_deadline_seconds=background_hard_deadline_seconds,
                 video_hard_deadline_seconds=max(image_hard_deadline_seconds, video_timeout_seconds + 15.0),

--- a/backend/app/services/classifier_supervisor.py
+++ b/backend/app/services/classifier_supervisor.py
@@ -6,8 +6,12 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Literal
 
+import structlog
+
 from .classifier_worker_client import ClassifierWorkerClient
 from .classifier_worker_protocol import build_classify_request, build_classify_video_request
+
+log = structlog.get_logger()
 
 
 WorkPriority = Literal["live", "background", "video"]
@@ -65,6 +69,7 @@ class ClassifierSupervisor:
         video_worker_count: int = 1,
         heartbeat_timeout_seconds: float,
         hard_deadline_seconds: float,
+        video_heartbeat_timeout_seconds: float | None = None,
         background_hard_deadline_seconds: float | None = None,
         video_hard_deadline_seconds: float | None = None,
         worker_ready_timeout_seconds: float = 20.0,
@@ -81,7 +86,19 @@ class ClassifierSupervisor:
             "background": max(1, int(background_worker_count)),
             "video": max(1, int(video_worker_count)),
         }
-        self._heartbeat_timeout_seconds = max(0.01, float(heartbeat_timeout_seconds))
+        base_heartbeat_timeout_seconds = max(0.01, float(heartbeat_timeout_seconds))
+        # A video analysis is one long native job, so its worker is judged on a
+        # longer silence than an image worker; the hard deadline stays the backstop.
+        self._heartbeat_timeout_seconds: dict[WorkPriority, float] = {
+            "live": base_heartbeat_timeout_seconds,
+            "background": base_heartbeat_timeout_seconds,
+            "video": max(
+                0.01,
+                float(video_heartbeat_timeout_seconds)
+                if video_heartbeat_timeout_seconds is not None
+                else base_heartbeat_timeout_seconds,
+            ),
+        }
         base_hard_deadline_seconds = max(0.01, float(hard_deadline_seconds))
         self._hard_deadline_seconds = {
             "live": base_hard_deadline_seconds,
@@ -114,7 +131,7 @@ class ClassifierSupervisor:
         # worker has completed its first request it is judged against this
         # longer window instead of the steady-state heartbeat timeout.
         self._warmup_liveness_timeout_seconds = (
-            max(self._heartbeat_timeout_seconds, float(warmup_liveness_timeout_seconds))
+            max(max(self._heartbeat_timeout_seconds.values()), float(warmup_liveness_timeout_seconds))
             if warmup_liveness_timeout_seconds is not None
             else None
         )
@@ -126,6 +143,10 @@ class ClassifierSupervisor:
         self._worker_factory = worker_factory
         self._slots: dict[WorkPriority, list[_WorkerSlot]] = {"live": [], "background": [], "video": []}
         self._assignments: dict[str, _Assignment] = {}
+        # Workers whose replacement is under way. The dead worker keeps its slot
+        # until the new one is ready, so without this the slot looks idle to a
+        # queued request and dead to the watchdog, and both act on it again.
+        self._replacing: set[str] = set()
         self._metrics = {
             "live": {
                 "workers": 0,
@@ -482,8 +503,16 @@ class ClassifierSupervisor:
                 )
 
             for slot in self._slots[priority]:
+                if slot.worker_name in self._replacing:
+                    continue
                 if slot.worker is not None and slot.worker_name not in self._assignments:
                     return slot
+            # A slot under replacement is worth waiting for; a pool with no worker
+            # left and nothing on the way is not, and the caller queues again.
+            if not any(
+                slot.worker is not None or slot.worker_name in self._replacing for slot in self._slots[priority]
+            ):
+                raise ClassifierWorkerExitedError(f"No active workers available for {priority}")
             await self._condition.wait()
 
     async def _restore_unavailable_slots(self, priority: WorkPriority) -> None:
@@ -516,7 +545,7 @@ class ClassifierSupervisor:
                 worker = ClassifierWorkerClient(
                     worker_name=worker_name,
                     worker_generation=generation,
-                    heartbeat_timeout_seconds=self._heartbeat_timeout_seconds,
+                    heartbeat_timeout_seconds=self._heartbeat_timeout_seconds[priority],
                 )
             else:
                 worker = await self._worker_factory(
@@ -689,7 +718,7 @@ class ClassifierSupervisor:
                     continue
 
                 for index, slot in enumerate(list(self._slots[priority])):
-                    if slot.worker is None:
+                    if slot.worker is None or slot.worker_name in self._replacing:
                         continue
                     status = slot.worker.get_status()
                     exit_code = status.get("exit_code")
@@ -724,7 +753,9 @@ class ClassifierSupervisor:
                         and (slot.worker_name, slot.worker_generation) not in self._completed_once
                     )
                     liveness_budget = (
-                        self._warmup_liveness_timeout_seconds if warming_up else self._heartbeat_timeout_seconds
+                        self._warmup_liveness_timeout_seconds
+                        if warming_up
+                        else self._heartbeat_timeout_seconds[priority]
                     )
                     if now - liveness_reference > liveness_budget:
                         await self._replace_worker(
@@ -757,38 +788,99 @@ class ClassifierSupervisor:
         kill: bool,
     ) -> None:
         slot = self._slots[priority][index]
-        worker_status = slot.worker.get_status()
-        if kill:
-            await slot.worker.kill()
-        else:
-            await self._close_failed_worker(slot.worker)
-        assignment = self._assignments.pop(slot.worker_name, None)
-        if assignment is not None and not assignment.future.done():
-            assignment.future.set_exception(assignment_error)
-        self._completed_once.discard((slot.worker_name, slot.worker_generation))
-        self._metrics[priority]["restarts"] += 1
-        self._metrics[priority]["last_exit_reason"] = reason
-        self._metrics[priority]["last_stderr_excerpt"] = str(worker_status.get("recent_stderr_excerpt") or "")
-        self._metrics[priority]["last_stderr_truncated_bytes"] = int(worker_status.get("stderr_truncated_bytes") or 0)
-        self._record_restart(priority)
+        if slot.worker_name in self._replacing:
+            return
+        self._replacing.add(slot.worker_name)
         try:
-            new_slot = await self._spawn_worker(priority, index, generation=slot.worker_generation + 1)
-        except ClassifierWorkerStartupTimeoutError:
-            self._record_unavailable_slot(priority, index, "startup_timeout")
-        except Exception:
-            self._record_unavailable_slot(priority, index, "startup_failed")
-        else:
-            # DEFENSIVE: If another concurrent _replace_worker (e.g. from restart_pool)
-            # replaced this slot while we were awaiting _spawn_worker, we must kill
-            # the worker we just spawned to prevent a zombie process leak.
-            if self._slots[priority][index] is not slot:
-                await new_slot.worker.kill()
-                return
+            worker_status = slot.worker.get_status()
+            assignment = self._assignments.pop(slot.worker_name, None)
+            self._log_replacement(slot, worker_status, assignment, reason=reason, killed=kill)
+            if kill:
+                await slot.worker.kill()
+            else:
+                await self._close_failed_worker(slot.worker)
+            if assignment is not None and not assignment.future.done():
+                assignment.future.set_exception(assignment_error)
+            self._completed_once.discard((slot.worker_name, slot.worker_generation))
+            self._metrics[priority]["restarts"] += 1
+            self._metrics[priority]["last_exit_reason"] = reason
+            self._metrics[priority]["last_stderr_excerpt"] = str(worker_status.get("recent_stderr_excerpt") or "")
+            self._metrics[priority]["last_stderr_truncated_bytes"] = int(
+                worker_status.get("stderr_truncated_bytes") or 0
+            )
+            self._record_restart(priority)
+            try:
+                new_slot = await self._spawn_worker(priority, index, generation=slot.worker_generation + 1)
+            except ClassifierWorkerStartupTimeoutError:
+                self._record_unavailable_slot(priority, index, "startup_timeout")
+                log.error("Classifier worker replacement timed out", worker=slot.worker_name, pool=priority)
+            except Exception as exc:
+                self._record_unavailable_slot(priority, index, "startup_failed")
+                log.error(
+                    "Classifier worker replacement failed to start",
+                    worker=slot.worker_name,
+                    pool=priority,
+                    error=str(exc),
+                )
+            else:
+                # DEFENSIVE: If another concurrent _replace_worker (e.g. from restart_pool)
+                # replaced this slot while we were awaiting _spawn_worker, we must kill
+                # the worker we just spawned to prevent a zombie process leak.
+                if self._slots[priority][index] is not slot:
+                    await new_slot.worker.kill()
+                    return
 
-            self._slots[priority][index] = new_slot
-            self._metrics[priority]["workers"] = self._active_worker_count(priority)
-        async with self._condition:
-            self._condition.notify_all()
+                self._slots[priority][index] = new_slot
+                self._metrics[priority]["workers"] = self._active_worker_count(priority)
+                log.info(
+                    "Classifier worker replaced",
+                    worker=slot.worker_name,
+                    pool=priority,
+                    generation=new_slot.worker_generation,
+                    reason=reason,
+                )
+        finally:
+            self._replacing.discard(slot.worker_name)
+            async with self._condition:
+                self._condition.notify_all()
+
+    def _log_replacement(
+        self,
+        slot: _WorkerSlot,
+        worker_status: dict[str, Any],
+        assignment: _Assignment | None,
+        *,
+        reason: str,
+        killed: bool,
+    ) -> None:
+        """One line per kill with the numbers the decision rested on, so a false
+        positive can be told from a hung worker after the fact."""
+        now = time.monotonic()
+
+        def age(key: str) -> float | None:
+            value = worker_status.get(key)
+            return round(now - float(value), 2) if isinstance(value, (int, float)) else None
+
+        excerpt = str(worker_status.get("recent_stderr_excerpt") or "").strip()
+        log.warning(
+            "Replacing classifier worker",
+            worker=slot.worker_name,
+            pool=slot.priority,
+            generation=slot.worker_generation,
+            reason=reason,
+            killed=killed,
+            busy=bool(worker_status.get("busy")),
+            request_id=assignment.request_id if assignment is not None else None,
+            work_id=assignment.work_id if assignment is not None else None,
+            seconds_in_request=round(now - assignment.started_at, 2) if assignment is not None else None,
+            seconds_since_heartbeat=age("last_heartbeat_monotonic"),
+            seconds_since_activity=age("last_activity_monotonic"),
+            seconds_since_stderr=age("last_stderr_monotonic"),
+            liveness_budget_seconds=self._heartbeat_timeout_seconds[slot.priority],
+            restarts_in_window=len(self._restart_history[slot.priority]) + 1,
+            restart_threshold=self._restart_threshold,
+            stderr_excerpt=excerpt[-300:] if excerpt else None,
+        )
 
     def _find_slot(self, worker_name: str) -> _WorkerSlot | None:
         for priority in ("live", "background", "video"):
@@ -806,6 +898,13 @@ class ClassifierSupervisor:
         if len(history) >= self._restart_threshold:
             self._metrics[priority]["circuit_open"] = True
             self._metrics[priority]["circuit_open_until_monotonic"] = now + self._breaker_cooldown_seconds
+            log.warning(
+                "Classifier worker circuit opened",
+                pool=priority,
+                restarts_in_window=len(history),
+                window_seconds=self._restart_window_seconds,
+                cooldown_seconds=self._breaker_cooldown_seconds,
+            )
 
     def _refresh_circuit_state(self, priority: WorkPriority) -> None:
         if not self._metrics[priority]["circuit_open"]:

--- a/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
+++ b/backend/tests/test_auto_video_classifier_snapshot_upgrade.py
@@ -769,6 +769,11 @@ async def test_process_event_records_backend_diagnostic_for_worker_failure():
 @pytest.mark.asyncio
 async def test_process_event_worker_failure_falls_back_to_snapshot_for_manual_retry():
     service = AutoVideoClassifierService()
+    # The visit has already been queued again as often as a worker failure allows;
+    # only then does a manual request fall back to the retained snapshot.
+    service._worker_failure_requeues["evt-video-worker-fallback"] = (
+        auto_video_classifier_module.WORKER_FAILURE_MAX_REQUEUES
+    )
     service._classifier = MagicMock()
     service._classifier.classify_video_async = AsyncMock(
         side_effect=VideoClassificationWorkerError("video_worker_heartbeat_timeout")
@@ -1149,3 +1154,132 @@ async def test_persist_video_top_frames_discards_unknown_frames_when_known_frame
 
     assert [frame["top_label"] for frame in persisted] == ["European Robin", "Blue Tit"]
     assert [frame["rank"] for frame in persisted] == [1, 2]
+
+
+def _service_that_loses_its_worker(reason: str) -> AutoVideoClassifierService:
+    service = AutoVideoClassifierService()
+    service._running = True
+    service._classifier = MagicMock()
+    service._classifier.classify_video_async = AsyncMock(side_effect=VideoClassificationWorkerError(reason))
+    service._update_status = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    service._save_results = AsyncMock()  # type: ignore[method-assign]
+    service._auto_delete_if_missing = AsyncMock()  # type: ignore[method-assign]
+    service._wait_for_clip = AsyncMock(return_value=(True, None))  # type: ignore[method-assign]
+    service._record_failure = MagicMock()  # type: ignore[method-assign]
+    return service
+
+
+@pytest.mark.asyncio
+async def test_a_worker_lost_mid_analysis_queues_the_visit_again_instead_of_failing_it(monkeypatch):
+    """The classifier worker being restarted is not a verdict on the visit. The
+    job goes back on the queue once the worker has had time to come back, its
+    durable status returns to pending so a restart would pick it up too, and
+    nobody is told it failed."""
+    service = _service_that_loses_its_worker("video_worker_heartbeat_timeout")
+    requeue = AsyncMock(return_value="queued")
+    monkeypatch.setattr(service, "queue_classification", requeue)
+    monkeypatch.setattr(auto_video_classifier_module, "WORKER_FAILURE_REQUEUE_DELAY_SECONDS", 0.01)
+    broadcast = AsyncMock()
+    error_diagnostics_history.clear()
+
+    try:
+        with (
+            patch.object(
+                auto_video_classifier_module.frigate_client,
+                "get_event_with_error",
+                new=AsyncMock(return_value=({"has_clip": True}, None)),
+            ),
+            patch.object(auto_video_classifier_module.broadcaster, "broadcast", new=broadcast),
+        ):
+            await service._process_event("evt-worker-lost", "cam1", skip_delay=True, source="live")
+            assert "evt-worker-lost" in service._worker_failure_retry_tasks
+            await asyncio.sleep(0.05)
+
+        failed_updates = [
+            call for call in service._update_status.await_args_list if len(call.args) > 1 and call.args[1] == "failed"
+        ]
+        assert failed_updates == []
+        service._update_status.assert_any_await("evt-worker-lost", "pending", error=None, broadcast=False)
+        service._record_failure.assert_not_called()
+        terminal = [
+            call.args[0]
+            for call in broadcast.await_args_list
+            if call.args and call.args[0].get("type") == "reclassification_completed"
+        ]
+        assert terminal == []
+
+        requeue.assert_awaited_once_with(
+            "evt-worker-lost", "cam1", skip_delay=True, fallback_to_snapshot=False, source="live"
+        )
+        assert service._worker_failure_requeues["evt-worker-lost"] == 1
+        assert "evt-worker-lost" not in service._worker_failure_retry_tasks
+
+        snapshot = error_diagnostics_history.snapshot(limit=20)
+        event = next(
+            item
+            for item in snapshot["events"]
+            if item["event_id"] == "evt-worker-lost"
+            and item["reason_code"] == "auto_classify_retry_after_worker_failure"
+        )
+        assert event["severity"] == "warning"
+        assert event["context"]["prior_error"] == "video_worker_heartbeat_timeout"
+        assert event["context"]["attempt"] == 1
+    finally:
+        error_diagnostics_history.clear()
+
+
+@pytest.mark.asyncio
+async def test_a_visit_fails_honestly_once_worker_requeues_are_spent(monkeypatch):
+    service = _service_that_loses_its_worker("video_worker_unavailable")
+    service._worker_failure_requeues["evt-worker-spent"] = auto_video_classifier_module.WORKER_FAILURE_MAX_REQUEUES
+    requeue = AsyncMock(return_value="queued")
+    monkeypatch.setattr(service, "queue_classification", requeue)
+    broadcast = AsyncMock()
+
+    with (
+        patch.object(
+            auto_video_classifier_module.frigate_client,
+            "get_event_with_error",
+            new=AsyncMock(return_value=({"has_clip": True}, None)),
+        ),
+        patch.object(auto_video_classifier_module.broadcaster, "broadcast", new=broadcast),
+    ):
+        await service._process_event("evt-worker-spent", "cam1", skip_delay=True, source="live")
+
+    requeue.assert_not_awaited()
+    service._update_status.assert_any_await(
+        "evt-worker-spent", "failed", error="video_worker_unavailable", broadcast=True
+    )
+    service._record_failure.assert_called_once_with("evt-worker-spent", "video_worker_unavailable", source="live")
+    terminal = [
+        call.args[0]["data"]
+        for call in broadcast.await_args_list
+        if call.args and call.args[0].get("type") == "reclassification_completed"
+    ]
+    assert terminal == [
+        {"event_id": "evt-worker-spent", "results": [], "outcome": "failed", "reason": "video_worker_unavailable"}
+    ]
+    assert "evt-worker-spent" not in service._worker_failure_requeues
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_service_does_not_queue_a_lost_visit_again(monkeypatch):
+    service = _service_that_loses_its_worker("video_worker_startup_timeout")
+    requeue = AsyncMock(return_value="queued")
+    monkeypatch.setattr(service, "queue_classification", requeue)
+    monkeypatch.setattr(auto_video_classifier_module, "WORKER_FAILURE_REQUEUE_DELAY_SECONDS", 0.05)
+
+    with (
+        patch.object(
+            auto_video_classifier_module.frigate_client,
+            "get_event_with_error",
+            new=AsyncMock(return_value=({"has_clip": True}, None)),
+        ),
+        patch.object(auto_video_classifier_module.broadcaster, "broadcast", new=AsyncMock()),
+    ):
+        await service._process_event("evt-worker-stop", "cam1", skip_delay=True, source="maintenance")
+        await service.stop()
+        await asyncio.sleep(0.1)
+
+    requeue.assert_not_awaited()
+    assert service._worker_failure_retry_tasks == {}

--- a/backend/tests/test_classifier_service.py
+++ b/backend/tests/test_classifier_service.py
@@ -572,6 +572,8 @@ def test_classifier_supervisor_config_defaults():
     assert config.live_worker_count is None
     assert config.background_worker_count is None
     assert config.worker_heartbeat_timeout_seconds == pytest.approx(5.0)
+    # A video analysis is a long native job, so its worker is judged on a longer silence.
+    assert config.video_worker_heartbeat_timeout_seconds == pytest.approx(30.0)
     assert config.worker_hard_deadline_seconds == pytest.approx(60.0)
     assert config.background_worker_hard_deadline_seconds == pytest.approx(120.0)
     assert config.strict_non_finite_output is True

--- a/backend/tests/test_classifier_supervisor.py
+++ b/backend/tests/test_classifier_supervisor.py
@@ -114,6 +114,15 @@ class _GateReadyWorker(_FakeWorker):
         await self._gate.wait()
 
 
+class _ExitOnKillWorker(_FakeWorker):
+    """Mirrors the real client: a killed process reports an exit code afterwards,
+    which is what the watchdog sees on its next pass over the same slot."""
+
+    async def kill(self) -> None:
+        await super().kill()
+        self.exit_code = -9
+
+
 def _find_worker(created: list[_FakeWorker], worker_name: str, generation: int) -> _FakeWorker:
     for worker in created:
         if worker.worker_name == worker_name and worker.worker_generation == generation:
@@ -1378,4 +1387,196 @@ async def test_supervisor_records_the_runtime_a_worker_reports_when_it_becomes_r
         "model_id": "rope_vit_b14_inat21",
     }
     assert metrics["background"]["runtime"] is None, "only a pool that started has a runtime to report"
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_request_queued_during_a_replacement_waits_for_the_new_worker():
+    """A worker killed mid-job keeps its slot until the replacement is ready. A
+    request arriving meanwhile must wait for the fresh worker, never be handed
+    to the dead one, and the watchdog must not count the same death twice."""
+    created: list[_FakeWorker] = []
+    gate = asyncio.Event()
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        if worker_generation == 1:
+            worker: _FakeWorker = _ExitOnKillWorker(worker_name, worker_generation)
+        else:
+            worker = _GateReadyWorker(worker_name, worker_generation, gate=gate)
+        created.append(worker)
+        return worker
+
+    supervisor = ClassifierSupervisor(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.05,
+        hard_deadline_seconds=1.0,
+        worker_factory=_factory,
+        watchdog_interval_seconds=0.01,
+    )
+    await supervisor.start()
+
+    first = asyncio.create_task(
+        supervisor.classify(
+            priority="live",
+            work_id="live-1",
+            lease_token=1,
+            image_b64="payload",
+            camera_name="front",
+            model_id="default",
+        )
+    )
+    await asyncio.sleep(0.01)
+    dead = _find_worker(created, "live-0", 1)
+    dead.last_heartbeat_monotonic = time.monotonic() - 1.0
+    with pytest.raises(ClassifierWorkerHeartbeatTimeoutError):
+        await first
+
+    second = asyncio.create_task(
+        supervisor.classify(
+            priority="live",
+            work_id="live-2",
+            lease_token=1,
+            image_b64="payload",
+            camera_name="front",
+            model_id="default",
+        )
+    )
+    await asyncio.sleep(0.05)  # several watchdog passes while the replacement still loads
+    assert len(dead.sent_messages) == 1, "the queued request went to the dead worker"
+    assert not second.done()
+
+    gate.set()
+    await asyncio.sleep(0.02)
+    fresh = _find_worker(created, "live-0", 2)
+    assert fresh.sent_messages[0]["type"] == "classify"
+    await fresh.events.put(
+        {
+            "type": "result",
+            "worker_generation": 2,
+            "request_id": fresh.sent_messages[0]["request_id"],
+            "work_id": "live-2",
+            "lease_token": 1,
+            "results": [{"label": "Robin", "score": 0.9}],
+        }
+    )
+    results = await second
+    assert results[0]["label"] == "Robin"
+
+    metrics = supervisor.get_metrics()["live"]
+    assert metrics["restarts"] == 1
+    assert metrics["workers"] == 1
+    assert [w.worker_generation for w in created if w.worker_name == "live-0"] == [1, 2]
+
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_waiter_is_released_when_the_replacement_fails_to_start():
+    """Waiting for a replacement must not become waiting forever: if the new
+    worker cannot start, the queued request fails so its owner can queue again."""
+    created: list[_FakeWorker] = []
+    release_failed_spawn = asyncio.Event()
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        if worker_name == "live-0" and any(w.worker_name == "live-0" for w in created):
+            # The replacement is under way for as long as the gate holds, then never starts.
+            await release_failed_spawn.wait()
+            raise RuntimeError("no worker for you")
+        worker = _ExitOnKillWorker(worker_name, worker_generation)
+        created.append(worker)
+        return worker
+
+    supervisor = ClassifierSupervisor(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.05,
+        hard_deadline_seconds=1.0,
+        worker_factory=_factory,
+        watchdog_interval_seconds=0.01,
+    )
+    await supervisor.start()
+
+    first = asyncio.create_task(
+        supervisor.classify(
+            priority="live",
+            work_id="live-1",
+            lease_token=1,
+            image_b64="payload",
+            camera_name="front",
+            model_id="default",
+        )
+    )
+    await asyncio.sleep(0.01)
+    _find_worker(created, "live-0", 1).last_heartbeat_monotonic = time.monotonic() - 1.0
+    with pytest.raises(ClassifierWorkerHeartbeatTimeoutError):
+        await first
+
+    second = asyncio.create_task(
+        supervisor.classify(
+            priority="live",
+            work_id="live-2",
+            lease_token=1,
+            image_b64="payload",
+            camera_name="front",
+            model_id="default",
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert not second.done(), "the queued request must wait while the replacement is under way"
+    assert len(_find_worker(created, "live-0", 1).sent_messages) == 1
+
+    release_failed_spawn.set()
+    with pytest.raises(ClassifierWorkerExitedError):
+        await asyncio.wait_for(second, timeout=1.0)
+    assert supervisor.get_metrics()["live"]["workers"] == 0
+
+    await supervisor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_video_pool_keeps_a_busy_worker_within_its_own_heartbeat_budget():
+    """A video analysis is a long native job; a silence that would be fatal for
+    an image worker is normal for it. The video pool judges liveness by its own
+    budget while the live pool keeps the short one."""
+    created: list[_FakeWorker] = []
+
+    async def _factory(*, worker_name: str, worker_generation: int, **_kwargs):
+        worker = _FakeWorker(worker_name, worker_generation)
+        created.append(worker)
+        return worker
+
+    supervisor = ClassifierSupervisor(
+        live_worker_count=1,
+        background_worker_count=1,
+        heartbeat_timeout_seconds=0.05,
+        video_heartbeat_timeout_seconds=1.0,
+        hard_deadline_seconds=1.0,
+        video_hard_deadline_seconds=2.0,
+        worker_factory=_factory,
+        watchdog_interval_seconds=0.01,
+    )
+
+    task = asyncio.create_task(supervisor.classify_video(work_id="video-1", lease_token=1, video_path="/tmp/clip.mp4"))
+    await asyncio.sleep(0.02)
+    video_worker = _find_worker(created, "video-0", 1)
+    video_worker.last_heartbeat_monotonic = time.monotonic() - 0.3
+    await asyncio.sleep(0.05)
+    assert video_worker.killed is False
+    assert not task.done()
+
+    await video_worker.events.put(
+        {
+            "type": "result",
+            "worker_generation": 1,
+            "request_id": video_worker.sent_messages[0]["request_id"],
+            "work_id": "video-1",
+            "lease_token": 1,
+            "results": [{"label": "Dunnock", "score": 0.95}],
+        }
+    )
+    results = await task
+    assert results[0]["label"] == "Dunnock"
+    assert supervisor.get_metrics()["video"]["restarts"] == 0
+
     await supervisor.shutdown()

--- a/backend/tests/test_config_env_mapping.py
+++ b/backend/tests/test_config_env_mapping.py
@@ -238,6 +238,13 @@ CLASSIFICATION_ENV_PRECEDENCE_CASES = [
         7.5,
     ),
     (
+        "video_worker_heartbeat_timeout_seconds",
+        "CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS",
+        "45",
+        30.0,
+        45.0,
+    ),
+    (
         "worker_hard_deadline_seconds",
         "CLASSIFICATION__WORKER_HARD_DEADLINE_SECONDS",
         "42.5",
@@ -347,6 +354,7 @@ def test_classification_startup_load_env_precedence_with_full_file_payload(monke
                     "live_worker_count": 2,
                     "background_worker_count": 1,
                     "worker_heartbeat_timeout_seconds": 5.0,
+                    "video_worker_heartbeat_timeout_seconds": 30.0,
                     "worker_hard_deadline_seconds": 35.0,
                     "background_worker_hard_deadline_seconds": 120.0,
                     "worker_ready_timeout_seconds": 20.0,
@@ -384,6 +392,7 @@ def test_classification_startup_load_env_precedence_with_full_file_payload(monke
     monkeypatch.setenv("CLASSIFICATION__LIVE_WORKER_COUNT", "4")
     monkeypatch.setenv("CLASSIFICATION__BACKGROUND_WORKER_COUNT", "2")
     monkeypatch.setenv("CLASSIFICATION__WORKER_HEARTBEAT_TIMEOUT_SECONDS", "7.5")
+    monkeypatch.setenv("CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS", "45")
     monkeypatch.setenv("CLASSIFICATION__WORKER_HARD_DEADLINE_SECONDS", "42.5")
     monkeypatch.setenv("CLASSIFICATION__BACKGROUND_WORKER_HARD_DEADLINE_SECONDS", "140.0")
     monkeypatch.setenv("CLASSIFICATION__WORKER_READY_TIMEOUT_SECONDS", "22.5")
@@ -419,6 +428,7 @@ def test_classification_startup_load_env_precedence_with_full_file_payload(monke
     assert loaded.classification.live_worker_count == 4
     assert loaded.classification.background_worker_count == 2
     assert loaded.classification.worker_heartbeat_timeout_seconds == 7.5
+    assert loaded.classification.video_worker_heartbeat_timeout_seconds == 45.0
     assert loaded.classification.worker_hard_deadline_seconds == 42.5
     assert loaded.classification.background_worker_hard_deadline_seconds == 140.0
     assert loaded.classification.worker_ready_timeout_seconds == 22.5

--- a/docs/features/video-analysis.md
+++ b/docs/features/video-analysis.md
@@ -52,6 +52,18 @@ Temporal inference always runs in a supervised subprocess; cancellation or a har
 terminates that worker, so native OpenVINO/ONNX work cannot continue invisibly after the request
 ends.
 
+The worker is not the visit. A video worker is judged alive on its own heartbeat budget
+(`CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS`, thirty seconds by default, because a
+temporal analysis is one long native job), and the video hard deadline still ends one that has truly
+hung. When a worker is replaced mid-analysis, whatever the reason, the visit in hand goes back on the
+queue after a short pause and runs again on the fresh worker, twice at most, with its durable status
+returned to **pending** so a process restart in the gap recovers it like any other queued visit.
+Work queued while the replacement loads waits for it rather than being handed to the dead worker.
+Only when those attempts are spent is the visit marked failed with the worker's reason, and a
+manual request then falls back to the retained snapshot as before. Every worker kill is logged with
+the numbers it rested on (seconds since the last heartbeat, activity and stderr, time in the
+request, restarts in the window), so a false positive can be told from a hung worker afterwards.
+
 A shorter-than-requested full-visit clip remains valid evidence when it is a real, decodable MP4.
 YA-WAMF analyzes the frames it contains instead of discarding the clip merely because Frigate could
 not provide the ideal window.

--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -118,7 +118,8 @@ settings and do not follow the `SECTION__FIELD` precedence rules above.
 | `CLASSIFICATION__BACKGROUND_WORKER_COUNT` | _(one)_ | Background-inference worker processes; unset means one. |
 | `CLASSIFICATION__LIVE_EVENT_COALESCING_ENABLED` | `true` | Coalesce rapid live events. |
 | `CLASSIFICATION__LIVE_EVENT_STALE_DROP_SECONDS` | `30.0` | Drop live events older than this. |
-| `CLASSIFICATION__WORKER_HEARTBEAT_TIMEOUT_SECONDS` | `5.0` | Worker heartbeat timeout. |
+| `CLASSIFICATION__WORKER_HEARTBEAT_TIMEOUT_SECONDS` | `5.0` | Image worker heartbeat timeout. A live or background worker silent for longer is replaced. |
+| `CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS` | `30.0` | Video worker heartbeat timeout (`1.0`–`300.0`). A video analysis is one long native job, so its worker is allowed a longer silence; the video hard deadline still ends a hung one. |
 | `CLASSIFICATION__WORKER_HARD_DEADLINE_SECONDS` | `60.0` | Live worker hard deadline, in seconds (`1.0`–`300.0`). |
 | `CLASSIFICATION__BACKGROUND_WORKER_HARD_DEADLINE_SECONDS` | `120.0` | Background worker hard deadline, in seconds (`1.0`–`600.0`). |
 | `CLASSIFICATION__WORKER_READY_TIMEOUT_SECONDS` | `60.0` | Worker start-up readiness timeout. Start-up includes hardware probes and, on an accelerator, a model compile. |


### PR DESCRIPTION
## What happened on the reference install

Twice this morning (07:51 and 08:59) a visit in the Jobs view read "Failed to reclassify: video_worker_heartbeat_timeout" and the next one "video_worker_unavailable". From the container log:

1. The video worker was analysing a clip when the supervisor judged it silent for longer than the five-second heartbeat budget and killed it. The visit in hand was marked failed and never retried.
2. The dead worker kept its slot while the replacement loaded. The next queued visit was handed to that slot, `send` failed, the supervisor spawned a second replacement (later discarded as a duplicate), and the visit was marked failed too. Two restarts were counted against a breaker that opens at three.

## What changes

- **Supervisor**: a slot under replacement is invisible to queued work, to the watchdog and to send-failure re-entry until its new worker is ready. Queued work waits for the fresh worker; a replacement that cannot start releases the waiters with an error instead of leaving them hanging. One death, one restart.
- **Video liveness budget**: the video pool is judged on `CLASSIFICATION__VIDEO_WORKER_HEARTBEAT_TIMEOUT_SECONDS` (default 30 s) instead of the 5 s meant for image workers; the 195 s video hard deadline stays the backstop.
- **Jobs are queued, not failed**: a visit whose worker was lost mid-analysis (unavailable, heartbeat, startup timeout, circuit open) goes back on the queue after 20 s, twice at most, with its durable status returned to pending so a process restart in the gap recovers it too. A late-clip re-queue and a worker-failure re-queue cannot double up. Only once attempts are spent is it failed with the worker's reason, and a manual request then falls back to the snapshot as before.
- **Diagnosability**: the supervisor logged nothing before. Every kill now logs the worker, pool, reason, busy state, request, seconds since last heartbeat/activity/stderr, time in request, restarts in window and the stderr tail; circuit opening is logged too.

## Not in scope

The root cause of the worker's silence is not established. Parent event-loop lag measured from stderr forwarding was zero at both moments, progress payloads are tiny, and the analyses that succeeded took 57 to 98 s. The new kill log line carries the numbers needed to settle it next time.

## Verification

Backend: three new supervisor tests (queued request waits for the replacement and one restart is counted; a failed replacement releases the waiter; the video pool keeps a busy worker within its own budget), three new auto-video tests (re-queue with diagnostics and pending status; honest failure once attempts are spent; a stopped service does not re-queue), env mapping and defaults tests; the manual-fallback test now models spent attempts. Full pytest green, ruff clean, docs check passes, OpenAPI artifacts unchanged. Docs: environment variable table and the video analysis feature doc.
